### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-05-11
+
+### Runtime-owned wave starts
+
+- Added `bounty_start_next_wave` so normal HUNT/EXPLORE wave assignment policy now lives in the MCP runtime instead of orchestrator prompt prose.
+- Added the pure wave planner for standard bucket ordering, open requeue coverage, lead-surface follow-up, assignment caps, dedupe, and stable `aN` labels.
+- Moved automatic deep lead promotion into the new next-wave starter, leaving `bounty_promote_surface_leads` for explicit operator use.
+- Updated HUNT -> CHAIN gating, prompts, manifests, generated Claude/Codex artifacts, and tests so normal waves use the runtime-owned result instead of manual assignment calculation.
+- Rewrote the README into a cleaner user-facing guide and removed install instructions aimed at users' coding assistants.
+- Release notes: [docs/releases/v1.3.1.md](docs/releases/v1.3.1.md).
+
 ## [1.3.0] - 2026-05-10
 
 ### Capability hypergraph

--- a/README.md
+++ b/README.md
@@ -2,81 +2,66 @@
   <img src="docs/hacker-bob.png" alt="Hacker Bob" width="320" />
 </p>
 
-<h1 align="center">Meet Hacker Bob</h1>
+<h1 align="center">Hacker Bob</h1>
 
-<p align="center"><i>Portable autonomous bug bounty MCP framework with host adapters.</i></p>
+<p align="center"><i>A local MCP workflow framework for authorized bug bounty research.</i></p>
 
 <p align="center">
   <a href="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml/badge.svg" /></a>
   <a href="https://www.npmjs.com/package/hacker-bob"><img alt="hacker-bob on npm" src="https://img.shields.io/npm/v/hacker-bob?label=hacker-bob" /></a>
-  <a href="https://www.npmjs.com/package/hacker-bob-cc"><img alt="hacker-bob-cc compatibility package on npm" src="https://img.shields.io/npm/v/hacker-bob-cc?label=hacker-bob-cc" /></a>
-  <a href="https://www.npmjs.com/package/hacker-bob-codex"><img alt="hacker-bob-codex compatibility package on npm" src="https://img.shields.io/npm/v/hacker-bob-codex?label=hacker-bob-codex" /></a>
+  <a href="https://www.npmjs.com/package/hacker-bob-cc"><img alt="hacker-bob-cc on npm" src="https://img.shields.io/npm/v/hacker-bob-cc?label=hacker-bob-cc" /></a>
+  <a href="https://www.npmjs.com/package/hacker-bob-codex"><img alt="hacker-bob-codex on npm" src="https://img.shields.io/npm/v/hacker-bob-codex?label=hacker-bob-codex" /></a>
   <a href="LICENSE"><img alt="Apache-2.0 license" src="https://img.shields.io/github/license/vmihalis/hacker-bob" /></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/vmihalis/hacker-bob"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/vmihalis/hacker-bob/badge" /></a>
 </p>
 
-Bob is an autonomous bug bounty hunting framework built around a local MCP runtime. You point him at an authorized target, and the runtime coordinates recon, hunting, verification, grading, reporting, telemetry, and local evidence.
+Hacker Bob installs a local MCP runtime into a project directory and connects it to Claude Code, Codex, or another MCP-capable host. The runtime coordinates reconnaissance, authentication setup, parallel surface testing, finding verification, grading, reporting, and local evidence handling.
 
-You go to bed. Bob does not.
+Bob is designed for authorized security testing. It can send real network requests, run local recon tools, import local artifacts, and preserve sensitive run data on disk. You are responsible for using it only where you have permission.
 
 ## Quickstart
 
