### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-10
+
+### Capability hypergraph
+
+- Shipped the post-v2 [capability hypergraph](docs/capability-hypergraph.md): 8 capabilities, with C8 shipping substrate-only until explicit program policy permits live AI-driven disclosure speedruns.
+- Added 26 MCP tools across schema contracts, doc delta, auth differential, findings index, surface graph, chain tree, audit report ingest, invariant suggestions/runs, route extraction, symbol-surface indexing, diff impact, capability metrics, and capability evaluation.
+- Added 9 session artifacts: `schema-contracts.jsonl`, `doc-delta-results.json`, `auth-differential-results.json`, `findings-index.jsonl`, `surface-graph.jsonl`, `chain-tree.jsonl`, `audit-reports.jsonl`, `invariant-runs.jsonl`, and `symbol-surface-index.json`.
+- Added 3 bounded hunter-brief slices: `schema_slice`, `priors_slice`, and `surface_graph_slice`.
+- Added regression guards for web and smart-contract hunter brief size, v1/v2 `/bob-status` verification-panel rendering, and MCP-driven doc-delta execution against a local HTTP fixture.
+- Release notes: [docs/releases/v1.3.0.md](docs/releases/v1.3.0.md).
+
 ## [1.2.5] - 2026-05-08
 
 ### Adapter wrapper READMEs

--- a/adapters/codex/hacker-bob/.codex-plugin/plugin.json
+++ b/adapters/codex/hacker-bob/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Codex MCP wiring for the Hacker Bob bug bounty hunting runtime.",
   "author": {
     "name": "Hacker Bob contributors",

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,49 @@
+# Hacker Bob v1.3.0 Release Notes
+
+## Highlights
+
+`v1.3.0` ships the post-v2 capability hypergraph: 8 capabilities, with C8 shipping substrate-only until explicit program policy permits live AI-driven disclosure speedruns. The release adds 26 MCP tools, 9 session artifacts, and 3 new hunter-brief slices while keeping the runtime load at 102 tools.
+
+## Capabilities
+
+- C1 cross-surface correlation via `surface_graph_slice`.
+- C2 doc-vs-behavior delta hunting through schema ingest plus `bounty_run_doc_delta`.
+- C3 diff-aware regression hunting through route extraction, symbol-surface indexing, and diff impact summaries.
+- C4 multi-account differential checks through auth-profile fanout and divergence classification.
+- C5 invariant fuzzing from audit findings using Foundry template generation and run persistence.
+- C6 cross-target pattern memory through the findings index and `priors_slice`.
+- C7 branching chain search through a content-addressed chain state tree.
+- C8 live disclosure speedrun substrate only: NVD parsing and CVE-to-scope matching ship for offline triage, with no live dispatch wrapper.
+
+## Tools, Artifacts, And Briefs
+
+- Added 26 MCP tools across schema contracts, doc delta, auth differential, findings index, surface graph, chain tree, audit report ingest, invariant suggestions/runs, route extraction, symbol-surface indexing, diff impact, capability metrics, and capability evaluation.
+- Added 9 artifacts: `schema-contracts.jsonl`, `doc-delta-results.json`, `auth-differential-results.json`, `findings-index.jsonl`, `surface-graph.jsonl`, `chain-tree.jsonl`, `audit-reports.jsonl`, `invariant-runs.jsonl`, and `symbol-surface-index.json`.
+- Added 3 bounded hunter-brief slices: `schema_slice`, `priors_slice`, and `surface_graph_slice`.
+
+## Guardrails
+
+- Added regression coverage for representative web and smart-contract hunter brief size, with a 30k JSON budget for each profile.
+- Added a v1/v2 `/bob-status` verification-panel structural assertion so new status prompts preserve both v2 replay metadata and the v1 fallback.
+- Added an MCP-driven doc-delta integration test against a local HTTP fixture, including scope registration and hook invocation.
+- Resolved final PR review blockers around prompt tool allowlists, doc-delta examples, response hashing, blocked telemetry accounting, CVE parsing, route extraction, artifact writes, secret-marker redaction, and graph neighbor validation.
+
+## Install
+
+```bash
+npx -y hacker-bob@1.3.0 install /path/to/your/project
+# or, via the adapter wrappers
+npx -y hacker-bob-cc@1.3.0 install /path/to/your/project
+npx -y hacker-bob-codex@1.3.0 install /path/to/your/project
+```
+
+After installing, fully restart your host CLI (Claude Code or Codex) in that project.
+
+## Verification
+
+- `npm run test:mcp` passes.
+- `npm run test:prompts` passes.
+- `git diff --check` passes.
+- `npm test` passes.
+- `node -e "require('./mcp/server.js')"` loads the runtime successfully.
+- Fresh PR CI for `test (20)` and `test (22)` passed before merge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hacker-bob",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hacker-bob",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Portable autonomous bug bounty hunting MCP framework with host adapters",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-cc/package.json
+++ b/packages/hacker-bob-cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-cc",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Hacker Bob — Claude Code adapter wrapper. Pins --adapter claude and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "1.2.5"
+    "hacker-bob": "1.3.0"
   }
 }

--- a/packages/hacker-bob-codex/package.json
+++ b/packages/hacker-bob-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-codex",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Hacker Bob — Codex adapter wrapper. Pins --adapter codex and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "1.2.5"
+    "hacker-bob": "1.3.0"
   }
 }

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -232,10 +232,10 @@ function checkCanonicalPack(rootPackage) {
     }
   }
 
-  if (canonical.size < 2000000) {
-    pass(`canonical pack size ${canonical.size} bytes is under 2.0 MB`);
+  if (canonical.size < 2500000) {
+    pass(`canonical pack size ${canonical.size} bytes is under 2.5 MB`);
   } else {
-    fail(`canonical pack size ${canonical.size} bytes exceeds 2.0 MB`);
+    fail(`canonical pack size ${canonical.size} bytes exceeds 2.5 MB`);
   }
 
   let foundDisallowed = false;


### PR DESCRIPTION
## Summary
- Bump canonical package, adapter wrappers, lockfile, and Codex plugin manifest to 1.3.0.
- Add v1.3.0 release notes and changelog entry for the capability hypergraph release.
- Align the release-check canonical package size gate with the existing package test threshold after the PR #21 runtime/docs growth.

## Verification
- npm run release:check
- npm run release:check -- --registry (passed with one npm access warning; package/version/latest checks passed)
- npm run test:package
- git diff --check

Merge with a merge commit after required CI is green.