### PR TITLE
Remove legacy bounty agent copy

### DIFF
--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Bounty Agent MCP Server facade — tool registry, public exports, and CLI startup
+// Hacker Bob MCP server facade - tool registry, public exports, and CLI startup
 // Provides: bounty_http_scan, bounty_record_finding, bounty_read_findings,
 //           bounty_list_findings, bounty_write_verification_round,
 //           bounty_read_verification_round, bounty_write_grade_verdict,

--- a/site/index.html
+++ b/site/index.html
@@ -3,23 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hacker Bob | Open-source autonomous bug bounty agent</title>
+    <title>Hacker Bob | Open-source bug bounty workflow framework</title>
     <meta
       name="description"
-      content="Hacker Bob is an open-source autonomous bug bounty agent for Claude Code with local MCP state, parallel hunter agents, verification rounds, and evidence-backed reports."
+      content="Hacker Bob is an open-source bug bounty workflow framework for Claude Code with local MCP state, parallel hunter agents, verification rounds, and evidence-backed reports."
     />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Hacker Bob" />
     <meta
       property="og:description"
-      content="Open-source autonomous bug bounty agent for Claude Code."
+      content="Open-source bug bounty workflow framework for Claude Code."
     />
     <meta property="og:image" content="/brand/hacker-bob-social.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Hacker Bob" />
     <meta
       name="twitter:description"
-      content="Open-source autonomous bug bounty agent for Claude Code."
+      content="Open-source bug bounty workflow framework for Claude Code."
     />
     <meta name="twitter:image" content="/brand/hacker-bob-social.png" />
     <link rel="icon" type="image/png" href="/brand/hacker-bob.png" />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -151,7 +151,7 @@ function App() {
             <div className="hero__copy">
               <p className="eyebrow">Apache-2.0 / local-first / Claude Code</p>
               <h1>Hacker Bob</h1>
-              <p className="hero__subtitle">Open-source autonomous bug bounty agent for Claude Code.</p>
+              <p className="hero__subtitle">Open-source bug bounty workflow framework for Claude Code.</p>
               <p className="hero__body">
                 Bob coordinates recon, auth capture, hunting, chaining, verification, grading, and report writing through
                 local agents and a project-local MCP server.
@@ -364,7 +364,7 @@ function App() {
       <footer className="site-footer">
         <div className="site-footer__inner">
           <span>Hacker Bob</span>
-          <span>Open-source autonomous bug bounty agent for Claude Code.</span>
+          <span>Open-source bug bounty workflow framework for Claude Code.</span>
           <a href={repoUrl} {...externalProps('Open Hacker Bob on GitHub')}>
             <Github size={16} />
             GitHub

--- a/test/prompt-contracts.test.js
+++ b/test/prompt-contracts.test.js
@@ -151,6 +151,23 @@ function roleMcpToolsFromClaudeOutput(roleId) {
     .sort();
 }
 
+test("public copy uses Hacker Bob naming instead of retired product phrasing", () => {
+  const publicFiles = [
+    "mcp/server.js",
+    "site/index.html",
+    "site/src/App.tsx",
+  ];
+  const retiredNamePattern = new RegExp("\\bBounty " + "Agent\\b|\\bbounty " + "agent\\b", "i");
+
+  for (const file of publicFiles) {
+    assert.doesNotMatch(
+      readFile(file),
+      retiredNamePattern,
+      `${file} should use Hacker Bob or Bob naming`,
+    );
+  }
+});
+
 test("Claude roles render exactly from the shared role model", () => {
   for (const [roleId, spec] of Object.entries(CLAUDE_ROLE_SPECS)) {
     assert.equal(


### PR DESCRIPTION
## Summary
- replace public site metadata and page copy with Hacker Bob / bug bounty workflow framework wording
- update the MCP server facade comment to Hacker Bob naming
- add a prompt contract regression so public copy does not reintroduce the retired wording

Fixes #7

## Verification
- npm run build --prefix site
- npm run test:prompts
- npm run release:check
- git diff --check
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation & Branding**
  * Updated product messaging across the website and documentation to reflect current positioning as a workflow framework.
  * Refreshed SEO metadata and marketing copy to align with updated brand language.

* **Tests**
  * Added test to validate consistent product naming conventions across public-facing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->