### PR TITLE
Fix release registry access check and status contract coverage

### DIFF
--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -390,7 +390,7 @@ function checkRegistry(rootPackage, wrapperPackages) {
     checkPackageRegistry(wrapperPackage.name, wrapperPackage.version);
   }
 
-  const access = npm(["access", "ls-packages", "--json"]);
+  const access = npm(["access", "list", "packages", "--json"]);
   if (access.status !== 0) {
     const allNames = [rootPackage.name, ...wrapperPackages.map(({ wrapperPackage }) => wrapperPackage.name)].join(", ");
     warn(`Could not verify npm read-write package access. Ensure the token can read and write ${allNames}.`);
@@ -398,7 +398,7 @@ function checkRegistry(rootPackage, wrapperPackages) {
     return;
   }
 
-  const accessMap = parseJsonOutput(access, "npm access ls-packages");
+  const accessMap = parseJsonOutput(access, "npm access list packages");
   if (!accessMap) return;
   const names = [rootPackage.name, ...wrapperPackages.map(({ wrapperPackage }) => wrapperPackage.name)];
   for (const name of names) {

--- a/test/prompt-contracts.test.js
+++ b/test/prompt-contracts.test.js
@@ -926,7 +926,9 @@ test("Claude ships generated command shims for update and export", () => {
 
 test("bountyagentstatus skill is compact, read-only, and points to next commands", () => {
   const skill = readFile(".claude/skills/bob-status/SKILL.md");
+  const codexSkill = readFile("adapters/codex/skills/bob-status/SKILL.md");
   const allowedTools = parseYamlListFrontmatter(skill, "allowed-tools", "bob-status/SKILL.md");
+  const verificationPanelContract = /When `bounty_read_verification_context` reports `schema_version: 2`[\s\S]*Current attempt:[\s\S]*current_attempt_id[\s\S]*first 8 chars of `snapshot_hash`[\s\S]*replay_execution_policy[\s\S]*archived_attempts\.length[\s\S]*snapshot <snapshot_hash:0\.\.8>[\s\S]*Older v1 sessions print `verification: schema v1` and skip the panel\./;
   const forbiddenTools = [
     "Task",
     "Write",
@@ -974,7 +976,8 @@ test("bountyagentstatus skill is compact, read-only, and points to next commands
   assert.match(skill, /snapshot_hash_current/);
   assert.match(skill, /replay_execution_policy/);
   assert.match(skill, /Archive trail/);
-  assert.match(skill, /When `bounty_read_verification_context` reports `schema_version: 2`[\s\S]*Current attempt:[\s\S]*current_attempt_id[\s\S]*first 8 chars of `snapshot_hash`[\s\S]*replay_execution_policy[\s\S]*archived_attempts\.length[\s\S]*snapshot <snapshot_hash:0\.\.8>[\s\S]*Older v1 sessions print `verification: schema v1` and skip the panel\./);
+  assert.match(skill, verificationPanelContract);
+  assert.match(codexSkill, verificationPanelContract);
   for (const tool of forbiddenTools) {
     assert.ok(!allowedTools.includes(tool), `${tool} must not be allowed in bountyagentstatus`);
   }


### PR DESCRIPTION
## Summary
- update release registry access check to use the supported npm access list packages command
- reuse the v2 verification panel contract regex for bob-status prompt assertions
- assert the same status panel contract for the Codex bob-status skill

## Tests
- node --check scripts/release-check.js
- npm access list packages --help
- git diff --check
- npm run test:prompts
- npm run release:check
- npm run release:check:registry -- --allow-published (passes with one npm credential access-list warning)
- npm test