-### For AI Coding Agents
-
-If a user pastes this repository URL into an AI coding agent, treat it as an install request. Install Bob into the current working directory by default — that is the project the user is already in. Do not ask "what do you want to do?" when the current directory is a normal project. Ask only if the current directory is the Hacker Bob source tree itself, a home directory, or a root directory.
-
-```bash
-npx -y hacker-bob@latest install "$PWD"
-node -e "require('./mcp/server.js'); console.log('MCP ok')"
-```
-
-Verify the host integration based on the adapter Bob picked. The install command logs the chosen adapter and reason to stderr (e.g., `hacker-bob: auto-selected adapter claude (reason: project_dot_claude)`). Pass `--adapter claude|codex|generic-mcp` to override.
-
-| Adapter | Verification |
-|---|---|
-| `claude` | `claude mcp list` should show `bountyagent` connected. Then fully restart Claude Code in this directory and run `/bob-hunt target.com`. |
-| `codex` | `~/.codex/skills/bob-hunt/SKILL.md` should exist. Then fully restart Codex and run `$bob-hunt target.com`. |
-| `generic-mcp` | `.mcp.json` should contain `mcpServers.bountyagent` pointing at this project's `mcp/server.js`. Then reload your MCP host. |
-
-**Adapter auto-selection.** When `--adapter` is omitted, Bob picks one based on (1) prior install metadata in `.hacker-bob/install.json`, (2) host environment markers (`$CLAUDE_PROJECT_DIR`, `$CODEX_HOME`), (3) project files (`.claude/`, `.codex/plugins/`, `.agents/plugins/`, `.mcp.json`), or (4) host CLI on `PATH`. Claude is the final fallback.
-
-**MCP namespace.** Bob's MCP server is registered as `bountyagent`, so its tools appear as `mcp__bountyagent__bounty_*` in Claude Code. That name is expected. The user-facing commands renamed to `/bob-*` (Claude) and `$bob-*` (Codex), but the MCP server name stayed `bountyagent` for backward-compatible tool wiring. Do not "fix" the namespace.
-
-**Do not install into the Hacker Bob source tree.** If the install target contains `adapters/`, `mcp/server.js`, and `prompts/roles/` at its root, the user has handed you the source checkout. Ask for the actual target project before continuing.
-
-### Before You Run
-
-Bob is autonomous and can send real requests, use local tools, attempt signup and authentication flows, and interact with third-party, internal, or private hosts when instructed by Bob's agents. Only run Bob when you have explicit authorization for the target, accounts, testing methods, automation, and any third-party systems involved.
-
-The `claude --dangerously-skip-permissions` examples below disable Claude Code permission prompts. Use that mode only in a dedicated workspace for authorized security testing.
-
-Create or choose one project directory, then install Bob into that directory. Claude is the default host adapter:
+Choose the project directory where you want to run Bob. Install into that project, not into this source checkout unless you are developing Bob itself.
 
 ```bash
 npx -y hacker-bob@latest install /path/to/your/project
 cd /path/to/your/project
-claude --dangerously-skip-permissions --effort max
+node -e "require('./mcp/server.js'); console.log('MCP ok')"
 ```
 
-Then run:
+Restart your host CLI from the same project directory, then run the matching command:
 
-```
-/bob-hunt target.com
-```
+| Host | Command |
+|---|---|
+| Claude Code | `/bob-hunt target.com` |
+| Codex | `$bob-hunt target.com` |
+| Generic MCP host | Connect the generated `.mcp.json`, then follow `.hacker-bob/generic-mcp/hacker-bob.md`. |
 
-## Install
+Run a status check before a full hunt if you want to confirm the integration is loaded:
 
-Bob installs into **one project directory per command**. The install target is the project you will later open from your host CLI. The installer always writes the shared MCP runtime into `mcp/` and neutral Bob resources into `.hacker-bob/`; host adapters add their own integration files.
+| Host | Status command |
+|---|---|
+| Claude Code | `/bob-status` |
+| Codex | `$bob-status` |
+| Shell | `hacker-bob doctor /path/to/your/project` |
 
