### PR TITLE
add optional recon tool coverage

### DIFF
--- a/.claude/agents/deep-recon-agent.md
+++ b/.claude/agents/deep-recon-agent.md
@@ -22,7 +22,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; for t in dnsx tlsx subzy; do command -v "$t" >/dev/null && echo "OK:$t" || { [ -x "$HOME/go/bin/$t" ] && echo "OK:$t" || echo "MISSING:$t"; }; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -51,11 +51,14 @@ PY
 printf "%s\nwww.%s\n" "$DOMAIN" "$DOMAIN" >> "$SESSION/raw/subdomains-tools.txt"
 sort -u "$SESSION/raw/subdomains-tools.txt" | head -n 5000 > "$SESSION/subdomains.txt"
 ```
-3. Live hosts, DNS, CNAME, and tech hints
+3. Live hosts, DNS, CNAME, TLS, takeover, and tech hints
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
-: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"
+DNSX="$(command -v dnsx 2>/dev/null || true)"; [ -z "$DNSX" ] && [ -x ~/go/bin/dnsx ] && DNSX="$HOME/go/bin/dnsx"
+TLSX="$(command -v tlsx 2>/dev/null || true)"; [ -z "$TLSX" ] && [ -x ~/go/bin/tlsx ] && TLSX="$HOME/go/bin/tlsx"
+SUBZY="$(command -v subzy 2>/dev/null || true)"; [ -z "$SUBZY" ] && [ -x ~/go/bin/subzy ] && SUBZY="$HOME/go/bin/subzy"
+: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/raw/dnsx.jsonl"; : > "$SESSION/raw/tlsx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"; : > "$SESSION/tlsx_sans.txt"; : > "$SESSION/takeover_probe_hosts.txt"; : > "$SESSION/subzy_takeovers.txt"
 if [ -n "$HTTPX" ]; then timeout 180 "$HTTPX" -l "$SESSION/subdomains.txt" -silent -follow-redirects -tech-detect -title -status-code -content-length -json -o "$SESSION/raw/httpx.jsonl" 2>/dev/null || true; fi
 python3 - "$SESSION" <<'PY'
 import json, pathlib, sys
@@ -77,6 +80,57 @@ for line in (session / "raw" / "httpx.jsonl").read_text(errors="ignore").splitli
 PY
 if [ ! -s "$SESSION/live_hosts.txt" ]; then printf "https://%s\nhttps://www.%s\n" "$DOMAIN" "$DOMAIN" > "$SESSION/live_hosts.txt"; fi
 if command -v dig >/dev/null; then awk '{print $1}' "$SESSION/subdomains.txt" | head -n 500 | while read -r h; do timeout 4 dig +short CNAME "$h" 2>/dev/null | sed "s#^#$h #" >> "$SESSION/cname_records.txt" || true; timeout 4 dig +short A "$h" 2>/dev/null | sed "s#^#$h A #" >> "$SESSION/dns_records.txt" || true; done; fi
+if [ -n "$DNSX" ]; then timeout 120 "$DNSX" -l "$SESSION/subdomains.txt" -silent -a -aaaa -cname -resp -json -o "$SESSION/raw/dnsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    return [str(value)]
+cname_rows, dns_rows = [], []
+for line in (session / "raw" / "dnsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        item = json.loads(line)
+    except Exception:
+        continue
+    host = str(item.get("host") or item.get("input") or "").lower().strip(".")
+    if not host:
+        continue
+    for key in ("cname", "cnames", "cname_record"):
+        for cname in as_list(item.get(key)):
+            cname = cname.lower().strip(".")
+            if cname:
+                cname_rows.append(f"{host} {cname}")
+    for key in ("a", "aaaa", "resp", "answers"):
+        for answer in as_list(item.get(key)):
+            answer = answer.strip()
+            if answer:
+                dns_rows.append(f"{host} {key.upper()} {answer}")
+(session / "cname_records.txt").write_text("\n".join(sorted(set((session / "cname_records.txt").read_text(errors="ignore").splitlines() + cname_rows))) + "\n")
+(session / "dns_records.txt").write_text("\n".join(sorted(set((session / "dns_records.txt").read_text(errors="ignore").splitlines() + dns_rows))) + "\n")
+PY
+awk '{print $1}' "$SESSION/cname_records.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/takeover_probe_hosts.txt"
+if [ -n "$SUBZY" ] && [ -s "$SESSION/takeover_probe_hosts.txt" ]; then timeout 120 "$SUBZY" run --targets "$SESSION/takeover_probe_hosts.txt" --hide_fails --timeout 10 > "$SESSION/subzy_takeovers.txt" 2>/dev/null || true; fi
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/subdomains.txt" 2>/dev/null; } | sort -u | head -n 500 > "$SESSION/tls_probe_hosts.txt"
+if [ -n "$TLSX" ] && [ -s "$SESSION/tls_probe_hosts.txt" ]; then timeout 120 "$TLSX" -l "$SESSION/tls_probe_hosts.txt" -silent -san -cn -json -o "$SESSION/raw/tlsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+hosts = set()
+for line in (session / "raw" / "tlsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        text = json.dumps(json.loads(line))
+    except Exception:
+        text = line
+    for host in re.findall(r'\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b', text.lower()):
+        host = host.strip("*. ")
+        if host == domain or host.endswith("." + domain):
+            hosts.add(host)
+(session / "tlsx_sans.txt").write_text("\n".join(sorted(hosts)) + ("\n" if hosts else ""))
+PY
 ```
 4. First-party family discovery
 Target-domain family probing remains bounded to `[DOMAIN]` and hosts ending in `.[DOMAIN]`. Also record compact sibling-domain candidates from linked hosts; do not probe the broad `sibling-domain-candidates.txt` set. Deep mode may run a tiny explicit liveness check only for brand-linked sibling hosts written to `brand-sibling-probe-candidates.txt`; same-TLD-only repeat evidence stays record-only.
