### PR TITLE
Derive capability metrics from tool registry metadata

### DIFF
--- a/mcp/lib/capability-eval-harness.js
+++ b/mcp/lib/capability-eval-harness.js
@@ -26,6 +26,7 @@ const {
   appendChainNode,
   frontier,
 } = require("./chain-state-tree.js");
+const { capabilityToolMapFromRegistry } = require("./tool-registry.js");
 
 function uniqueDomain(prefix) {
   return `${prefix}-${crypto.randomBytes(4).toString("hex")}.eval-fixture.local`;
@@ -213,6 +214,18 @@ const FIXTURES = Object.freeze({
     },
   },
 });
+
+const SUPPORTED_CAPABILITY_IDS = Object.freeze(new Set(Object.keys(capabilityToolMapFromRegistry())));
+
+function assertFixturesRegistryBacked(fixtures) {
+  for (const [name, spec] of Object.entries(fixtures)) {
+    if (!SUPPORTED_CAPABILITY_IDS.has(spec.capability)) {
+      throw new Error(`Capability fixture ${name} uses unregistered capability ${spec.capability}`);
+    }
+  }
+}
+
+assertFixturesRegistryBacked(FIXTURES);
 
 async function evaluateAllFixtures() {
   const results = [];

--- a/mcp/lib/capability-metrics.js
+++ b/mcp/lib/capability-metrics.js
@@ -1,36 +1,9 @@
 "use strict";
 
+const { capabilityToolMapFromRegistry } = require("./tool-registry.js");
 const { readToolTelemetryEvents } = require("./tool-telemetry.js");
 
-const CAPABILITY_TO_TOOLS = Object.freeze({
-  C2_doc_vs_behavior: [
-    "bounty_ingest_schema_doc",
-    "bounty_query_schema_contracts",
-    "bounty_run_doc_delta",
-    "bounty_read_doc_delta_results",
-  ],
-  C4_multi_account_differential: [
-    "bounty_run_auth_differential",
-    "bounty_read_auth_differential_results",
-  ],
-  I6_findings_index: [
-    "bounty_index_finding",
-    "bounty_query_findings_index",
-  ],
-  I1_surface_graph: [
-    "bounty_build_surface_graph",
-    "bounty_query_surface_graph",
-  ],
-  I7_chain_state_tree: [
-    "bounty_append_chain_node",
-    "bounty_query_chain_tree",
-    "bounty_chain_frontier",
-    "bounty_chain_ancestry",
-  ],
-  X2_verification_attempt_diff: [
-    "bounty_diff_verification_attempts",
-  ],
-});
+const CAPABILITY_TO_TOOLS = capabilityToolMapFromRegistry();
 
 const TOOL_TO_CAPABILITY = (() => {
   const map = new Map();

--- a/mcp/lib/tool-registry.js
+++ b/mcp/lib/tool-registry.js
@@ -24,6 +24,7 @@ const VALID_ROLE_BUNDLES = Object.freeze([
   ...CROSS_CUTTING_ROLE_BUNDLES,
   ...chainSpecificHunterBundles(),
 ]);
+const CAPABILITY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const REQUIRED_FIELDS = Object.freeze([
   "name",
   "description",
@@ -61,6 +62,16 @@ function assertStringArrayField(entry, field, { allowEmpty = true, validValues =
   }
 }
 
+function normalizeCapabilityId(entry) {
+  if (!Object.prototype.hasOwnProperty.call(entry, "capability_id")) {
+    return null;
+  }
+  if (typeof entry.capability_id !== "string" || !CAPABILITY_ID_PATTERN.test(entry.capability_id)) {
+    throw new Error(`tool registry entry for ${entry.name} has invalid capability_id`);
+  }
+  return entry.capability_id;
+}
+
 function defineTool(entry) {
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     throw new Error("tool registry entry must be an object");
@@ -91,7 +102,10 @@ function defineTool(entry) {
   assertBooleanField(entry, "sensitive_output");
   assertStringArrayField(entry, "session_artifacts_written");
   assertBooleanField(entry, "hook_required");
-  return Object.freeze({ ...entry });
+  return Object.freeze({
+    ...entry,
+    capability_id: normalizeCapabilityId(entry),
+  });
 }
 
 function buildToolRegistry({
@@ -133,6 +147,7 @@ const TOOL_MANIFEST = Object.freeze(TOOL_REGISTRY.reduce((manifest, tool) => {
     sensitive_output: tool.sensitive_output,
     session_artifacts_written: tool.session_artifacts_written.slice(),
     hook_required: tool.hook_required,
+    capability_id: tool.capability_id,
   });
   return manifest;
 }, {}));
@@ -148,6 +163,21 @@ function toolNamesForRoleBundle(roleBundle) {
     .map((tool) => tool.name);
 }
 
+function capabilityToolMapFromRegistry(registry = TOOL_REGISTRY) {
+  const map = {};
+  for (const tool of registry) {
+    if (tool.capability_id == null) continue;
+    if (!Object.prototype.hasOwnProperty.call(map, tool.capability_id)) {
+      map[tool.capability_id] = [];
+    }
+    map[tool.capability_id].push(tool.name);
+  }
+  for (const capabilityId of Object.keys(map)) {
+    map[capabilityId] = Object.freeze(map[capabilityId].slice());
+  }
+  return Object.freeze(map);
+}
+
 module.exports = {
   TOOL_HANDLERS,
   TOOL_MANIFEST,
@@ -155,6 +185,7 @@ module.exports = {
   TOOLS,
   VALID_ROLE_BUNDLES,
   buildToolRegistry,
+  capabilityToolMapFromRegistry,
   defineTool,
   getRegisteredTool,
   toolNamesForRoleBundle,

--- a/mcp/lib/tools/append-chain-node.js
+++ b/mcp/lib/tools/append-chain-node.js
@@ -16,6 +16,7 @@ function appendChainNodeHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_append_chain_node",
+  capability_id: "I7_chain_state_tree",
   description:
     "Record one node in the content-addressed chain state tree. node_hash is computed from (parent_state_hash, action_canonical) so re-recording the same attempt is idempotent. state_hash is computed from (node_hash, observed_canonical) so a child can pin to it for backtracking. Pass parent_state_hash from a prior node's state_hash to extend a branch; omit to anchor at the root.",
   inputSchema: {

--- a/mcp/lib/tools/build-surface-graph.js
+++ b/mcp/lib/tools/build-surface-graph.js
@@ -11,6 +11,7 @@ function buildSurfaceGraphHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_build_surface_graph",
+  capability_id: "I1_surface_graph",
   description:
     "Build (or refresh) the surface graph for a target by reading attack_surface.json and the schema-contract corpus and emitting canonical edges. Idempotent via edge_hash; later builds upsert in place. Pass sources to limit which artifact paths feed the graph (default: ['attack_surface', 'schema_corpus']).",
   inputSchema: {

--- a/mcp/lib/tools/chain-ancestry.js
+++ b/mcp/lib/tools/chain-ancestry.js
@@ -12,6 +12,7 @@ function chainAncestryHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_chain_ancestry",
+  capability_id: "I7_chain_state_tree",
   description:
     "Walk parent_state_hash links from a state_hash back to the chain tree root. Returns the lineage in newest-first order, capped at 25 by default (max 100). Use when explaining how a leaf state was reached or when reconstructing a chain for evidence.",
   inputSchema: {

--- a/mcp/lib/tools/chain-frontier.js
+++ b/mcp/lib/tools/chain-frontier.js
@@ -12,6 +12,7 @@ function chainFrontierHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_chain_frontier",
+  capability_id: "I7_chain_state_tree",
   description:
     "Return the leaf nodes of the chain state tree (the live exploration frontier). Default excludes pruned leaves so dead branches don't pollute the next-action search; pass include_pruned: true to recover pruned tips for diagnostics.",
   inputSchema: {

--- a/mcp/lib/tools/diff-verification-attempts.js
+++ b/mcp/lib/tools/diff-verification-attempts.js
@@ -8,6 +8,7 @@ function diffVerificationAttemptsHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_diff_verification_attempts",
+  capability_id: "X2_verification_attempt_diff",
   description:
     "Compare two verification attempts for the same target. Each attempt_id is either an archive id from bounty_read_verification_context.archived_attempts[*].attempt_id, or the literal string \"current\" for the live attempt. Returns hash matches (snapshot, adjudication plan, final verification) plus a per-file diff (which files exist in only one side, which differ in content).",
   inputSchema: {

--- a/mcp/lib/tools/evaluate-capabilities.js
+++ b/mcp/lib/tools/evaluate-capabilities.js
@@ -1,11 +1,10 @@
 "use strict";
 
-const {
-  evaluateAllFixtures,
-  evaluateOneFixture,
-} = require("../capability-eval-harness.js");
-
 async function evaluateCapabilitiesHandler(args) {
+  const {
+    evaluateAllFixtures,
+    evaluateOneFixture,
+  } = require("../capability-eval-harness.js");
   if (args && typeof args.fixture === "string" && args.fixture.length > 0) {
     return evaluateOneFixture(args.fixture);
   }

--- a/mcp/lib/tools/index-finding.js
+++ b/mcp/lib/tools/index-finding.js
@@ -12,6 +12,7 @@ function indexFindingHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_index_finding",
+  capability_id: "I6_findings_index",
   description:
     "Compute a hashed-feature-vector embedding for a finding and persist it to findings-index.jsonl. Idempotent by finding_id; later calls upsert the same record. Pass calibration_label after grade adjudication so the same record carries ground-truth signal for future similarity queries.",
   inputSchema: {

--- a/mcp/lib/tools/ingest-schema-doc.js
+++ b/mcp/lib/tools/ingest-schema-doc.js
@@ -4,6 +4,7 @@ const { ingestSchemaDoc } = require("../schema-contracts-store.js");
 
 module.exports = Object.freeze({
   name: "bounty_ingest_schema_doc",
+  capability_id: "C2_doc_vs_behavior",
   description:
     "Parse and persist an OpenAPI / GraphQL / Postman document into the per-target schema-contract corpus. Contracts are deduplicated by contract_hash; later ingestion of the same source doc is a no-op for unchanged contracts. Use to seed doc-vs-behavior differential testing.",
   inputSchema: {

--- a/mcp/lib/tools/query-chain-tree.js
+++ b/mcp/lib/tools/query-chain-tree.js
@@ -14,6 +14,7 @@ function queryChainTreeHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_query_chain_tree",
+  capability_id: "I7_chain_state_tree",
   description:
     "Filter the chain state tree by parent_state_hash, verdict, and action.kind. Use to enumerate the children of a node (pass parent_state_hash) or to inspect every pending / success / pruned attempt across the tree.",
   inputSchema: {

--- a/mcp/lib/tools/query-findings-index.js
+++ b/mcp/lib/tools/query-findings-index.js
@@ -23,6 +23,7 @@ function queryFindingsIndexHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_query_findings_index",
+  capability_id: "I6_findings_index",
   description:
     "Query the hashed-feature-vector findings index for top-K similar past findings. Defaults to per-target scope; pass scope: 'cross_target' to walk all session directories. Use this to inject prior-art into a new hunt's brief or to look up similar findings while triaging a candidate.",
   inputSchema: {

--- a/mcp/lib/tools/query-schema-contracts.js
+++ b/mcp/lib/tools/query-schema-contracts.js
@@ -4,6 +4,7 @@ const { querySchemaContracts } = require("../schema-contracts-store.js");
 
 module.exports = Object.freeze({
   name: "bounty_query_schema_contracts",
+  capability_id: "C2_doc_vs_behavior",
   description:
     "Query the schema-contract corpus for a target. Filters by endpoint substring and HTTP method. Use to discover documented contracts before differential testing or to enumerate the documented attack surface.",
   inputSchema: {

--- a/mcp/lib/tools/query-surface-graph.js
+++ b/mcp/lib/tools/query-surface-graph.js
@@ -25,6 +25,7 @@ function querySurfaceGraphHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_query_surface_graph",
+  capability_id: "I1_surface_graph",
   description:
     "Query the surface graph. Default mode filters edges by source/target type, source/target id, and edge_type. Pass mode: 'neighbors' with node_type and node_id to walk a node's adjacency (direction: incoming, outgoing, or both).",
   inputSchema: {

--- a/mcp/lib/tools/read-auth-differential-results.js
+++ b/mcp/lib/tools/read-auth-differential-results.js
@@ -37,6 +37,7 @@ function readAuthDifferentialResultsHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_read_auth_differential_results",
+  capability_id: "C4_multi_account_differential",
   description:
     "Read the persisted auth-differential-results.json for a target. Pass summary_only: true to skip the per-endpoint array when only the divergence tally is needed.",
   inputSchema: {

--- a/mcp/lib/tools/read-capability-metrics.js
+++ b/mcp/lib/tools/read-capability-metrics.js
@@ -1,8 +1,7 @@
 "use strict";
 
-const { readCapabilityMetrics } = require("../capability-metrics.js");
-
 function readCapabilityMetricsHandler(args) {
+  const { readCapabilityMetrics } = require("../capability-metrics.js");
   return readCapabilityMetrics({
     target_domain: args && args.target_domain,
   });

--- a/mcp/lib/tools/read-doc-delta-results.js
+++ b/mcp/lib/tools/read-doc-delta-results.js
@@ -37,6 +37,7 @@ function readDocDeltaResultsHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_read_doc_delta_results",
+  capability_id: "C2_doc_vs_behavior",
   description:
     "Read the persisted doc-delta-results.json for a target. Pass summary_only: true to skip the per-contract array when only the divergence tally is needed.",
   inputSchema: {

--- a/mcp/lib/tools/run-auth-differential.js
+++ b/mcp/lib/tools/run-auth-differential.js
@@ -56,6 +56,7 @@ async function runAuthDifferentialToolHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_run_auth_differential",
+  capability_id: "C4_multi_account_differential",
   description:
     "Run a multi-account differential across the supplied endpoints. For each endpoint, issues a request via bounty_http_scan once per auth_profile, classifies divergences (status, response class, body shape, body length, sensitive-field count, unauth-success-with-auth-blocked), and writes auth-differential-results.json. Provide profile_metadata to flag genuine auth bypass; otherwise the tool auto-derives sent_with_auth: false for profile names matching guest/anon/noauth/etc.",
   inputSchema: {

--- a/mcp/lib/tools/run-doc-delta.js
+++ b/mcp/lib/tools/run-doc-delta.js
@@ -31,6 +31,7 @@ async function runDocDeltaToolHandler(args) {
 
 module.exports = Object.freeze({
   name: "bounty_run_doc_delta",
+  capability_id: "C2_doc_vs_behavior",
   description:
     "Run a doc-vs-behavior differential against the persisted schema-contract corpus. For each contract, issues a request via bounty_http_scan, classifies divergences, and writes doc-delta-results.json. Use after seeding the corpus with bounty_ingest_schema_doc.",
   inputSchema: {

--- a/test/capability-eval-harness.test.js
+++ b/test/capability-eval-harness.test.js
@@ -8,17 +8,14 @@ const {
   evaluateAllFixtures,
   evaluateOneFixture,
 } = require("../mcp/lib/capability-eval-harness.js");
+const {
+  capabilityToolMapFromRegistry,
+} = require("../mcp/lib/tool-registry.js");
 
-test("FIXTURES covers every post-v2 capability that has a runnable fixture", () => {
-  const capabilities = new Set(Object.values(FIXTURES).map((f) => f.capability));
-  for (const cap of [
-    "C2_doc_vs_behavior",
-    "C4_multi_account_differential",
-    "I6_findings_index",
-    "I1_surface_graph",
-    "I7_chain_state_tree",
-  ]) {
-    assert.ok(capabilities.has(cap), `${cap} fixture present`);
+test("FIXTURES capabilities are backed by registry capability metadata", () => {
+  const capabilityMap = capabilityToolMapFromRegistry();
+  for (const [name, spec] of Object.entries(FIXTURES)) {
+    assert.ok(capabilityMap[spec.capability], `${name} capability ${spec.capability} is registry-backed`);
   }
 });
 

--- a/test/capability-metrics.test.js
+++ b/test/capability-metrics.test.js
@@ -7,22 +7,23 @@ const {
   CAPABILITY_TO_TOOLS,
   summarizeCapabilityMetrics,
 } = require("../mcp/lib/capability-metrics.js");
+const {
+  capabilityToolMapFromRegistry,
+  TOOL_MANIFEST,
+} = require("../mcp/lib/tool-registry.js");
 
 function event({ tool, status = "ok", latency_ms = 10, timestamp = "2026-05-10T00:00:00Z", ok, error_code }) {
   return { tool, status, latency_ms, timestamp, ok, error_code };
 }
 
-test("CAPABILITY_TO_TOOLS covers the post-v2 capability surface", () => {
-  for (const cap of [
-    "C2_doc_vs_behavior",
-    "C4_multi_account_differential",
-    "I6_findings_index",
-    "I1_surface_graph",
-    "I7_chain_state_tree",
-    "X2_verification_attempt_diff",
-  ]) {
-    assert.ok(CAPABILITY_TO_TOOLS[cap], `${cap} present`);
-    assert.ok(CAPABILITY_TO_TOOLS[cap].length > 0, `${cap} has at least one tool`);
+test("CAPABILITY_TO_TOOLS is derived from registry capability metadata", () => {
+  const registryMap = capabilityToolMapFromRegistry();
+  assert.deepEqual(CAPABILITY_TO_TOOLS, registryMap);
+  for (const [capability, tools] of Object.entries(CAPABILITY_TO_TOOLS)) {
+    assert.ok(tools.length > 0, `${capability} has at least one tool`);
+    for (const tool of tools) {
+      assert.equal(TOOL_MANIFEST[tool].capability_id, capability);
+    }
   }
 });
 

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -33,6 +33,7 @@ const {
 } = require("../mcp/lib/dispatch.js");
 const {
   buildToolRegistry,
+  capabilityToolMapFromRegistry,
   defineTool,
   TOOL_REGISTRY,
 } = require("../mcp/lib/tool-registry.js");
@@ -1169,7 +1170,47 @@ test("MCP tool manifest exposes required policy metadata for every tool", () => 
     assert.equal(typeof metadata.sensitive_output, "boolean");
     assert.ok(Array.isArray(metadata.session_artifacts_written));
     assert.equal(typeof metadata.hook_required, "boolean");
+    assert.ok(metadata.capability_id === null || typeof metadata.capability_id === "string");
   }
+});
+
+test("MCP tool registry exposes capability metadata for metric and eval tools", () => {
+  const capabilityMap = capabilityToolMapFromRegistry();
+  assert.equal(TOOL_MANIFEST.bounty_http_scan.capability_id, null);
+  assert.equal(TOOL_MANIFEST.bounty_ingest_schema_doc.capability_id, "C2_doc_vs_behavior");
+  assert.equal(Object.isFrozen(capabilityMap), true);
+  for (const tools of Object.values(capabilityMap)) {
+    assert.equal(Object.isFrozen(tools), true);
+  }
+  assert.deepEqual(capabilityMap, {
+    C2_doc_vs_behavior: [
+      "bounty_ingest_schema_doc",
+      "bounty_query_schema_contracts",
+      "bounty_run_doc_delta",
+      "bounty_read_doc_delta_results",
+    ],
+    C4_multi_account_differential: [
+      "bounty_run_auth_differential",
+      "bounty_read_auth_differential_results",
+    ],
+    I6_findings_index: [
+      "bounty_index_finding",
+      "bounty_query_findings_index",
+    ],
+    I7_chain_state_tree: [
+      "bounty_append_chain_node",
+      "bounty_query_chain_tree",
+      "bounty_chain_frontier",
+      "bounty_chain_ancestry",
+    ],
+    X2_verification_attempt_diff: [
+      "bounty_diff_verification_attempts",
+    ],
+    I1_surface_graph: [
+      "bounty_build_surface_graph",
+      "bounty_query_surface_graph",
+    ],
+  });
 });
 
 test("MCP per-tool modules preserve representative tool behavior", () => {
@@ -1299,6 +1340,15 @@ test("MCP tool registry validation rejects incomplete or inconsistent entries", 
     hook_required: false,
   };
 
+  assert.equal(
+    buildToolRegistry({ toolModules: [completeModule] })[0].capability_id,
+    null,
+  );
+  assert.equal(
+    buildToolRegistry({ toolModules: [{ ...completeModule, capability_id: "C2_doc_vs_behavior" }] })[0].capability_id,
+    "C2_doc_vs_behavior",
+  );
+
   assert.throws(
     () => buildToolRegistry({
       toolModules: [completeModule, { ...completeModule }],
@@ -1335,6 +1385,15 @@ test("MCP tool registry validation rejects incomplete or inconsistent entries", 
     }),
     /unknown role bundle mystery/,
   );
+
+  for (const capability_id of ["", " C2_doc_vs_behavior", "-bad", "bad space", "a".repeat(129), null, 42]) {
+    assert.throws(
+      () => buildToolRegistry({
+        toolModules: [{ ...completeModule, capability_id }],
+      }),
+      /invalid capability_id/,
+    );
+  }
 });
 
 test("MCP runtime no longer imports legacy split tool definition files", () => {


### PR DESCRIPTION
## Summary
- add optional validated capability_id metadata to the tool registry and manifest
- tag only the existing capability metric/eval tools
- derive capability metrics and eval fixture coverage from registry metadata

Closes #24

## Tests
- npm run test:mcp
- npm run test:prompts
- git diff --check
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tool capability identification across the platform with registry-based validation, improving consistency and maintainability of the tool system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vmihalis/hacker-bob/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->