-Recommended one-off Claude install:
+## Safety
+
+Only run Bob against targets, accounts, applications, APIs, and infrastructure you own or are explicitly authorized to test. Read the target program's scope and rules of engagement before starting a hunt.
+
+Bob does not prove authorization, enforce a program policy, or guarantee containment. By default, supported HTTP tooling does not block localhost, private networks, internal hostnames, or cloud metadata-style hostnames. That default keeps local labs, VPN scopes, internal programs, and authorized pivots usable, but it also means you must choose targets carefully. For tools that support it, pass `block_internal_hosts: true` when you need that restriction.
+
+If your Claude Code workflow uses `--dangerously-skip-permissions`, use it only in a dedicated workspace for authorized security testing.
+
+## Installation
+
+`hacker-bob` is the canonical npm package:
 
 ```bash
 npx -y hacker-bob@latest install /path/to/your/project
 ```
 
-`hacker-bob` is the canonical npm package. `hacker-bob-cc` and `hacker-bob-codex` are small compatibility wrappers that delegate to the matching `hacker-bob` version while pinning the Claude or Codex adapter by default.
-
-Adapter-specific installs:
+Adapter-specific installs are available when you want to choose the host explicitly:
 
 ```bash
 npx -y hacker-bob@latest install /path/to/your/project --adapter claude
@@ -85,30 +70,35 @@ npx -y hacker-bob@latest install /path/to/your/project --adapter generic-mcp
 npx -y hacker-bob@latest install /path/to/your/project --adapter all
 ```
 
-The Claude adapter writes `.claude/` commands, skills, agents, hooks, statusline, and settings. The Codex adapter installs direct `$bob-*` skills into `~/.codex/skills`, writes a local `.codex/plugins/hacker-bob` plugin for MCP wiring and command wrappers, writes a repo-local `.agents/plugins/marketplace.json` entry, and activates the plugin in Codex's cache/config for MCP discovery. The generic MCP adapter writes root `.mcp.json` plus prompt docs under `.hacker-bob/generic-mcp/`.
+The installer is idempotent and preserves unrelated host configuration. It writes the shared MCP runtime to `mcp/`, neutral Bob resources to `.hacker-bob/`, and adapter-specific files for the selected host.
 
-Run installs as many times as you like. They are idempotent and preserve unrelated host config. Bob is polite about other people's settings.
+| Adapter | Installed files |
+|---|---|
+| `claude` | `.claude/` commands, skills, agents, hooks, statusline setup, and MCP settings. |
+| `codex` | `$bob-*` skills in `~/.codex/skills`, a local `.codex/plugins/hacker-bob` plugin, `.agents/plugins/marketplace.json`, and Codex MCP activation metadata. |
+| `generic-mcp` | A root `.mcp.json` entry plus prompt guide files under `.hacker-bob/generic-mcp/`. |
 
-If you prefer a global command, install the CLI once:
+When `--adapter` is omitted, Bob chooses an adapter from prior install metadata, host environment markers, project files, and installed host CLIs. Claude is the final fallback.
+
+The MCP server namespace is still `bountyagent`. Seeing `bountyagent` in `.mcp.json`, `claude mcp list`, or tool names such as `mcp__bountyagent__bounty_*` is expected and kept for compatibility.
+
+Small wrapper packages are available when you want the host choice encoded in the package name:
+
+```bash
+npx -y hacker-bob-cc@latest install /path/to/your/project
+npx -y hacker-bob-codex@latest install /path/to/your/project
+```
+
+You can also install the CLI globally:
 
 ```bash
 npm install -g hacker-bob
-hacker-bob install /path/to/your/project
+hacker-bob install /path/to/your/project --adapter claude
 ```
 
-Global npm install only puts the `hacker-bob` command on your `PATH`; it does **not** install Bob into every directory. To use Bob in another project, run `hacker-bob install /path/to/that/project --adapter <adapter>` for that project too.
+A global install only adds the `hacker-bob` command to your `PATH`; it does not install Bob into every project automatically.
 