@@ -127,7 +181,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
+{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
@@ -214,12 +268,16 @@ js_secrets = lines("js_secrets.txt", 200)
 jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
+dns_records = lines("dns_records.txt", 300)
+tlsx_sans = lines("tlsx_sans.txt", 200)
+subzy_takeovers = lines("subzy_takeovers.txt", 100)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
 archive_params = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_param_summary.txt", 120)]
 tech_text = "\n".join(live + family + nuclei)
 tech_stack = uniq(re.findall(r'\[([A-Za-z0-9., _+-]{2,120})\]', tech_text), 20)
 takeover_patterns = ("github.io","herokuapp.com","azurewebsites.net","cloudapp.net","readme.io","surge.sh","pages.dev","pantheonsite.io","unbouncepages.com")
-takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+pattern_takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+takeovers = uniq(pattern_takeovers + subzy_takeovers, 200)
 sibling_candidates = lines("sibling-domain-candidates.txt", 50)
 brand_sibling_candidates = lines("brand-sibling-probe-candidates.txt", 20)
 brand_sibling_live = lines("brand_sibling_live.txt", 20)
@@ -252,9 +310,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates + subzy_takeovers)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0) + (10 if subzy_takeovers else 0) + (5 if tlsx_sans else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -275,10 +333,12 @@ surfaces = [{
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
         f"{len(jwt_candidates)} JWT-shaped candidates",
+        f"{len(tlsx_sans)} TLS SAN first-party hostnames",
+        f"{len(subzy_takeovers)} Subzy takeover findings",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "subzy_takeover" if subzy_takeovers else "", "tls_san_discovery" if tlsx_sans else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -321,9 +381,16 @@ if js_secrets:
 if jwt_candidates:
     add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
-    add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
+    takeover_hosts = []
+    for item in takeovers:
+        match = re.search(r'([a-z0-9.-]+\.' + re.escape(domain) + r')', item.lower())
+        takeover_hosts.append(match.group(1) if match else item.split()[0])
+    title = "Subzy takeover candidates" if subzy_takeovers else "Dangling CNAME takeover candidates"
+    add_lead(title, "deep-recon", takeover_hosts, [], [], "unknown", ["takeover"], takeovers[:10], 90 if subzy_takeovers else 85)
 if cve_hints:
     add_lead("Technology/CVE review candidates", "deep-recon", base_hosts, endpoint_pool[:40], [], "unknown", ["authz"], cve_hints, 68)
+if tlsx_sans:
+    add_lead("TLS certificate SAN first-party hosts recorded", "deep-recon", [f"https://{host}" for host in tlsx_sans[:20]], [], [], "unknown", [], [f"{len(tlsx_sans)} in-scope SAN hostnames recorded in tlsx_sans.txt; SAN hosts are not automatically promoted without liveness or endpoint evidence"], 38, promote=False)
 if brand_sibling_live:
     add_lead("Brand-linked sibling properties lightly probed", "deep-recon", [row.split()[0] for row in brand_sibling_live], [], [], "unknown", [], [f"{len(brand_sibling_live)} brand-linked sibling hosts checked with httpx; same-TLD-only candidates remain unprobed", *brand_sibling_live[:5]], 55, promote=True)
 elif brand_sibling_candidates:
@@ -339,6 +406,9 @@ counts = {
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
     "katana_urls": len(katana_urls),
+    "dns_records": len(dns_records),
+    "tlsx_sans": len(tlsx_sans),
+    "subzy_takeovers": len(subzy_takeovers),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),

--- a/.claude/agents/deep-recon-agent.md
+++ b/.claude/agents/deep-recon-agent.md
@@ -12,7 +12,7 @@ The spawn prompt includes concrete `[DOMAIN]` and `[SESSION]` values for this ru
 Replace placeholders before each Bash call. Do not send literal `$DOMAIN` or `$SESSION` to Bash.
 
 Execution contract:
-- Passive discovery only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
+- Passive discovery plus bounded in-scope liveness and crawling only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
 - Collection uses Bash only; final review may use Read and Write if a generated JSON artifact needs a small correction.
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
@@ -22,7 +22,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -124,12 +124,17 @@ if [ -s "$SESSION/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 90 "
 : > "$SESSION/brand_sibling_live.txt"
 if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "$SESSION/brand-sibling-probe-candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "$SESSION/brand_sibling_live.txt" 2>/dev/null || true; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
+: > "$SESSION/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'
 import collections, pathlib, re, sys, urllib.parse
@@ -160,6 +165,7 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "raw" / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization|bearer)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 clusters = []
 for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/billing", "/checkout", "/export", "/invite"):
     hits = [e for e in endpoints if pattern.lower() in e.lower()]
@@ -167,6 +173,7 @@ for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/b
         clusters.append(f"{pattern} {len(hits)}")
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:1000]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:200]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:100]) + ("\n" if jwt_candidates else ""))
 (session / "js_endpoint_clusters.txt").write_text("\n".join(clusters) + ("\n" if clusters else ""))
 PY
 ```
@@ -201,8 +208,10 @@ def uniq(values, limit):
 live = lines("live_hosts.txt", 250)
 family = lines("family_live.txt", 100)
 urls = lines("all_urls.txt")
+katana_urls = lines("katana_urls.txt")
 js_endpoints = lines("js_endpoints.txt", 1000)
 js_secrets = lines("js_secrets.txt", 200)
+jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
@@ -243,9 +252,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -262,12 +271,14 @@ surfaces = [{
     "evidence": uniq([
         f"{len(base_hosts)} live/family hosts retained",
         f"{len(urls)} CDX/Wayback URLs summarized",
+        f"{len(katana_urls)} Katana crawl URLs",
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
+        f"{len(jwt_candidates)} JWT-shaped candidates",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -307,6 +318,8 @@ billing_eps = [e for e in endpoint_pool if re.search(r'(?i)billing|checkout|invo
 add_lead("Billing and business logic candidates", "deep-recon", base_hosts, billing_eps, [p for p in interesting if re.search(r'(?i)amount|plan|coupon|price', p)], "billing", ["business_logic"], [f"{len(billing_eps)} billing/payment endpoints"], 72 if billing_eps else 0)
 if js_secrets:
     add_lead("JS-disclosed key material review", "deep-recon", base_hosts, js_endpoints[:40], [], "secrets", ["jwt_oauth"], [f"{len(js_secrets)} compact secret/token hints in js_secrets.txt"], 82)
+if jwt_candidates:
+    add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
     add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
 if cve_hints:
@@ -325,9 +338,11 @@ counts = {
     "brand_sibling_probe_candidates": len(brand_sibling_candidates),
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
+    "katana_urls": len(katana_urls),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),
+    "jwt_candidates": len(jwt_candidates),
     "takeover_candidates": len(takeovers),
     "tech_cve_hints": len(cve_hints),
     "surface_leads": len(leads),
@@ -379,6 +394,6 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Promote only evidence-backed surfaces; raw discovery noise belongs in files under `[SESSION]/raw`, not JSON.
-- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, takeover candidates, nuclei hits, and concrete tech/CVE leads.
+- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths and JWT-shaped candidates -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, takeover candidates, nuclei hits, and concrete tech/CVE leads.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.

--- a/.claude/agents/recon-agent.md
+++ b/.claude/agents/recon-agent.md
@@ -1,6 +1,6 @@
 ---
 name: recon-agent
-description: Runs bounded normal recon — subdomain enum, live hosts, archived URLs, nuclei, JS extraction — and produces attack_surface.json
+description: Runs bounded normal recon — subdomain enum, live hosts, archived/crawled URLs, nuclei, JS/JWT extraction — and produces attack_surface.json
 tools: Bash, Read, Write, Glob, Grep
 model: opus
 color: cyan
@@ -20,7 +20,7 @@ Execution contract:
 
 1. Binary check
 ```bash
-mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Subdomain aggregation
 ```bash
@@ -63,11 +63,16 @@ PY
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
 if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "[SESSION]/family_candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "[SESSION]/family_live.txt" 2>/dev/null || true; else : > "[SESSION]/family_live.txt"; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. URL discovery with CDX/Wayback and Katana
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
 while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+{ printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
+: > "[SESSION]/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "[SESSION]/crawl_roots.txt" ]; then timeout 90 "$KATANA" -list "[SESSION]/crawl_roots.txt" -silent -d 2 -jc -fs rdn -rl 20 -timeout 8 -o "[SESSION]/katana_urls.txt" 2>/dev/null || true; fi
+cat "[SESSION]/katana_urls.txt" >> "[SESSION]/all_urls.txt" 2>/dev/null || true
 sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
@@ -87,17 +92,19 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:400]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:100]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:50]) + ("\n" if jwt_candidates else ""))
 counts = {}
-for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","js_urls.txt","js_endpoints.txt","nuclei_results.txt"):
+for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","katana_urls.txt","js_urls.txt","js_endpoints.txt","jwt_candidates.txt","nuclei_results.txt"):
     path = session / name
     counts[name[:-4] if name.endswith(".txt") else name] = sum(1 for _ in path.open(errors="ignore")) if path.exists() else 0
 (session / "recon-summary.json").write_text(json.dumps({"version": 1, "counts": counts}, indent=2) + "\n")
 PY
 ```
 
-Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, and `recon-summary.json`.
+Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, `jwt_candidates.txt`, and `recon-summary.json`.
 Do not make any additional Bash calls while building final JSON. Use collected files only.
 
 Use this backward-compatible schema:
@@ -125,7 +132,7 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Group by application/property, not only subdomain. Include first-party sibling or parent properties only when links, redirects, or hostnames suggest org ownership.
-- Pull endpoints from archived URLs and JS extraction so hunters do not rediscover them.
+- Pull endpoints from archived URLs, Katana crawl output, and JS extraction so hunters do not rediscover them.
 - Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, and nuclei hits.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, and nuclei hits.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Recon tool coverage
+
+- Added optional Katana integration to normal and deep recon so bounded in-scope crawling augments CDX/Wayback and JS extraction before `attack_surface.json` is built.
+- Added JWT-shaped candidate extraction from JavaScript artifacts plus `jwt_tool` availability checks for later authorized token review without adding automated cracking or token mutation.
+- Expanded installer, doctor, README, and troubleshooting guidance to cover the existing passive recon tools (`amass`, `assetfinder`, `chaos`) plus `katana` and `jwt_tool`.
+
 ### Capability-pack routing for hunter dispatch
 
 - New `mcp/lib/capability-packs.js` defines a registry of capability packs (web + smart_contract_evm/svm/aptos/sui/substrate/cosmwasm) plus a `HUNTER_ROLES` map keyed by role_id. Each pack pins `hunter_agent`, `brief_profile`, `role_bundles`, and pack-keyed verifier/evidence/spawn dispatch metadata. `HUNTER_ROLES` is the single source of truth for hunter role display (name, description, color, role_bundles, prompt body filename).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Added optional Katana integration to normal and deep recon so bounded in-scope crawling augments CDX/Wayback and JS extraction before `attack_surface.json` is built.
 - Added JWT-shaped candidate extraction from JavaScript artifacts plus `jwt_tool` availability checks for later authorized token review without adding automated cracking or token mutation.
-- Expanded installer, doctor, README, and troubleshooting guidance to cover the existing passive recon tools (`amass`, `assetfinder`, `chaos`) plus `katana` and `jwt_tool`.
+- Added optional deep-recon DNS/TLS enrichment with `dnsx` and `tlsx`, plus bounded `subzy` checks against CNAME takeover candidates.
+- Expanded installer, doctor, README, and troubleshooting guidance to cover the existing passive recon tools (`amass`, `assetfinder`, `chaos`) plus `dnsx`, `tlsx`, `katana`, `subzy`, and `jwt_tool`.
 
 ### Capability-pack routing for hunter dispatch
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ In Codex, use `$bob-update`. In generic MCP hosts, run `hacker-bob update /path/
 RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT
 ```
 
