### PR TITLE
Publish hacker-bob-codex from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,24 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish compatibility package
+      - name: Publish Claude wrapper package
         working-directory: packages/hacker-bob-cc
         run: |
           VERSION="$(node -p "require('./package.json').version")"
           if npm view "hacker-bob-cc@$VERSION" version >/dev/null 2>&1; then
             echo "hacker-bob-cc@$VERSION is already published; skipping."
+          else
+            npm publish --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish Codex wrapper package
+        working-directory: packages/hacker-bob-codex
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "hacker-bob-codex@$VERSION" version >/dev/null 2>&1; then
+            echo "hacker-bob-codex@$VERSION is already published; skipping."
           else
             npm publish --provenance --access public
           fi


### PR DESCRIPTION
## Summary

Add a `Publish Codex wrapper package` step to `.github/workflows/release.yml` so tagging `v*` publishes all three packages (`hacker-bob`, `hacker-bob-cc`, `hacker-bob-codex`).

The previous workflow only published `hacker-bob-cc`. `release-check.js` already validates both wrapper packages via `WRAPPER_PACKAGES`, and the README/PR-body promote `npx hacker-bob-codex install`, so the workflow was the only consumer that hadn't caught up.

The renamed `Publish Claude wrapper package` step matches the new symmetry; the body of the rename is unchanged.

## Test plan

- [x] `gh pr create` triggers CI on the branch.
- [ ] CI green; merge.
- [ ] Tag `v1.2.0` from main; confirm Codex publish step runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to improve package publication process for wrapper packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->