-The adapter wrapper packages provide pinned entrypoints when you want the host choice encoded in the package name:
-
-```bash
-npm install -g hacker-bob-cc
-hacker-bob-cc install /path/to/your/project
-
-npm install -g hacker-bob-codex
-hacker-bob-codex install /path/to/your/project
-```
-
-Source installs still work for contributors:
+Source installs are for contributors and local development:
 
 ```bash
 git clone https://github.com/vmihalis/hacker-bob.git
@@ -116,78 +106,63 @@ cd hacker-bob
 ./install.sh /path/to/your/project
 ```
 
-## Usage
+## Commands
 
-```bash
-cd /path/to/your/project
-claude --dangerously-skip-permissions --effort max
+Claude Code commands:
+
+```text
+/bob-hunt target.com         # start a normal hunt
+/bob-hunt target.com --deep  # broader recon and deep lead follow-up
+/bob-hunt resume target.com  # resume an existing session
+/bob-status                  # show latest session status
+/bob-debug                   # inspect the latest local run
+/bob-update                  # preview and install the latest release
+/bob-export                  # create a release-scoped improvement bundle
 ```
 
-Then in Claude Code, use the Claude slash commands:
+Codex uses the same command names with a `$` prefix:
 
-```
-/bob-hunt target.com         # full autonomous run
-/bob-hunt target.com --deep  # broader script-heavy recon and lead promotion
-/bob-hunt resume target.com  # pick up where you left off
-/bob-status                 # quick latest-session status
-/bob-debug                   # review the latest local session
-/bob-update                  # preview and install the latest Bob release
-/bob-export                  # create a post-release improvement bundle
+```text
+$bob-hunt target.com
+$bob-status
+$bob-debug
+$bob-update
+$bob-export
 ```
 
-That's it. Now go make coffee.
-
-In Codex, restart in the target project and use `$bob-hunt`, `$bob-status`, `$bob-debug`, `$bob-update`, and `$bob-export`. In generic MCP hosts, connect to `mcp/server.js` through the generated `.mcp.json` entry and follow `.hacker-bob/generic-mcp/hacker-bob.md`.
-
-For install diagnostics, run:
+For install diagnostics:
 
 ```bash
 hacker-bob doctor /path/to/your/project
 hacker-bob doctor /path/to/your/project --adapter codex
 ```
 
-For common setup issues, see [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md).
-For a copy-paste first-run flow, see [`docs/FIRST_RUN.md`](docs/FIRST_RUN.md).
+## How A Hunt Works
 
-## Updates
+Bob follows a structured workflow:
 