-1. **RECON** — Bob sniffs around. Subdomains, live hosts, archived URLs, Katana crawl URLs, nuclei, JWT-shaped candidates, and JS secrets people forgot about. Add `--deep` for broader discovery, JS endpoint clustering, takeover/CVE-style lead hints, and promoted follow-up surfaces.
+1. **RECON** — Bob sniffs around. Subdomains, live hosts, archived URLs, Katana crawl URLs, DNS/TLS enrichment, Subzy takeover checks, nuclei, JWT-shaped candidates, and JS secrets people forgot about. Add `--deep` for broader discovery, JS endpoint clustering, takeover/CVE-style lead hints, and promoted follow-up surfaces.
 2. **AUTH** — Bob tries to sign up. If he can, he keeps a victim and an attacker account in his pocket. If he can't, he shrugs and hunts unauthenticated.
 3. **HUNT** — Parallel hunter agents fan out, one per attack surface. They are not gentle.
 4. **CHAIN** — Bob squints at the findings and asks "wait, can I combine these into something worse?"
@@ -187,7 +187,10 @@ go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
 go install github.com/owasp-amass/amass/v4/...@latest
 go install github.com/tomnomnom/assetfinder@latest
 go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest
+go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+go install github.com/projectdiscovery/tlsx/cmd/tlsx@latest
 go install github.com/projectdiscovery/katana/cmd/katana@latest
+go install -v github.com/PentestPad/subzy@latest
 git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool
 python3 -m pip install -r ~/jwt_tool/requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ In Codex, use `$bob-update`. In generic MCP hosts, run `hacker-bob update /path/
 RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT
 ```
 
-1. **RECON** — Bob sniffs around. Subdomains, live hosts, archived URLs, nuclei, JS secrets people forgot about. Add `--deep` for broader passive discovery, JS endpoint clustering, takeover/CVE-style lead hints, and promoted follow-up surfaces.
+1. **RECON** — Bob sniffs around. Subdomains, live hosts, archived URLs, Katana crawl URLs, nuclei, JWT-shaped candidates, and JS secrets people forgot about. Add `--deep` for broader discovery, JS endpoint clustering, takeover/CVE-style lead hints, and promoted follow-up surfaces.
 2. **AUTH** — Bob tries to sign up. If he can, he keeps a victim and an attacker account in his pocket. If he can't, he shrugs and hunts unauthenticated.
 3. **HUNT** — Parallel hunter agents fan out, one per attack surface. They are not gentle.
 4. **CHAIN** — Bob squints at the findings and asks "wait, can I combine these into something worse?"
@@ -187,6 +187,9 @@ go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
 go install github.com/owasp-amass/amass/v4/...@latest
 go install github.com/tomnomnom/assetfinder@latest
 go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest
+go install github.com/projectdiscovery/katana/cmd/katana@latest
+git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool
+python3 -m pip install -r ~/jwt_tool/requirements.txt
 ```
 
 If those aren't installed, Bob just works with what he's got and doesn't complain.

--- a/adapters/codex/skills/bob-hunt/SKILL.md
+++ b/adapters/codex/skills/bob-hunt/SKILL.md
@@ -282,7 +282,7 @@ Execution contract:
 
 1. Binary check
 ```bash
-mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Subdomain aggregation
 ```bash
@@ -325,11 +325,16 @@ PY
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
 if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "[SESSION]/family_candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "[SESSION]/family_live.txt" 2>/dev/null || true; else : > "[SESSION]/family_live.txt"; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. URL discovery with CDX/Wayback and Katana
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
 while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+{ printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
+: > "[SESSION]/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "[SESSION]/crawl_roots.txt" ]; then timeout 90 "$KATANA" -list "[SESSION]/crawl_roots.txt" -silent -d 2 -jc -fs rdn -rl 20 -timeout 8 -o "[SESSION]/katana_urls.txt" 2>/dev/null || true; fi
+cat "[SESSION]/katana_urls.txt" >> "[SESSION]/all_urls.txt" 2>/dev/null || true
 sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
@@ -349,17 +354,19 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:400]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:100]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:50]) + ("\n" if jwt_candidates else ""))
 counts = {}
-for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","js_urls.txt","js_endpoints.txt","nuclei_results.txt"):
+for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","katana_urls.txt","js_urls.txt","js_endpoints.txt","jwt_candidates.txt","nuclei_results.txt"):
     path = session / name
     counts[name[:-4] if name.endswith(".txt") else name] = sum(1 for _ in path.open(errors="ignore")) if path.exists() else 0
 (session / "recon-summary.json").write_text(json.dumps({"version": 1, "counts": counts}, indent=2) + "\n")
 PY
 ```
 
-Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, and `recon-summary.json`.
+Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, `jwt_candidates.txt`, and `recon-summary.json`.
 Do not make any additional Bash calls while building final JSON. Use collected files only.
 
 Use this backward-compatible schema:
@@ -387,9 +394,9 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Group by application/property, not only subdomain. Include first-party sibling or parent properties only when links, redirects, or hostnames suggest org ownership.
-- Pull endpoints from archived URLs and JS extraction so hunters do not rediscover them.
+- Pull endpoints from archived URLs, Katana crawl output, and JS extraction so hunters do not rediscover them.
 - Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, and nuclei hits.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, and nuclei hits.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.
 END recon CONTRACT
 
@@ -401,7 +408,7 @@ The spawn prompt includes concrete `[DOMAIN]` and `[SESSION]` values for this ru
 Replace placeholders before each Bash call. Do not send literal `$DOMAIN` or `$SESSION` to Bash.
 
 Execution contract:
-- Passive discovery only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
+- Passive discovery plus bounded in-scope liveness and crawling only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
 - Collection uses Bash only; final review may use Read and Write if a generated JSON artifact needs a small correction.
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
@@ -411,7 +418,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -513,12 +520,17 @@ if [ -s "$SESSION/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 90 "
 : > "$SESSION/brand_sibling_live.txt"
 if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "$SESSION/brand-sibling-probe-candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "$SESSION/brand_sibling_live.txt" 2>/dev/null || true; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
+: > "$SESSION/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'
 import collections, pathlib, re, sys, urllib.parse
@@ -549,6 +561,7 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "raw" / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization|bearer)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 clusters = []
 for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/billing", "/checkout", "/export", "/invite"):
     hits = [e for e in endpoints if pattern.lower() in e.lower()]
@@ -556,6 +569,7 @@ for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/b
         clusters.append(f"{pattern} {len(hits)}")
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:1000]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:200]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:100]) + ("\n" if jwt_candidates else ""))
 (session / "js_endpoint_clusters.txt").write_text("\n".join(clusters) + ("\n" if clusters else ""))
 PY
 ```
@@ -590,8 +604,10 @@ def uniq(values, limit):
 live = lines("live_hosts.txt", 250)
 family = lines("family_live.txt", 100)
 urls = lines("all_urls.txt")
+katana_urls = lines("katana_urls.txt")
 js_endpoints = lines("js_endpoints.txt", 1000)
 js_secrets = lines("js_secrets.txt", 200)
+jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
@@ -632,9 +648,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -651,12 +667,14 @@ surfaces = [{
     "evidence": uniq([
         f"{len(base_hosts)} live/family hosts retained",
         f"{len(urls)} CDX/Wayback URLs summarized",
+        f"{len(katana_urls)} Katana crawl URLs",
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
+        f"{len(jwt_candidates)} JWT-shaped candidates",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -696,6 +714,8 @@ billing_eps = [e for e in endpoint_pool if re.search(r'(?i)billing|checkout|invo
 add_lead("Billing and business logic candidates", "deep-recon", base_hosts, billing_eps, [p for p in interesting if re.search(r'(?i)amount|plan|coupon|price', p)], "billing", ["business_logic"], [f"{len(billing_eps)} billing/payment endpoints"], 72 if billing_eps else 0)
 if js_secrets:
     add_lead("JS-disclosed key material review", "deep-recon", base_hosts, js_endpoints[:40], [], "secrets", ["jwt_oauth"], [f"{len(js_secrets)} compact secret/token hints in js_secrets.txt"], 82)
+if jwt_candidates:
+    add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
     add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
 if cve_hints:
@@ -714,9 +734,11 @@ counts = {
     "brand_sibling_probe_candidates": len(brand_sibling_candidates),
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
+    "katana_urls": len(katana_urls),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),
+    "jwt_candidates": len(jwt_candidates),
     "takeover_candidates": len(takeovers),
     "tech_cve_hints": len(cve_hints),
     "surface_leads": len(leads),
@@ -768,8 +790,8 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Promote only evidence-backed surfaces; raw discovery noise belongs in files under `[SESSION]/raw`, not JSON.
-- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, takeover candidates, nuclei hits, and concrete tech/CVE leads.
+- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths and JWT-shaped candidates -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, takeover candidates, nuclei hits, and concrete tech/CVE leads.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.
 END deep-recon CONTRACT
 

--- a/adapters/codex/skills/bob-hunt/SKILL.md
+++ b/adapters/codex/skills/bob-hunt/SKILL.md
@@ -418,7 +418,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; for t in dnsx tlsx subzy; do command -v "$t" >/dev/null && echo "OK:$t" || { [ -x "$HOME/go/bin/$t" ] && echo "OK:$t" || echo "MISSING:$t"; }; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -447,11 +447,14 @@ PY
 printf "%s\nwww.%s\n" "$DOMAIN" "$DOMAIN" >> "$SESSION/raw/subdomains-tools.txt"
 sort -u "$SESSION/raw/subdomains-tools.txt" | head -n 5000 > "$SESSION/subdomains.txt"
 ```
-3. Live hosts, DNS, CNAME, and tech hints
+3. Live hosts, DNS, CNAME, TLS, takeover, and tech hints
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
-: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"
+DNSX="$(command -v dnsx 2>/dev/null || true)"; [ -z "$DNSX" ] && [ -x ~/go/bin/dnsx ] && DNSX="$HOME/go/bin/dnsx"
+TLSX="$(command -v tlsx 2>/dev/null || true)"; [ -z "$TLSX" ] && [ -x ~/go/bin/tlsx ] && TLSX="$HOME/go/bin/tlsx"
+SUBZY="$(command -v subzy 2>/dev/null || true)"; [ -z "$SUBZY" ] && [ -x ~/go/bin/subzy ] && SUBZY="$HOME/go/bin/subzy"
+: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/raw/dnsx.jsonl"; : > "$SESSION/raw/tlsx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"; : > "$SESSION/tlsx_sans.txt"; : > "$SESSION/takeover_probe_hosts.txt"; : > "$SESSION/subzy_takeovers.txt"
 if [ -n "$HTTPX" ]; then timeout 180 "$HTTPX" -l "$SESSION/subdomains.txt" -silent -follow-redirects -tech-detect -title -status-code -content-length -json -o "$SESSION/raw/httpx.jsonl" 2>/dev/null || true; fi
 python3 - "$SESSION" <<'PY'
 import json, pathlib, sys
@@ -473,6 +476,57 @@ for line in (session / "raw" / "httpx.jsonl").read_text(errors="ignore").splitli
 PY
 if [ ! -s "$SESSION/live_hosts.txt" ]; then printf "https://%s\nhttps://www.%s\n" "$DOMAIN" "$DOMAIN" > "$SESSION/live_hosts.txt"; fi
 if command -v dig >/dev/null; then awk '{print $1}' "$SESSION/subdomains.txt" | head -n 500 | while read -r h; do timeout 4 dig +short CNAME "$h" 2>/dev/null | sed "s#^#$h #" >> "$SESSION/cname_records.txt" || true; timeout 4 dig +short A "$h" 2>/dev/null | sed "s#^#$h A #" >> "$SESSION/dns_records.txt" || true; done; fi