-Run `/bob-update` inside Claude Code from the project where Bob is installed. The command checks the installed version, previews relevant `CHANGELOG.md` entries, asks before changing files, installs with:
-
-```bash
-npx -y hacker-bob@latest install "$CLAUDE_PROJECT_DIR"
+```text
+RECON -> AUTH -> HUNT -> CHAIN -> VERIFY -> GRADE -> REPORT
 ```
 
-After an update, fully restart Claude Code in that project. Bob also checks for available updates once per day on `SessionStart` and stores the result in `~/.cache/hacker-bob/update-checks/`; the statusline and `/bob-status` only read that local cache.
+- `RECON`: Collects subdomains, live hosts, archived URLs, crawled URLs, nuclei signals, JavaScript hints, and optional deep-recon lead data.
+- `AUTH`: Attempts authorized account setup when possible and records usable profiles for later differential testing.
+- `HUNT`: Starts parallel hunters against runtime-prioritized attack surfaces.
+- `CHAIN`: Evaluates whether individual findings combine into higher-impact scenarios.
+- `VERIFY`: Runs independent verification passes and collects bounded evidence for surviving reportable findings.
+- `GRADE`: Scores confirmed findings and decides whether they are ready to submit, should be held, or should be discarded.
+- `REPORT`: Produces a clean report with verified proof and evidence references.
 
-In Codex, use `$bob-update`. In generic MCP hosts, run `hacker-bob update /path/to/your/project --adapter generic-mcp` from a shell and reload the host's MCP config.
-
-## Post-Release Export
-
-After running Bob on one or more sessions with the installed release, run `/bob-export` in Claude or `$bob-export` in Codex. Bob writes a timestamped bundle under `~/bounty-agent-telemetry/release-bundles/v<version>/` with a fresh-agent prompt, manifest, summaries, filtered telemetry, and source paths for improving the next release. The export is read-only and release-scoped; it does not start hunts or touch targets.
-
-## How Bob hunts
-
-```
-RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT
-```
-
-1. **RECON** — Bob sniffs around. Normal mode collects subdomains, live hosts, archived and Katana-crawled URLs, nuclei hits, JWT-shaped candidates, and JS hints. Add `--deep` for broader discovery, DNS/TLS enrichment, bounded Subzy takeover checks, JS endpoint clustering, takeover/CVE-style lead hints, and promoted follow-up surfaces.
-2. **AUTH** — Bob tries to sign up. If he can, he keeps a victim and an attacker account in his pocket. If he can't, he shrugs and hunts unauthenticated.
-3. **HUNT** — Parallel hunter agents fan out, one per attack surface. They are not gentle.
-4. **CHAIN** — Bob squints at the findings and asks "wait, can I combine these into something worse?"
-5. **VERIFY** — Three rounds of arguing with himself: skeptical Bob, balanced Bob, and final-PoC Bob. Most "bugs" do not survive. After final verification, Bob collects bounded evidence packs for every final reportable finding.
-6. **GRADE** — 5-axis scoring. Bob decides: SUBMIT, HOLD, or "this is not a bug, please stop." Valid evidence packs are required before grading or reporting when final reportable findings exist.
-7. **REPORT** — A clean, submission-ready writeup with PoCs and evidence. No "could potentially". No "an attacker may". Just receipts.
-
-MCP ranking computes runtime priority for status views and hunter briefs. `/bob-status` also shows evidence readiness so missing or invalid evidence packs are visible before grade/report work. Imports and public-intel fetches do not rewrite `attack_surface.json`.
+MCP ranking computes runtime priority for status views and hunter briefs. Imports and public-intel fetches do not rewrite `attack_surface.json`.
 
 ## Requirements
 
-- One supported host: Claude Code, Codex, or another MCP-capable host
 - Node.js 20 or newer
-- For Claude: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with a model suitable for long autonomous workflows
-- `curl` and `python3` (already on your machine, probably)
-- Optional sidekicks for deeper recon:
+- One supported host: Claude Code, Codex, or another MCP-capable host
+- `curl` and `python3`
+- A dedicated project directory for the installed runtime
+
+Optional recon tools improve coverage when they are installed:
 
 ```bash
 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
@@ -204,86 +179,97 @@ git clone https://github.com/ticarpi/jwt_tool ~/jwt_tool
 python3 -m pip install -r ~/jwt_tool/requirements.txt
 ```
 
-If those aren't installed, Bob just works with what he's got and doesn't complain.
+Bob still runs without the optional tools; the installed toolset determines which recon paths are available.
 
-## MCP Troubleshooting
+## Updates
 
-If the MCP runtime isn't loading or Bob's tools don't appear in your host CLI, work through these failure modes before reinstalling.
+From Claude Code:
 
-### `Cannot find module './tools/index.js'`
-
-The MCP runtime is partially copied: `mcp/lib/tool-registry.js` exists but `mcp/lib/tools/` is missing or empty. This affects upgrades from older Bob versions where the install copied a stale subset. Reinstall to refresh:
-
-```bash
-npx -y hacker-bob@latest install /path/to/your/project
-cd /path/to/your/project
-node -e "require('./mcp/server.js'); console.log('MCP ok')"
+```text
+/bob-update
 ```
 
-### `bountyagent` does not appear in `claude mcp list` (Claude adapter)
+From Codex:
 