+if [ -n "$DNSX" ]; then timeout 120 "$DNSX" -l "$SESSION/subdomains.txt" -silent -a -aaaa -cname -resp -json -o "$SESSION/raw/dnsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    return [str(value)]
+cname_rows, dns_rows = [], []
+for line in (session / "raw" / "dnsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        item = json.loads(line)
+    except Exception:
+        continue
+    host = str(item.get("host") or item.get("input") or "").lower().strip(".")
+    if not host:
+        continue
+    for key in ("cname", "cnames", "cname_record"):
+        for cname in as_list(item.get(key)):
+            cname = cname.lower().strip(".")
+            if cname:
+                cname_rows.append(f"{host} {cname}")
+    for key in ("a", "aaaa", "resp", "answers"):
+        for answer in as_list(item.get(key)):
+            answer = answer.strip()
+            if answer:
+                dns_rows.append(f"{host} {key.upper()} {answer}")
+(session / "cname_records.txt").write_text("\n".join(sorted(set((session / "cname_records.txt").read_text(errors="ignore").splitlines() + cname_rows))) + "\n")
+(session / "dns_records.txt").write_text("\n".join(sorted(set((session / "dns_records.txt").read_text(errors="ignore").splitlines() + dns_rows))) + "\n")
+PY
+awk '{print $1}' "$SESSION/cname_records.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/takeover_probe_hosts.txt"
+if [ -n "$SUBZY" ] && [ -s "$SESSION/takeover_probe_hosts.txt" ]; then timeout 120 "$SUBZY" run --targets "$SESSION/takeover_probe_hosts.txt" --hide_fails --timeout 10 > "$SESSION/subzy_takeovers.txt" 2>/dev/null || true; fi
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/subdomains.txt" 2>/dev/null; } | sort -u | head -n 500 > "$SESSION/tls_probe_hosts.txt"
+if [ -n "$TLSX" ] && [ -s "$SESSION/tls_probe_hosts.txt" ]; then timeout 120 "$TLSX" -l "$SESSION/tls_probe_hosts.txt" -silent -san -cn -json -o "$SESSION/raw/tlsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+hosts = set()
+for line in (session / "raw" / "tlsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        text = json.dumps(json.loads(line))
+    except Exception:
+        text = line
+    for host in re.findall(r'\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b', text.lower()):
+        host = host.strip("*. ")
+        if host == domain or host.endswith("." + domain):
+            hosts.add(host)
+(session / "tlsx_sans.txt").write_text("\n".join(sorted(hosts)) + ("\n" if hosts else ""))
+PY
 ```
 4. First-party family discovery
 Target-domain family probing remains bounded to `[DOMAIN]` and hosts ending in `.[DOMAIN]`. Also record compact sibling-domain candidates from linked hosts; do not probe the broad `sibling-domain-candidates.txt` set. Deep mode may run a tiny explicit liveness check only for brand-linked sibling hosts written to `brand-sibling-probe-candidates.txt`; same-TLD-only repeat evidence stays record-only.
@@ -523,7 +577,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
+{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
@@ -610,12 +664,16 @@ js_secrets = lines("js_secrets.txt", 200)
 jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
+dns_records = lines("dns_records.txt", 300)
+tlsx_sans = lines("tlsx_sans.txt", 200)
+subzy_takeovers = lines("subzy_takeovers.txt", 100)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
 archive_params = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_param_summary.txt", 120)]
 tech_text = "\n".join(live + family + nuclei)
 tech_stack = uniq(re.findall(r'\[([A-Za-z0-9., _+-]{2,120})\]', tech_text), 20)
 takeover_patterns = ("github.io","herokuapp.com","azurewebsites.net","cloudapp.net","readme.io","surge.sh","pages.dev","pantheonsite.io","unbouncepages.com")
-takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+pattern_takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+takeovers = uniq(pattern_takeovers + subzy_takeovers, 200)
 sibling_candidates = lines("sibling-domain-candidates.txt", 50)
 brand_sibling_candidates = lines("brand-sibling-probe-candidates.txt", 20)
 brand_sibling_live = lines("brand_sibling_live.txt", 20)
@@ -648,9 +706,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates + subzy_takeovers)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0) + (10 if subzy_takeovers else 0) + (5 if tlsx_sans else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -671,10 +729,12 @@ surfaces = [{
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
         f"{len(jwt_candidates)} JWT-shaped candidates",
+        f"{len(tlsx_sans)} TLS SAN first-party hostnames",
+        f"{len(subzy_takeovers)} Subzy takeover findings",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "subzy_takeover" if subzy_takeovers else "", "tls_san_discovery" if tlsx_sans else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -717,9 +777,16 @@ if js_secrets:
 if jwt_candidates:
     add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
-    add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
+    takeover_hosts = []
+    for item in takeovers:
+        match = re.search(r'([a-z0-9.-]+\.' + re.escape(domain) + r')', item.lower())
+        takeover_hosts.append(match.group(1) if match else item.split()[0])
+    title = "Subzy takeover candidates" if subzy_takeovers else "Dangling CNAME takeover candidates"
+    add_lead(title, "deep-recon", takeover_hosts, [], [], "unknown", ["takeover"], takeovers[:10], 90 if subzy_takeovers else 85)
 if cve_hints:
     add_lead("Technology/CVE review candidates", "deep-recon", base_hosts, endpoint_pool[:40], [], "unknown", ["authz"], cve_hints, 68)
+if tlsx_sans:
+    add_lead("TLS certificate SAN first-party hosts recorded", "deep-recon", [f"https://{host}" for host in tlsx_sans[:20]], [], [], "unknown", [], [f"{len(tlsx_sans)} in-scope SAN hostnames recorded in tlsx_sans.txt; SAN hosts are not automatically promoted without liveness or endpoint evidence"], 38, promote=False)
 if brand_sibling_live:
     add_lead("Brand-linked sibling properties lightly probed", "deep-recon", [row.split()[0] for row in brand_sibling_live], [], [], "unknown", [], [f"{len(brand_sibling_live)} brand-linked sibling hosts checked with httpx; same-TLD-only candidates remain unprobed", *brand_sibling_live[:5]], 55, promote=True)
 elif brand_sibling_candidates:
@@ -735,6 +802,9 @@ counts = {
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
     "katana_urls": len(katana_urls),
+    "dns_records": len(dns_records),
+    "tlsx_sans": len(tlsx_sans),
+    "subzy_takeovers": len(subzy_takeovers),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -59,6 +59,8 @@ OK: mcp_server_loadable - mcp/server.js loads successfully
 WARN: optional_tool_subfinder - subfinder is missing; related recon steps will be skipped
 WARN: optional_tool_nuclei - nuclei is missing; related recon steps will be skipped
 WARN: optional_tool_httpx - httpx is missing; related recon steps will be skipped
+WARN: optional_tool_katana - katana is missing; related recon steps will be skipped
+WARN: optional_tool_jwt_tool - jwt_tool is missing; JWT candidate review helpers will be skipped
 WARN: optional_patchright - patchright is missing; Tier 2 auto-signup is disabled
 WARN: optional_capsolver - CAPSOLVER_API_KEY is not set; CAPTCHA solving is disabled
 

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -59,7 +59,10 @@ OK: mcp_server_loadable - mcp/server.js loads successfully
 WARN: optional_tool_subfinder - subfinder is missing; related recon steps will be skipped
 WARN: optional_tool_nuclei - nuclei is missing; related recon steps will be skipped
 WARN: optional_tool_httpx - httpx is missing; related recon steps will be skipped
+WARN: optional_tool_dnsx - dnsx is missing; related recon steps will be skipped
+WARN: optional_tool_tlsx - tlsx is missing; related recon steps will be skipped
 WARN: optional_tool_katana - katana is missing; related recon steps will be skipped
+WARN: optional_tool_subzy - subzy is missing; related recon steps will be skipped
 WARN: optional_tool_jwt_tool - jwt_tool is missing; JWT candidate review helpers will be skipped
 WARN: optional_patchright - patchright is missing; Tier 2 auto-signup is disabled
 WARN: optional_capsolver - CAPSOLVER_API_KEY is not set; CAPTCHA solving is disabled

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -100,7 +100,10 @@ go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
 go install github.com/owasp-amass/amass/v4/...@latest
 go install github.com/tomnomnom/assetfinder@latest
 go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest
+go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+go install github.com/projectdiscovery/tlsx/cmd/tlsx@latest
 go install github.com/projectdiscovery/katana/cmd/katana@latest
+go install -v github.com/PentestPad/subzy@latest
 git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool
 python3 -m pip install -r ~/jwt_tool/requirements.txt
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,12 +91,18 @@ cd hacker-bob
 
 Bob works without optional recon tools, but some recon steps are skipped. `hacker-bob doctor` reports these as warnings.
 
-Install the ProjectDiscovery tools when you want deeper recon:
+Install the optional recon tools when you want deeper recon:
 
 ```bash
 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 go install github.com/projectdiscovery/httpx/cmd/httpx@latest
 go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
+go install github.com/owasp-amass/amass/v4/...@latest
+go install github.com/tomnomnom/assetfinder@latest
+go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest
+go install github.com/projectdiscovery/katana/cmd/katana@latest
+git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool
+python3 -m pip install -r ~/jwt_tool/requirements.txt
 ```
 
 Optional browser automation for Tier 2 auto-signup requires `patchright` in the project and browser binaries:

--- a/prompts/roles/deep-recon.md
+++ b/prompts/roles/deep-recon.md
@@ -5,7 +5,7 @@ The spawn prompt includes concrete `[DOMAIN]` and `[SESSION]` values for this ru
 Replace placeholders before each Bash call. Do not send literal `$DOMAIN` or `$SESSION` to Bash.
 
 Execution contract:
-- Passive discovery only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
+- Passive discovery plus bounded in-scope liveness and crawling only: no brute forcing, credential attacks, form submission, destructive checks, or authenticated actions.
 - Collection uses Bash only; final review may use Read and Write if a generated JSON artifact needs a small correction.
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
@@ -15,7 +15,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -117,12 +117,17 @@ if [ -s "$SESSION/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 90 "
 : > "$SESSION/brand_sibling_live.txt"
 if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "$SESSION/brand-sibling-probe-candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "$SESSION/brand_sibling_live.txt" 2>/dev/null || true; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
+: > "$SESSION/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'
 import collections, pathlib, re, sys, urllib.parse
@@ -153,6 +158,7 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "raw" / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization|bearer)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 clusters = []
 for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/billing", "/checkout", "/export", "/invite"):
     hits = [e for e in endpoints if pattern.lower() in e.lower()]
@@ -160,6 +166,7 @@ for pattern in ("/api/", "/graphql", "/admin", "/auth", "/oauth", "/upload", "/b
         clusters.append(f"{pattern} {len(hits)}")
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:1000]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:200]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:100]) + ("\n" if jwt_candidates else ""))
 (session / "js_endpoint_clusters.txt").write_text("\n".join(clusters) + ("\n" if clusters else ""))
 PY
 ```
@@ -194,8 +201,10 @@ def uniq(values, limit):
 live = lines("live_hosts.txt", 250)
 family = lines("family_live.txt", 100)
 urls = lines("all_urls.txt")
+katana_urls = lines("katana_urls.txt")
 js_endpoints = lines("js_endpoints.txt", 1000)
 js_secrets = lines("js_secrets.txt", 200)
+jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
@@ -236,9 +245,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -255,12 +264,14 @@ surfaces = [{
     "evidence": uniq([
         f"{len(base_hosts)} live/family hosts retained",
         f"{len(urls)} CDX/Wayback URLs summarized",
+        f"{len(katana_urls)} Katana crawl URLs",
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
+        f"{len(jwt_candidates)} JWT-shaped candidates",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -300,6 +311,8 @@ billing_eps = [e for e in endpoint_pool if re.search(r'(?i)billing|checkout|invo
 add_lead("Billing and business logic candidates", "deep-recon", base_hosts, billing_eps, [p for p in interesting if re.search(r'(?i)amount|plan|coupon|price', p)], "billing", ["business_logic"], [f"{len(billing_eps)} billing/payment endpoints"], 72 if billing_eps else 0)
 if js_secrets:
     add_lead("JS-disclosed key material review", "deep-recon", base_hosts, js_endpoints[:40], [], "secrets", ["jwt_oauth"], [f"{len(js_secrets)} compact secret/token hints in js_secrets.txt"], 82)
+if jwt_candidates:
+    add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
     add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
 if cve_hints:
@@ -318,9 +331,11 @@ counts = {
     "brand_sibling_probe_candidates": len(brand_sibling_candidates),
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
+    "katana_urls": len(katana_urls),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),
+    "jwt_candidates": len(jwt_candidates),
     "takeover_candidates": len(takeovers),
     "tech_cve_hints": len(cve_hints),
     "surface_leads": len(leads),
@@ -372,6 +387,6 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Promote only evidence-backed surfaces; raw discovery noise belongs in files under `[SESSION]/raw`, not JSON.
-- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, takeover candidates, nuclei hits, and concrete tech/CVE leads.
+- Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths and JWT-shaped candidates -> `jwt_oauth`; GraphQL endpoints -> `graphql`; dangling CNAME patterns -> `takeover`.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, takeover candidates, nuclei hits, and concrete tech/CVE leads.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.

--- a/prompts/roles/deep-recon.md
+++ b/prompts/roles/deep-recon.md
@@ -15,7 +15,7 @@ Execution contract:
 
 1. Binary check and workspace setup
 ```bash
-mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" "[SESSION]/raw" && { for t in subfinder amass assetfinder chaos curl python3 nuclei dig; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; for t in dnsx tlsx subzy; do command -v "$t" >/dev/null && echo "OK:$t" || { [ -x "$HOME/go/bin/$t" ] && echo "OK:$t" || echo "MISSING:$t"; }; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Passive subdomain and CT aggregation
 ```bash
@@ -44,11 +44,14 @@ PY
 printf "%s\nwww.%s\n" "$DOMAIN" "$DOMAIN" >> "$SESSION/raw/subdomains-tools.txt"
 sort -u "$SESSION/raw/subdomains-tools.txt" | head -n 5000 > "$SESSION/subdomains.txt"
 ```
-3. Live hosts, DNS, CNAME, and tech hints
+3. Live hosts, DNS, CNAME, TLS, takeover, and tech hints
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
-: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"
+DNSX="$(command -v dnsx 2>/dev/null || true)"; [ -z "$DNSX" ] && [ -x ~/go/bin/dnsx ] && DNSX="$HOME/go/bin/dnsx"
+TLSX="$(command -v tlsx 2>/dev/null || true)"; [ -z "$TLSX" ] && [ -x ~/go/bin/tlsx ] && TLSX="$HOME/go/bin/tlsx"
+SUBZY="$(command -v subzy 2>/dev/null || true)"; [ -z "$SUBZY" ] && [ -x ~/go/bin/subzy ] && SUBZY="$HOME/go/bin/subzy"
+: > "$SESSION/raw/httpx.jsonl"; : > "$SESSION/raw/dnsx.jsonl"; : > "$SESSION/raw/tlsx.jsonl"; : > "$SESSION/live_hosts.txt"; : > "$SESSION/cname_records.txt"; : > "$SESSION/dns_records.txt"; : > "$SESSION/tlsx_sans.txt"; : > "$SESSION/takeover_probe_hosts.txt"; : > "$SESSION/subzy_takeovers.txt"
 if [ -n "$HTTPX" ]; then timeout 180 "$HTTPX" -l "$SESSION/subdomains.txt" -silent -follow-redirects -tech-detect -title -status-code -content-length -json -o "$SESSION/raw/httpx.jsonl" 2>/dev/null || true; fi
 python3 - "$SESSION" <<'PY'
 import json, pathlib, sys
@@ -70,6 +73,57 @@ for line in (session / "raw" / "httpx.jsonl").read_text(errors="ignore").splitli
 PY
 if [ ! -s "$SESSION/live_hosts.txt" ]; then printf "https://%s\nhttps://www.%s\n" "$DOMAIN" "$DOMAIN" > "$SESSION/live_hosts.txt"; fi
 if command -v dig >/dev/null; then awk '{print $1}' "$SESSION/subdomains.txt" | head -n 500 | while read -r h; do timeout 4 dig +short CNAME "$h" 2>/dev/null | sed "s#^#$h #" >> "$SESSION/cname_records.txt" || true; timeout 4 dig +short A "$h" 2>/dev/null | sed "s#^#$h A #" >> "$SESSION/dns_records.txt" || true; done; fi
+if [ -n "$DNSX" ]; then timeout 120 "$DNSX" -l "$SESSION/subdomains.txt" -silent -a -aaaa -cname -resp -json -o "$SESSION/raw/dnsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    return [str(value)]
+cname_rows, dns_rows = [], []
+for line in (session / "raw" / "dnsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        item = json.loads(line)
+    except Exception:
+        continue
+    host = str(item.get("host") or item.get("input") or "").lower().strip(".")
+    if not host:
+        continue
+    for key in ("cname", "cnames", "cname_record"):
+        for cname in as_list(item.get(key)):
+            cname = cname.lower().strip(".")
+            if cname:
+                cname_rows.append(f"{host} {cname}")
+    for key in ("a", "aaaa", "resp", "answers"):
+        for answer in as_list(item.get(key)):
+            answer = answer.strip()
+            if answer:
+                dns_rows.append(f"{host} {key.upper()} {answer}")
+(session / "cname_records.txt").write_text("\n".join(sorted(set((session / "cname_records.txt").read_text(errors="ignore").splitlines() + cname_rows))) + "\n")
+(session / "dns_records.txt").write_text("\n".join(sorted(set((session / "dns_records.txt").read_text(errors="ignore").splitlines() + dns_rows))) + "\n")
+PY
+awk '{print $1}' "$SESSION/cname_records.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/takeover_probe_hosts.txt"
+if [ -n "$SUBZY" ] && [ -s "$SESSION/takeover_probe_hosts.txt" ]; then timeout 120 "$SUBZY" run --targets "$SESSION/takeover_probe_hosts.txt" --hide_fails --timeout 10 > "$SESSION/subzy_takeovers.txt" 2>/dev/null || true; fi
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/subdomains.txt" 2>/dev/null; } | sort -u | head -n 500 > "$SESSION/tls_probe_hosts.txt"
+if [ -n "$TLSX" ] && [ -s "$SESSION/tls_probe_hosts.txt" ]; then timeout 120 "$TLSX" -l "$SESSION/tls_probe_hosts.txt" -silent -san -cn -json -o "$SESSION/raw/tlsx.jsonl" 2>/dev/null || true; fi
+python3 - "$DOMAIN" "$SESSION" <<'PY'
+import json, pathlib, re, sys
+domain, session = sys.argv[1].lower(), pathlib.Path(sys.argv[2])
+hosts = set()
+for line in (session / "raw" / "tlsx.jsonl").read_text(errors="ignore").splitlines():
+    try:
+        text = json.dumps(json.loads(line))
+    except Exception:
+        text = line
+    for host in re.findall(r'\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b', text.lower()):
+        host = host.strip("*. ")
+        if host == domain or host.endswith("." + domain):
+            hosts.add(host)
+(session / "tlsx_sans.txt").write_text("\n".join(sorted(hosts)) + ("\n" if hosts else ""))
+PY
 ```
 4. First-party family discovery
 Target-domain family probing remains bounded to `[DOMAIN]` and hosts ending in `.[DOMAIN]`. Also record compact sibling-domain candidates from linked hosts; do not probe the broad `sibling-domain-candidates.txt` set. Deep mode may run a tiny explicit liveness check only for brand-linked sibling hosts written to `brand-sibling-probe-candidates.txt`; same-TLD-only repeat evidence stays record-only.
@@ -120,7 +174,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 5. Archived URLs with CDX/Wayback and Katana
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
+{ echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
 while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
@@ -207,12 +261,16 @@ js_secrets = lines("js_secrets.txt", 200)
 jwt_candidates = lines("jwt_candidates.txt", 100)
 nuclei = lines("nuclei_results.txt", 200)
 cname = lines("cname_records.txt", 200)
+dns_records = lines("dns_records.txt", 300)
+tlsx_sans = lines("tlsx_sans.txt", 200)
+subzy_takeovers = lines("subzy_takeovers.txt", 100)
 archive_paths = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_path_summary.txt", 300)]
 archive_params = [re.sub(r'^\d+\s+', '', x) for x in lines("archive_param_summary.txt", 120)]
 tech_text = "\n".join(live + family + nuclei)
 tech_stack = uniq(re.findall(r'\[([A-Za-z0-9., _+-]{2,120})\]', tech_text), 20)
 takeover_patterns = ("github.io","herokuapp.com","azurewebsites.net","cloudapp.net","readme.io","surge.sh","pages.dev","pantheonsite.io","unbouncepages.com")
-takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+pattern_takeovers = [line for line in cname if any(p in line.lower() for p in takeover_patterns)]
+takeovers = uniq(pattern_takeovers + subzy_takeovers, 200)
 sibling_candidates = lines("sibling-domain-candidates.txt", 50)
 brand_sibling_candidates = lines("brand-sibling-probe-candidates.txt", 20)
 brand_sibling_live = lines("brand_sibling_live.txt", 20)
@@ -245,9 +303,9 @@ def classify(text):
     if re.search(r'invite|team|organization', text_l): flows.append("invites")
     return uniq(hints, 12), uniq(flows, 12)
 base_hosts = uniq([row.split()[0] for row in live + family], 30)
-main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates)
+main_text = "\n".join(endpoint_pool + interesting + nuclei + js_secrets + jwt_candidates + subzy_takeovers)
 bug_hints, flows = classify(main_text)
-score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0)
+score = 20 + min(25, len(endpoint_pool)//3) + (20 if interesting else 0) + (20 if nuclei else 0) + (15 if js_secrets else 0) + (10 if jwt_candidates else 0) + (10 if subzy_takeovers else 0) + (5 if tlsx_sans else 0)
 score = max(30, min(95, score))
 priority = "CRITICAL" if score >= 85 else "HIGH" if score >= 60 else "MEDIUM" if score >= 35 else "LOW"
 surfaces = [{
@@ -268,10 +326,12 @@ surfaces = [{
         f"{len(js_endpoints)} JS endpoints extracted",
         f"{len(js_secrets)} JS secret/key-material hints",
         f"{len(jwt_candidates)} JWT-shaped candidates",
+        f"{len(tlsx_sans)} TLS SAN first-party hostnames",
+        f"{len(subzy_takeovers)} Subzy takeover findings",
         f"{len(nuclei)} nuclei hits",
         *cve_hints[:5],
     ], 20),
-    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
+    "ranking": {"version": 1, "score": score, "priority": priority, "reasons": uniq(["archive_endpoint_density" if endpoint_pool else "", "object_identifier_params" if interesting else "", "js_secret_or_key_material" if js_secrets else "", "jwt_candidates" if jwt_candidates else "", "subzy_takeover" if subzy_takeovers else "", "tls_san_discovery" if tlsx_sans else "", "nuclei_hits" if nuclei else "", "tech_cve_hints" if cve_hints else ""], 10)}
 }]
 leads = []
 now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
@@ -314,9 +374,16 @@ if js_secrets:
 if jwt_candidates:
     add_lead("JWT and OIDC token review candidates", "deep-recon", base_hosts, [e for e in endpoint_pool if re.search(r'(?i)oauth|oidc|jwt|jwks|callback|token|sso', e)][:60], [], "auth", ["jwt_oauth"], [f"{len(jwt_candidates)} JWT-shaped candidates in jwt_candidates.txt for authorized jwt_tool review"], 78)
 if takeovers:
-    add_lead("Dangling CNAME takeover candidates", "deep-recon", [x.split()[0] for x in takeovers], [], [], "unknown", ["takeover"], takeovers[:10], 85)
+    takeover_hosts = []
+    for item in takeovers:
+        match = re.search(r'([a-z0-9.-]+\.' + re.escape(domain) + r')', item.lower())
+        takeover_hosts.append(match.group(1) if match else item.split()[0])
+    title = "Subzy takeover candidates" if subzy_takeovers else "Dangling CNAME takeover candidates"
+    add_lead(title, "deep-recon", takeover_hosts, [], [], "unknown", ["takeover"], takeovers[:10], 90 if subzy_takeovers else 85)
 if cve_hints:
     add_lead("Technology/CVE review candidates", "deep-recon", base_hosts, endpoint_pool[:40], [], "unknown", ["authz"], cve_hints, 68)
+if tlsx_sans:
+    add_lead("TLS certificate SAN first-party hosts recorded", "deep-recon", [f"https://{host}" for host in tlsx_sans[:20]], [], [], "unknown", [], [f"{len(tlsx_sans)} in-scope SAN hostnames recorded in tlsx_sans.txt; SAN hosts are not automatically promoted without liveness or endpoint evidence"], 38, promote=False)
 if brand_sibling_live:
     add_lead("Brand-linked sibling properties lightly probed", "deep-recon", [row.split()[0] for row in brand_sibling_live], [], [], "unknown", [], [f"{len(brand_sibling_live)} brand-linked sibling hosts checked with httpx; same-TLD-only candidates remain unprobed", *brand_sibling_live[:5]], 55, promote=True)
 elif brand_sibling_candidates:
@@ -332,6 +399,9 @@ counts = {
     "brand_sibling_live": len(brand_sibling_live),
     "archive_urls": len(urls),
     "katana_urls": len(katana_urls),
+    "dns_records": len(dns_records),
+    "tlsx_sans": len(tlsx_sans),
+    "subzy_takeovers": len(subzy_takeovers),
     "js_urls": len(lines("js_urls.txt")),
     "js_endpoints": len(js_endpoints),
     "secret_hints": len(js_secrets),

--- a/prompts/roles/recon.md
+++ b/prompts/roles/recon.md
@@ -13,7 +13,7 @@ Execution contract:
 
 1. Binary check
 ```bash
-mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; } > "[SESSION]/recon-tools.txt"
+mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v "$t" >/dev/null && echo "OK:$t" || echo "MISSING:$t"; done; command -v httpx >/dev/null && echo "OK:httpx" || { [ -x ~/go/bin/httpx ] && echo "OK:httpx" || echo "MISSING:httpx"; }; command -v katana >/dev/null && echo "OK:katana" || { [ -x ~/go/bin/katana ] && echo "OK:katana" || echo "MISSING:katana"; }; JWT_TOOL="$(command -v jwt_tool 2>/dev/null || command -v jwt_tool.py 2>/dev/null || true)"; [ -z "$JWT_TOOL" ] && [ -x "$HOME/jwt_tool/jwt_tool.py" ] && JWT_TOOL="$HOME/jwt_tool/jwt_tool.py"; [ -n "$JWT_TOOL" ] && echo "OK:jwt_tool" || echo "MISSING:jwt_tool"; } > "[SESSION]/recon-tools.txt"
 ```
 2. Subdomain aggregation
 ```bash
@@ -56,11 +56,16 @@ PY
 HTTPX="$(command -v httpx 2>/dev/null || true)"; [ -z "$HTTPX" ] && [ -x ~/go/bin/httpx ] && HTTPX="$HOME/go/bin/httpx"
 if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 "$HTTPX" -l "[SESSION]/family_candidates.txt" -silent -follow-redirects -tech-detect -title -status-code -o "[SESSION]/family_live.txt" 2>/dev/null || true; else : > "[SESSION]/family_live.txt"; fi
 ```
-5. Archived URLs with CDX/Wayback
+5. URL discovery with CDX/Wayback and Katana
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
 while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+{ printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
+: > "[SESSION]/katana_urls.txt"
+KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
+if [ -n "$KATANA" ] && [ -s "[SESSION]/crawl_roots.txt" ]; then timeout 90 "$KATANA" -list "[SESSION]/crawl_roots.txt" -silent -d 2 -jc -fs rdn -rl 20 -timeout 8 -o "[SESSION]/katana_urls.txt" 2>/dev/null || true; fi
+cat "[SESSION]/katana_urls.txt" >> "[SESSION]/all_urls.txt" 2>/dev/null || true
 sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
@@ -80,17 +85,19 @@ session = pathlib.Path(sys.argv[1])
 raw = (session / "js_raw.txt").read_text(errors="ignore")
 endpoints = sorted(set(re.findall(r'https?://[^\s"\'<>]+|/[A-Za-z0-9_./?=&%-]{4,}', raw)))
 secrets = sorted(set(s.strip() for s in re.findall(r'(?i)(?:api[_-]?key|token|secret|client[_-]?secret|authorization)[^,\n]{0,120}', raw) if len(s) < 180))
+jwt_candidates = sorted(set(re.findall(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b', raw)))
 (session / "js_endpoints.txt").write_text("\n".join(endpoints[:400]) + ("\n" if endpoints else ""))
 (session / "js_secrets.txt").write_text("\n".join(secrets[:100]) + ("\n" if secrets else ""))
+(session / "jwt_candidates.txt").write_text("\n".join(jwt_candidates[:50]) + ("\n" if jwt_candidates else ""))
 counts = {}
-for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","js_urls.txt","js_endpoints.txt","nuclei_results.txt"):
+for name in ("subdomains.txt","live_hosts.txt","all_urls.txt","katana_urls.txt","js_urls.txt","js_endpoints.txt","jwt_candidates.txt","nuclei_results.txt"):
     path = session / name
     counts[name[:-4] if name.endswith(".txt") else name] = sum(1 for _ in path.open(errors="ignore")) if path.exists() else 0
 (session / "recon-summary.json").write_text(json.dumps({"version": 1, "counts": counts}, indent=2) + "\n")
 PY
 ```
 
-Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, and `recon-summary.json`.
+Last step: build `[SESSION]/attack_surface.json` from `live_hosts.txt`, `family_live.txt`, `all_urls.txt`, `nuclei_results.txt`, `js_endpoints.txt`, `js_secrets.txt`, `jwt_candidates.txt`, and `recon-summary.json`.
 Do not make any additional Bash calls while building final JSON. Use collected files only.
 
 Use this backward-compatible schema:
@@ -118,7 +125,7 @@ Rules for `attack_surface.json`:
 - Required per-surface fields remain: `id`, `hosts`, `tech_stack`, `endpoints`, `interesting_params`, `nuclei_hits`, and `priority`.
 - Optional enrichment fields are additive: `surface_type`, `bug_class_hints`, `high_value_flows`, `evidence`, and `ranking`. Omit optional fields only without support.
 - Group by application/property, not only subdomain. Include first-party sibling or parent properties only when links, redirects, or hostnames suggest org ownership.
-- Pull endpoints from archived URLs and JS extraction so hunters do not rediscover them.
+- Pull endpoints from archived URLs, Katana crawl output, and JS extraction so hunters do not rediscover them.
 - Populate hints from evidence, not guesses: object IDs -> `idor`/`authz`; URL fetch/import/image params -> `ssrf`; upload/file paths -> `upload`; checkout/refund/coupon/plan flows -> `business_logic`; token/OAuth/JWKS/callback paths -> `jwt_oauth`; GraphQL endpoints -> `graphql`.
-- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, and nuclei hits.
+- Prioritize auth flows, object IDs, admin/debug paths, uploads, GraphQL, payments, API/mobile backends, JS-disclosed key material, JWT candidates, and nuclei hits.
 - Mark static/CDN-only/parked/WAF-only surfaces `LOW`.

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -244,6 +244,16 @@ function commandExists(command) {
   return result.status === 0;
 }
 
+function commandOrGoBinExists(command) {
+  return commandExists(command) || fs.existsSync(path.join(os.homedir(), "go", "bin", command));
+}
+
+function jwtToolExists() {
+  return commandExists("jwt_tool")
+    || commandExists("jwt_tool.py")
+    || fs.existsSync(path.join(os.homedir(), "jwt_tool", "jwt_tool.py"));
+}
+
 function patchrightAvailable(targetAbs, sourceRoot) {
   try {
     require.resolve("patchright", { paths: [targetAbs, sourceRoot] });
@@ -471,15 +481,20 @@ function printInstallSummary(summary) {
   }
   console.log("");
   console.log("Optional recon tools (hunting works without these, recon steps are skipped):");
-  for (const tool of ["subfinder", "nuclei"]) {
-    console.log(`  ${commandExists(tool) ? "OK" : "MISSING"}: ${tool}`);
+  for (const tool of ["subfinder", "httpx", "nuclei", "amass", "assetfinder", "chaos", "katana"]) {
+    console.log(`  ${commandOrGoBinExists(tool) ? "OK" : "MISSING"}: ${tool}`);
   }
-  console.log(`  ${commandExists("httpx") || fs.existsSync(path.join(os.homedir(), "go", "bin", "httpx")) ? "OK" : "MISSING"}: httpx`);
+  console.log(`  ${jwtToolExists() ? "OK" : "MISSING"}: jwt_tool`);
   console.log("");
   console.log("Install recon tools (optional):");
   console.log("  go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest");
   console.log("  go install github.com/projectdiscovery/httpx/cmd/httpx@latest");
   console.log("  go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest");
+  console.log("  go install github.com/owasp-amass/amass/v4/...@latest");
+  console.log("  go install github.com/tomnomnom/assetfinder@latest");
+  console.log("  go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest");
+  console.log("  go install github.com/projectdiscovery/katana/cmd/katana@latest");
+  console.log("  git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool && python3 -m pip install -r ~/jwt_tool/requirements.txt");
   console.log("");
   if (summary.adapters.length === 1 && summary.adapters[0] === "claude") {
     console.log(`Done. Restart Claude Code in ${summary.targetAbs}, then run: /bob-hunt target.com`);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -481,7 +481,7 @@ function printInstallSummary(summary) {
   }
   console.log("");
   console.log("Optional recon tools (hunting works without these, recon steps are skipped):");
-  for (const tool of ["subfinder", "httpx", "nuclei", "amass", "assetfinder", "chaos", "katana"]) {
+  for (const tool of ["subfinder", "httpx", "nuclei", "amass", "assetfinder", "chaos", "dnsx", "tlsx", "katana", "subzy"]) {
     console.log(`  ${commandOrGoBinExists(tool) ? "OK" : "MISSING"}: ${tool}`);
   }
   console.log(`  ${jwtToolExists() ? "OK" : "MISSING"}: jwt_tool`);
@@ -493,7 +493,10 @@ function printInstallSummary(summary) {
   console.log("  go install github.com/owasp-amass/amass/v4/...@latest");
   console.log("  go install github.com/tomnomnom/assetfinder@latest");
   console.log("  go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest");
+  console.log("  go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest");
+  console.log("  go install github.com/projectdiscovery/tlsx/cmd/tlsx@latest");
   console.log("  go install github.com/projectdiscovery/katana/cmd/katana@latest");
+  console.log("  go install -v github.com/PentestPad/subzy@latest");
   console.log("  git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool && python3 -m pip install -r ~/jwt_tool/requirements.txt");
   console.log("");
   if (summary.adapters.length === 1 && summary.adapters[0] === "claude") {

--- a/scripts/lib/claude-role-renderer.js
+++ b/scripts/lib/claude-role-renderer.js
@@ -144,7 +144,7 @@ const CLAUDE_ROLE_SPECS = Object.freeze({
     kind: "agent",
     output_path: path.join(".claude", "agents", "recon-agent.md"),
     name: "recon-agent",
-    description: "Runs bounded normal recon \u2014 subdomain enum, live hosts, archived URLs, nuclei, JS extraction \u2014 and produces attack_surface.json",
+    description: "Runs bounded normal recon \u2014 subdomain enum, live hosts, archived/crawled URLs, nuclei, JS/JWT extraction \u2014 and produces attack_surface.json",
     model: "opus",
     color: "cyan",
     local_tools: Object.freeze(["Bash", "Read", "Write", "Glob", "Grep"]),

--- a/scripts/lifecycle.js
+++ b/scripts/lifecycle.js
@@ -292,8 +292,18 @@ function addRuntimeResourceChecks(checks, targetAbs) {
   }
 }
 
+function commandOrGoBinAvailable(command) {
+  return commandExists(command) || fileExists(path.join(os.homedir(), "go", "bin", command));
+}
+
 function httpxAvailable() {
-  return commandExists("httpx") || fileExists(path.join(os.homedir(), "go", "bin", "httpx"));
+  return commandOrGoBinAvailable("httpx");
+}
+
+function jwtToolAvailable() {
+  return commandExists("jwt_tool")
+    || commandExists("jwt_tool.py")
+    || fileExists(path.join(os.homedir(), "jwt_tool", "jwt_tool.py"));
 }
 
 function doctorProject(projectDir, options = {}) {
@@ -369,8 +379,8 @@ function doctorProject(projectDir, options = {}) {
 
   addRuntimeResourceChecks(checks, targetAbs);
 
-  for (const tool of ["subfinder", "nuclei", "amass", "assetfinder", "chaos"]) {
-    if (commandExists(tool)) {
+  for (const tool of ["subfinder", "nuclei", "amass", "assetfinder", "chaos", "katana"]) {
+    if (commandOrGoBinAvailable(tool)) {
       addCheck(checks, "ok", `optional_tool_${tool}`, `${tool} is available`);
     } else {
       addCheck(checks, "warn", `optional_tool_${tool}`, `${tool} is missing; related recon steps will be skipped`);
@@ -381,6 +391,12 @@ function doctorProject(projectDir, options = {}) {
     addCheck(checks, "ok", "optional_tool_httpx", "httpx is available");
   } else {
     addCheck(checks, "warn", "optional_tool_httpx", "httpx is missing; related recon steps will be skipped");
+  }
+
+  if (jwtToolAvailable()) {
+    addCheck(checks, "ok", "optional_tool_jwt_tool", "jwt_tool is available");
+  } else {
+    addCheck(checks, "warn", "optional_tool_jwt_tool", "jwt_tool is missing; JWT candidate review helpers will be skipped");
   }
 
   if (patchrightAvailable(targetAbs, sourceRoot)) {

--- a/scripts/lifecycle.js
+++ b/scripts/lifecycle.js
@@ -379,7 +379,7 @@ function doctorProject(projectDir, options = {}) {
 
   addRuntimeResourceChecks(checks, targetAbs);
 
-  for (const tool of ["subfinder", "nuclei", "amass", "assetfinder", "chaos", "katana"]) {
+  for (const tool of ["subfinder", "nuclei", "amass", "assetfinder", "chaos", "dnsx", "tlsx", "katana", "subzy"]) {
     if (commandOrGoBinAvailable(tool)) {
       addCheck(checks, "ok", `optional_tool_${tool}`, `${tool} is available`);
     } else {

--- a/test/prompt-contracts.test.js
+++ b/test/prompt-contracts.test.js
@@ -927,6 +927,9 @@ test("normal recon agent is single-purpose and has no deep-only contract", () =>
   assert.doesNotMatch(reconPrompt, /amass/);
   assert.doesNotMatch(reconPrompt, /assetfinder/);
   assert.doesNotMatch(reconPrompt, /chaos/);
+  assert.doesNotMatch(reconPrompt, /dnsx/);
+  assert.doesNotMatch(reconPrompt, /tlsx/);
+  assert.doesNotMatch(reconPrompt, /subzy/);
   assert.doesNotMatch(reconPrompt, /surface-leads\.json/);
   assert.doesNotMatch(reconPrompt, /deep-summary\.json/);
 });
@@ -991,7 +994,12 @@ test("deep recon stays passive, broad, and writes compact ranked lead artifacts"
   assert.match(deepReconPrompt, /amass/);
   assert.match(deepReconPrompt, /assetfinder/);
   assert.match(deepReconPrompt, /chaos/);
+  assert.match(deepReconPrompt, /dnsx/);
+  assert.match(deepReconPrompt, /tlsx/);
   assert.match(deepReconPrompt, /katana/);
+  assert.match(deepReconPrompt, /subzy/);
+  assert.match(deepReconPrompt, /subzy_takeovers\.txt/);
+  assert.match(deepReconPrompt, /tlsx_sans\.txt/);
   assert.match(deepReconPrompt, /CDX\/Wayback/);
   assert.match(deepReconPrompt, /JS extraction/i);
   assert.match(deepReconPrompt, /JWT and OIDC token review candidates/);

--- a/test/prompt-contracts.test.js
+++ b/test/prompt-contracts.test.js
@@ -931,6 +931,20 @@ test("normal recon agent is single-purpose and has no deep-only contract", () =>
   assert.doesNotMatch(reconPrompt, /deep-summary\.json/);
 });
 
+test("recon agents include optional Katana crawl and JWT candidate artifacts", () => {
+  for (const agent of ["recon-agent", "deep-recon-agent"]) {
+    const reconPrompt = readFile(`.claude/agents/${agent}.md`);
+
+    assert.match(reconPrompt, /OK:katana/);
+    assert.match(reconPrompt, /MISSING:katana/);
+    assert.match(reconPrompt, /katana_urls\.txt/);
+    assert.match(reconPrompt, /OK:jwt_tool/);
+    assert.match(reconPrompt, /MISSING:jwt_tool/);
+    assert.match(reconPrompt, /jwt_candidates\.txt/);
+    assert.match(reconPrompt, /JWT-shaped candidates|jwt_candidates/);
+  }
+});
+
 test("recon attack_surface schema keeps required fields and adds optional enrichment", () => {
   const reconPrompt = readFile(".claude/agents/recon-agent.md");
 
@@ -977,8 +991,10 @@ test("deep recon stays passive, broad, and writes compact ranked lead artifacts"
   assert.match(deepReconPrompt, /amass/);
   assert.match(deepReconPrompt, /assetfinder/);
   assert.match(deepReconPrompt, /chaos/);
+  assert.match(deepReconPrompt, /katana/);
   assert.match(deepReconPrompt, /CDX\/Wayback/);
   assert.match(deepReconPrompt, /JS extraction/i);
+  assert.match(deepReconPrompt, /JWT and OIDC token review candidates/);
   assert.match(deepReconPrompt, /takeover_candidates/);
   assert.match(deepReconPrompt, /tech\/CVE hints/);
   assert.match(deepReconPrompt, /sibling-domain-candidates\.txt/);


### PR DESCRIPTION
## Summary

- Add optional Katana crawling to normal and deep recon so bounded in-scope crawl URLs augment CDX/Wayback and JS extraction.
- Add JWT-shaped candidate extraction from JavaScript artifacts plus jwt_tool availability checks for later authorized token review.
- Add deep-mode dnsx/tlsx enrichment and bounded subzy checks for CNAME takeover candidates.
- Update installer, doctor, docs, generated Claude/Codex artifacts, and prompt-contract coverage for the new optional recon tools.

## Validation

- npm run check:syntax
- node scripts/generate-claude-roles.js --check
- node scripts/generate-codex-skills.js --check
- npm run test:prompts
- node --test test/install-smoke.test.js
- node --test test/cli.test.js