-The MCP wiring lives in `.mcp.json`. After install, fully restart Claude Code in the project directory; the `claude` CLI must reload `.mcp.json` to pick up the new server. If `bountyagent` still does not appear, run `hacker-bob doctor /path/to/your/project` and check for `claude_mcp_server_config` errors.
-
-### `$bob-hunt` does not resolve in Codex (Codex adapter)
-
-The Codex plugin manifest lives in `.codex/plugins/hacker-bob/.codex-plugin/plugin.json`, and Codex skills install into `~/.codex/skills/bob-{hunt,status,debug,update}/`. If `$bob-hunt` is not recognized:
-
-```bash
-ls ~/.codex/skills/bob-hunt/SKILL.md
-ls .codex/plugins/hacker-bob/.codex-plugin/plugin.json
+```text
+$bob-update
 ```
 
-If either is missing, reinstall with `--adapter codex`. Then fully restart Codex.
+From a shell:
 
-### MCP server entry missing or stale (generic-mcp adapter)
+```bash
+hacker-bob update /path/to/your/project --adapter claude
+```
 
-Open `.mcp.json` and confirm it contains an `mcpServers.bountyagent` entry pointing at this project's `mcp/server.js`. If it does, the host has not reloaded its MCP config — follow your host's reload procedure. If it does not, reinstall with `--adapter generic-mcp`.
+After an update, fully restart your host CLI in the project directory so it reloads commands, MCP config, hooks, and skills.
 
-### `bountyagent` looks like a stale skill name
+Bob also checks for available updates once per day on session start and stores the result under `~/.cache/hacker-bob/update-checks/`. Status views read that local cache.
 
-It is not a skill name. The MCP server namespace stayed `bountyagent` so existing tool wiring (`mcp__bountyagent__bounty_*`) continues to work after the user-facing slash and skill commands renamed to `/bob-*` and `$bob-*`. Seeing `bountyagent` in `claude mcp list` or `.mcp.json` is correct.
+## Exporting Run Data
 
-### `brutalist` server missing from `claude mcp list`
+After testing with an installed release, run `/bob-export` in Claude or `$bob-export` in Codex. Bob writes a timestamped bundle under:
 
-The brutalist verifier uses the external [`@brutalist/mcp`](https://www.npmjs.com/package/@brutalist/mcp) server for an adversarial roast pass per finding. The installer registers it as an optional MCP server alongside `bountyagent`, but it is **not required** — the brutalist verifier falls back to PoC-only verification with `brutalist roast unavailable` noted in the verification reasoning. If you want the roast layer back, ensure your `.mcp.json` contains `mcpServers.brutalist` (`npx -y @brutalist/mcp@latest`) and reload your host CLI.
+```text
+~/bounty-agent-telemetry/release-bundles/v<version>/
+```
 
-## Security Model
+The bundle includes summaries, filtered telemetry, session references, and a handoff document for improving future releases. Export is read-only and does not touch targets.
 
-Bob installs into a local project directory. The installer writes Bob-managed shared files under `mcp/` and `.hacker-bob/`, then writes adapter-specific host files such as `.claude/`, `.codex/plugins/hacker-bob`, `.agents/plugins/marketplace.json`, and `.mcp.json`. The Codex adapter also writes Bob-managed activation entries under `$CODEX_HOME` or `~/.codex` so Codex can load the local plugin. These files should be reviewed like any other automation that can run commands from your host CLI.
+## Troubleshooting
 
-Bob stores local run state and evidence under `~/bounty-agent-sessions`. Treat that directory as sensitive: it can contain target names, request metadata, notes, and report evidence from authorized testing.
+Use the doctor command first:
 
-During a hunt, Bob may make outbound HTTP requests, run local recon tools you have installed, import local HTTP/static artifacts, and ask host agents to reason over the results. Optional third-party services, such as browser automation dependencies, CAPTCHA solving, public-intel sources, or external recon tools, are only used when you configure the relevant dependencies or credentials.
+```bash
+hacker-bob doctor /path/to/your/project --adapter all
+```
 
-Bob logs and audits some activity, including local session artifacts and MCP HTTP scan records, but those records are for operator review. Bob does not verify authorization, enforce bug bounty scope, or guarantee containment.
+Common checks:
 
-By default, Bob does not block localhost, private networks, internal hostnames, or cloud metadata-style hostnames. This keeps exploration flexible for local labs, VPN/internal scopes, SSRF chains, and user-authorized pivots. Supported MCP HTTP calls can reject those destinations when you pass `block_internal_hosts: true`.
+- `node -e "require('./mcp/server.js'); console.log('MCP ok')"` should pass from the installed project.
+- Claude Code must be restarted after install or update before `/bob-*` commands and MCP settings load.
+- Codex must be restarted after install or update before `$bob-*` skills and local plugin wiring load.
+- `.mcp.json` should contain an `mcpServers.bountyagent` entry pointing at the installed project's `mcp/server.js`.
+- If an upgrade leaves `mcp/lib/tools/` missing, rerun the installer with `hacker-bob@latest`.
 
-The npm packages are published through the GitHub release workflow with npm provenance. `hacker-bob` is the canonical package; `hacker-bob-cc` and `hacker-bob-codex` are small adapter wrapper packages that depend on the matching canonical version.
+Detailed guides:
 
-Bob will scan the targets you provide and may touch other hosts during authorized chaining or proof-of-concept work. You are responsible for running it only against domains, applications, accounts, and infrastructure that you own or are explicitly authorized to test, and for following each program's scope and rules of engagement.
+- [First Run](docs/FIRST_RUN.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [Adapters](docs/ADAPTERS.md)
+- [Roadmap](docs/ROADMAP.md)
+
+## Data And Security Model
+
+Bob stores local run state, telemetry, and evidence under `~/bounty-agent-sessions`. Treat that directory as sensitive. It can contain target names, request metadata, notes, credentials metadata, and report evidence from authorized testing.
+
+During a hunt, Bob may make outbound HTTP requests, run local recon tools, import HTTP or static artifacts, and use host-side reasoning over the collected context. Optional third-party services and dependencies, such as browser automation dependencies, CAPTCHA solving, public-intel sources, or external recon tools, are used only when you configure the relevant dependencies or credentials.
+
+The npm packages are published through the project release workflow with npm provenance. `hacker-bob` is the canonical package; `hacker-bob-cc` and `hacker-bob-codex` are small wrapper packages that depend on the matching canonical version.
+
+Read [DISCLAIMER.md](DISCLAIMER.md) before using Bob on any target.
 
 ## Development
 
-If you're hacking on Bob himself and want to push the current repo into a test workspace:
+For local development on Bob itself:
+
+```bash
+npm test
+npm run release:check
+```
+
+To push the current checkout into a separate test workspace:
 
 ```bash
 ./dev-sync.sh /absolute/path/to/test-workspace
 ./dev-sync.sh /absolute/path/to/test-workspace --adapter codex
 ```
 
-It backs up host config, runs the local installer with the selected adapter, recopies the MCP runtime and neutral resources, and runs adapter-appropriate smoke checks. You can find the maintainer workflow in [`CLAUDE.md`](CLAUDE.md).
-
-## A note on scope
-
-Bob will scan whatever you tell him to scan. **You are responsible for making sure the target is in scope and that you have permission.** Bob is enthusiastic, not licensed.
-
-Hunt responsibly. Read the program's policy. Read [`DISCLAIMER.md`](DISCLAIMER.md) before you point him at anything.
+The maintainer workflow is documented in [CLAUDE.md](CLAUDE.md).
 
 ## Contributing
 
-Community pull requests are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening an issue or PR, and report vulnerabilities in Hacker Bob itself through [`SECURITY.md`](SECURITY.md).
+Pull requests are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or PR. Report vulnerabilities in Hacker Bob itself through [SECURITY.md](SECURITY.md).
 
 ## License
 
-Apache License 2.0 — see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+Apache License 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/adapters/codex/hacker-bob/.codex-plugin/plugin.json
+++ b/adapters/codex/hacker-bob/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Codex MCP wiring for the Hacker Bob bug bounty hunting runtime.",
   "author": {
     "name": "Hacker Bob contributors",

--- a/docs/releases/v1.3.1.md
+++ b/docs/releases/v1.3.1.md
@@ -1,0 +1,52 @@
+# Hacker Bob v1.3.1 Release Notes
+
+## Highlights
+
+`v1.3.1` moves normal HUNT/EXPLORE wave starts into the MCP runtime. The orchestrator now calls `bounty_start_next_wave` for standard wave assignment, using the returned plan and assignments instead of recomputing policy from `attack_surface.json`.
+
+## Wave Runtime
+
+- Added `bounty_start_next_wave({ target_domain, dry_run? })`.
+- Added a pure planner for wave 1 and wave 2+ candidate ordering, open requeue coverage, lead-surface follow-up, max caps, dedupe, and stable `a1..aN` labels.
+- Preserved `bounty_start_wave` for explicit/manual focused hunts.
+- Kept dry runs side-effect free: no file writes, no handoff tokens, and no hunter-spawn action.
+- Re-read ranked surfaces after promotion before starting a real wave.
+
+## Deep Lead Ownership
+
+- Made `bounty_start_next_wave` the single normal-path owner for automatic deep lead promotion.
+- Left `bounty_promote_surface_leads` public for explicit operator use.
+- Removed merge-side and prompt-side automatic promotion from the normal path.
+- Updated deep HUNT -> CHAIN gating so promotable unpromoted lead debt points the orchestrator back to `bounty_start_next_wave`.
+
+## Prompt And Manifest Updates
+
+- Updated normal HUNT/EXPLORE guidance to consume the runtime-start result.
+- Removed instructions for the orchestrator to compute standard assignments manually.
+- Updated generated Claude and Codex artifacts, tool metadata, and prompt contract tests.
+- Hardened the new tool schema to reject empty `target_domain` values and unknown top-level fields.
+
+## README Refresh
+
+- Reworked the README around user-facing setup, safety, installation, commands, workflow, requirements, troubleshooting, updates, and data handling.
+- Removed the old "For AI Coding Agents" section and the instruction-style prose that told users' coding assistants how to interpret the repository URL.
+- Tightened the tone across the README to be more professional and easier to scan before first use.
+
+## Install
+
+```bash
+npx -y hacker-bob@1.3.1 install /path/to/your/project
+# or, via the adapter wrappers
+npx -y hacker-bob-cc@1.3.1 install /path/to/your/project
+npx -y hacker-bob-codex@1.3.1 install /path/to/your/project
+```
+
+After installing, fully restart your host CLI (Claude Code or Codex) in that project.
+
+## Verification
+
+- `npm run check:syntax` passes.
+- `npm run test:mcp` passes.
+- `npm run test:prompts` passes.
+- `npm test` passes.
+- `npm run release:check` passes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hacker-bob",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hacker-bob",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Portable autonomous bug bounty hunting MCP framework with host adapters",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-cc/package.json
+++ b/packages/hacker-bob-cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-cc",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Hacker Bob — Claude Code adapter wrapper. Pins --adapter claude and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "1.3.0"
+    "hacker-bob": "1.3.1"
   }
 }

--- a/packages/hacker-bob-codex/package.json
+++ b/packages/hacker-bob-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-codex",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Hacker Bob — Codex adapter wrapper. Pins --adapter codex and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "1.3.0"
+    "hacker-bob": "1.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- bump canonical, wrapper, lockfile, and Codex plugin versions to 1.3.1
- add v1.3.1 changelog and release notes for runtime-owned wave starts
- rewrite README into a cleaner user-facing guide and remove coding-assistant-directed install prose

## Verification
- npm run test:prompts
- git diff --check
- npm run release:check
- npm test
- npm run release:check:registry (passes with npm access warning: token cannot list package access, but 1.3.1 is unpublished and npm whoami succeeds)