### PR TITLE
ci: Brutalist Review on trusted PRs (claude + codex)

### DIFF
--- a/.github/brutalist-tools/package-lock.json
+++ b/.github/brutalist-tools/package-lock.json
@@ -1,0 +1,1825 @@
+{
+  "name": "hacker-bob-brutalist-tools",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hacker-bob-brutalist-tools",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.162",
+        "@brutalist/mcp": "1.14.7",
+        "@openai/codex": "0.136.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.162.tgz",
+      "integrity": "sha512-NjkOtm3GVmkR8cIxRR7m/Aq96sSrqnlr+ysDwn+N/rXbizPO317i2DV9hr2HFfXMHfEVuPJR1RmPevNRxr9Mbw==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.162",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.162",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.162",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.162",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.162",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.162",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.162",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.162"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.162.tgz",
+      "integrity": "sha512-+TIQroIsxSA3+dgYmnXOPbYzuxENYgpb8/n9UCr0Q/JbMV+STDR+Dp/sLPiqazsb3IoplXWYePkNgm7h4PzYog==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.162.tgz",
+      "integrity": "sha512-eMWaeQDDMYsUfMIlLQgprepgjU0ziqMyH2cgmKtk5EQxm2lNVDYEurSLCDy57RdyCDUQmrUONC358ezZ8M+tuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.162.tgz",
+      "integrity": "sha512-IQ+0ik+vMPMdI+Q/ugxLp989I8ADXrnBHBv28dwgr1UnjUX5777Wmt55JtKDkZ0Ed0fAWEK7eh2nd1iWP9R9tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.162.tgz",
+      "integrity": "sha512-Ii301T8IFroQV0/7DsvLsJW/pBulWUOAFMPgMq6+c7FrE41Kpm2divE1Qzi8/uzTaiwYYQKYzVIBAqXlFMaLFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.162.tgz",
+      "integrity": "sha512-PzIqBYYsRlzJvkL76TjXaDA7PlZf5UxCuBik6dOuX1D1ASUKIzuBevwZi632I21zweucM4hkllHmvbWI7HhWng==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.162.tgz",
+      "integrity": "sha512-IXfZmA0aZf/qt6dmfaEVzA3iFu29iLXNJuHJKGtuZHlr+exfbGm9LfjKTEvmlNyvKkxn4LcTM95+/so5o98I0g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.162.tgz",
+      "integrity": "sha512-vNh/cs5YEv60eX81x+fMoPdf30LWFu1fvQJHq9FqYqL6ypvxGLgF5mEukzau/93naWdimuTSVr4h1kCs9PHVUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.162",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.162.tgz",
+      "integrity": "sha512-pdo+M9VGEWLuDfZy/Trioev0/j24F7vH1SGzcmokdobck4jPRdx+3iIdRoUvJUPHjDbun62UtI9/NtggU6wq6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@brutalist/mcp": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/@brutalist/mcp/-/mcp-1.14.7.tgz",
+      "integrity": "sha512-3lyyscSbr90Wruj417sLBp+6Txh/kAYza6yC5NZNJXoqSaUP3UcYz6gbZ+wij/h4y/ikF2B9Yyt8X3iw6gI8KQ==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.18.1",
+        "express": "^4.18.2",
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "brutalist-mcp": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0.tgz",
+      "integrity": "sha512-yu+diXznSOt8h296/CDOf2CNi55z1raA7aZ6sejjGy1QWPqn72YkBc2ByTzZG6G+1yiUqlm2G5Hid54hm3/kaA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.136.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.136.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.136.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.136.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.136.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.136.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-arm64.tgz",
+      "integrity": "sha512-9xnEohnUO9l6qtPSDbG0Y2UXX5mBZ9Lsn0VMgjtkREGfWL9TawNC1d7D1ERMSJtHTlVvieoaFyK9LHPLQCO9Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-x64.tgz",
+      "integrity": "sha512-HD9YLalPg0cv+CiZSmRWOl/8sefuJlxJcAmxyzb8mSaAMchD3V+2yS6M6E1Z2I6NX1irp4Polt1fPsjGdlHYhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-arm64.tgz",
+      "integrity": "sha512-xDxTOk5ClEX/nzlQseqEoiubjIzVZfcWKn9nmKkHOLKknz+c7n6tbmw7eY4mwt29zTAAoFoecdRnbbsPZUHJ1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-x64.tgz",
+      "integrity": "sha512-Q6yZHRtUWD+27B5yAiOYyPAtM0BzW0Mm23YGaXDmfNEO5BYgHuUT80VDofUpjSyo2+ShYoZQUFVQAsNPKqd+Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-arm64.tgz",
+      "integrity": "sha512-mAHZXfygQxBg1JjZ9+bAZfBXe6fg8MabJhuDYhj5z0VF++orKSFsC1lMiv6PksQN36ikQefgVjc9EOlaE4lt7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.136.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-x64.tgz",
+      "integrity": "sha512-zS6DAmvjdWeAB1CL9KTUMkwzTwfXtxHy8GAtePw2a93jIqawoG07fBxAXuyoHZ3QXQkwEgqBx1zEEh33gdIKAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/.github/brutalist-tools/package.json
+++ b/.github/brutalist-tools/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hacker-bob-brutalist-tools",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.162",
+    "@brutalist/mcp": "1.14.7",
+    "@openai/codex": "0.136.0"
+  },
+  "overrides": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,7 +1,7 @@
 name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
-# Powered by ejmockler/brutalist-mcp (pinned to v1.14.2).
+# Powered by ejmockler/brutalist-mcp (pinned to v1.14.3).
 #
 # Critics: claude + codex + agy (Antigravity). Hard requirement is the
 # ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
@@ -34,7 +34,7 @@ jobs:
         # claude + brutalist-mcp are hard preflight requirements; codex and
         # agy are soft critics (warn if their auth secret is missing).
         run: |
-          npm install -g @brutalist/mcp@1.14.2 \
+          npm install -g @brutalist/mcp@1.14.3 \
                          @anthropic-ai/claude-code \
                          @openai/codex
           # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
@@ -42,7 +42,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.2
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.3
         env:
           # Backstop only. v1.14.2's agy adapter scopes/anchors agy on diff
           # reviews so it converges in ~15-50s instead of running out the

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,7 +1,7 @@
 name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
-# Powered by ejmockler/brutalist-mcp (pinned to v1.14.3).
+# Powered by ejmockler/brutalist-mcp (pinned to v1.14.4).
 #
 # Critics: claude + codex + agy (Antigravity). Hard requirement is the
 # ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
@@ -34,7 +34,7 @@ jobs:
         # claude + brutalist-mcp are hard preflight requirements; codex and
         # agy are soft critics (warn if their auth secret is missing).
         run: |
-          npm install -g @brutalist/mcp@1.14.3 \
+          npm install -g @brutalist/mcp@1.14.4 \
                          @anthropic-ai/claude-code \
                          @openai/codex
           # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
@@ -42,15 +42,15 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.3
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.4
         env:
-          # Backstop only. v1.14.2's agy adapter scopes/anchors agy on diff
-          # reviews so it converges in ~15-50s instead of running out the
-          # 30-min orchestrator budget. This per-critic spawn cap (default
-          # 1800000ms = 30min = the orchestrator budget) stays as defense in
-          # depth: if any critic stalls, it's killed and the review still
-          # posts from the others (executeMultiCLI uses allSettled).
+          # Per-critic spawn cap (brutalist-mcp). Real since v1.14.3.
           BRUTALIST_TIMEOUT: "180000"
+          # DIAGNOSTIC (v1.14.4): trace each orchestrator-brain SDK message
+          # to stderr (which roast call, timings, where it hangs) and cap the
+          # orchestrator wall-clock low so a stall fails in 12 min, not 30.
+          BRUTALIST_ORCHESTRATOR_TRACE: "1"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "720000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,7 +1,7 @@
 name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
-# Powered by ejmockler/brutalist-mcp (pinned to v1.14.4).
+# Powered by ejmockler/brutalist-mcp (pinned to v1.14.5).
 #
 # Critics: claude + codex + agy (Antigravity). Hard requirement is the
 # ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
@@ -34,7 +34,7 @@ jobs:
         # claude + brutalist-mcp are hard preflight requirements; codex and
         # agy are soft critics (warn if their auth secret is missing).
         run: |
-          npm install -g @brutalist/mcp@1.14.4 \
+          npm install -g @brutalist/mcp@1.14.5 \
                          @anthropic-ai/claude-code \
                          @openai/codex
           # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
@@ -42,7 +42,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.4
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
         env:
           # Per-critic spawn cap (brutalist-mcp). Real since v1.14.3.
           # Tightened to 90s: the trace showed 3 parallel roasts (9 critic

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -45,7 +45,11 @@ jobs:
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.4
         env:
           # Per-critic spawn cap (brutalist-mcp). Real since v1.14.3.
-          BRUTALIST_TIMEOUT: "180000"
+          # Tightened to 90s: the trace showed 3 parallel roasts (9 critic
+          # spawns) never returning in 12 min. If the cap works, 90s bounds
+          # each agy spawn so the roasts finish fast; if it still stalls, the
+          # cap isn't firing (deeper bug).
+          BRUTALIST_TIMEOUT: "90000"
           # DIAGNOSTIC (v1.14.4): trace each orchestrator-brain SDK message
           # to stderr (which roast call, timings, where it hangs) and cap the
           # orchestrator wall-clock low so a stall fails in 12 min, not 30.

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,0 +1,51 @@
+name: Brutalist Review
+
+# Multi-CLI adversarial code review on every PR, posted as inline comments.
+# Powered by ejmockler/brutalist-mcp (pinned to v1.14.1).
+#
+# Critics: claude + codex + agy (Antigravity). Hard requirement is the
+# ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
+# AGY_OAUTH_TOKEN (agy) are optional — a critic whose auth secret is
+# absent is skipped with a warning rather than failing the run.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read          # actions/checkout
+  pull-requests: write    # post the review
+
+jobs:
+  brutalist:
+    runs-on: ubuntu-latest
+    # Skip drafts and PRs from forks: forks can't read the OAuth secrets,
+    # so the preflight would fail noisily.
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install CLI critics
+        # claude + brutalist-mcp are hard preflight requirements; codex and
+        # agy are soft critics (warn if their auth secret is missing).
+        run: |
+          npm install -g @brutalist/mcp@1.14.1 \
+                         @anthropic-ai/claude-code \
+                         @openai/codex
+          # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
+          curl -fsSL https://antigravity.google/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Brutalist review
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.1
+        with:
+          github-token: ${{ github.token }}
+          anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          codex-auth: ${{ secrets.CODEX_AUTH }}
+          agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
+          minimum-severity: medium

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,7 +1,7 @@
 name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
-# Powered by ejmockler/brutalist-mcp (pinned to v1.14.1).
+# Powered by ejmockler/brutalist-mcp (pinned to v1.14.2).
 #
 # Critics: claude + codex + agy (Antigravity). Hard requirement is the
 # ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
@@ -34,7 +34,7 @@ jobs:
         # claude + brutalist-mcp are hard preflight requirements; codex and
         # agy are soft critics (warn if their auth secret is missing).
         run: |
-          npm install -g @brutalist/mcp@1.14.1 \
+          npm install -g @brutalist/mcp@1.14.2 \
                          @anthropic-ai/claude-code \
                          @openai/codex
           # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
@@ -42,16 +42,14 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.1
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.2
         env:
-          # Per-critic spawn cap (ms). brutalist-mcp's DEFAULT_TIMEOUT is
-          # 30 min, which equals the orchestrator's wall-clock budget — so
-          # a slow critic can sink the whole run. agy in particular runs an
-          # agentic loop that wanders the filesystem looking for code to
-          # review and often won't converge on a real repo. Capping each
-          # spawn at 3 min lets claude + codex always finish (they take
-          # seconds) and the review post; agy contributes only when it
-          # converges quickly, and is killed otherwise instead of stalling.
+          # Backstop only. v1.14.2's agy adapter scopes/anchors agy on diff
+          # reviews so it converges in ~15-50s instead of running out the
+          # 30-min orchestrator budget. This per-critic spawn cap (default
+          # 1800000ms = 30min = the orchestrator budget) stays as defense in
+          # depth: if any critic stalls, it's killed and the review still
+          # posts from the others (executeMultiCLI uses allSettled).
           BRUTALIST_TIMEOUT: "180000"
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -43,6 +43,16 @@ jobs:
 
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.1
+        env:
+          # Per-critic spawn cap (ms). brutalist-mcp's DEFAULT_TIMEOUT is
+          # 30 min, which equals the orchestrator's wall-clock budget — so
+          # a slow critic can sink the whole run. agy in particular runs an
+          # agentic loop that wanders the filesystem looking for code to
+          # review and often won't converge on a real repo. Capping each
+          # spawn at 3 min lets claude + codex always finish (they take
+          # seconds) and the review post; agy contributes only when it
+          # converges quickly, and is killed otherwise instead of stalling.
+          BRUTALIST_TIMEOUT: "180000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -34,9 +34,21 @@ jobs:
           node-version: '20'
       - name: Install CLI critics
         working-directory: .github/brutalist-tools
+        env:
+          EXPECTED_TOOLS_LOCK_SHA256: 26185c16a5bc18ec25badf9c74da4b0d0be0fe0ba64d8e24502f73bcb5412ddf
         run: |
-          npm ci
+          actual="$(sha256sum package-lock.json | cut -d ' ' -f1)"
+          if [ "$actual" != "$EXPECTED_TOOLS_LOCK_SHA256" ]; then
+            echo "Unexpected brutalist tools lockfile hash: $actual" >&2
+            exit 1
+          fi
+          npm ci --ignore-scripts
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          export PATH="$PWD/node_modules/.bin:$PATH"
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          command -v brutalist-mcp claude codex
+          claude --version
+          codex --version
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
@@ -57,4 +69,10 @@ jobs:
           minimum-severity: medium
       - name: Report advisory reviewer failure
         if: steps.brutalist-review.outcome == 'failure'
-        run: echo "::warning title=Brutalist Review::Advisory review failed; CI remains the hard merge gate."
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          echo "::warning title=Brutalist Review::Advisory review failed; CI remains the hard merge gate."
+          body="$(printf 'Brutalist Review failed for %s.\n\nCI remains the hard merge gate.\n\nRun: %s/%s/actions/runs/%s' "$GITHUB_SHA" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+          gh pr comment "$PR_URL" --body "$body"

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -25,7 +25,7 @@ jobs:
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
+        uses: ejmockler/brutalist-mcp/packages/github-action@90d77d503224896a5563c37accfd9b0cfd7831d0
         env:
           BRUTALIST_TIMEOUT: "90000"
           BRUTALIST_LOG_LEVEL: "debug"
@@ -37,3 +37,11 @@ jobs:
           codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
+      - name: Dump brutalist-mcp stderr
+        if: always()
+        run: |
+          echo "===== brutalist-mcp stderr (roast internals at the hang) ====="
+          if [ -f /tmp/bmcp-stderr.log ]; then
+            grep -iE "Executing|Released CLI|Waiting for|timed out|execution (failed|completed)|cli=|roast|Working directory|chunk|panel|slot" /tmp/bmcp-stderr.log | tail -120
+            echo "----- total lines: $(wc -l < /tmp/bmcp-stderr.log) -----"
+          else echo "(no log)"; fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -2,24 +2,17 @@ name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
 # Powered by ejmockler/brutalist-mcp (pinned to v1.14.5).
-#
-# Critics: claude + codex + agy (Antigravity). Hard requirement is the
-# ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
-# AGY_OAUTH_TOKEN (agy) are optional — a critic whose auth secret is
-# absent is skipped with a warning rather than failing the run.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read          # actions/checkout
-  pull-requests: write    # post the review
+  contents: read
+  pull-requests: write
 
 jobs:
   brutalist:
     runs-on: ubuntu-latest
-    # Skip drafts and PRs from forks: forks can't read the OAuth secrets,
-    # so the preflight would fail noisily.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
@@ -31,33 +24,44 @@ jobs:
           node-version: '20'
 
       - name: Install CLI critics
-        # claude + brutalist-mcp are hard preflight requirements; codex and
-        # agy are soft critics (warn if their auth secret is missing).
         run: |
           npm install -g @brutalist/mcp@1.14.5 \
                          @anthropic-ai/claude-code \
                          @openai/codex
-          # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # DIAGNOSTIC (workflow-only, no package release): shadow brutalist-mcp
+          # with a wrapper that captures its stderr (swallowed by the MCP stdio
+          # transport in CI) to a file, so we can finally see per-critic timing,
+          # slot use, and timeouts inside the roast.
+          REAL_BMCP="$(command -v brutalist-mcp)"
+          echo "real brutalist-mcp: $REAL_BMCP"
+          mkdir -p /tmp/bin
+          printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
+          chmod +x /tmp/bin/brutalist-mcp
+          echo "/tmp/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
         env:
-          # Per-critic spawn cap (brutalist-mcp). Real since v1.14.3.
-          # Tightened to 90s: the trace showed 3 parallel roasts (9 critic
-          # spawns) never returning in 12 min. If the cap works, 90s bounds
-          # each agy spawn so the roasts finish fast; if it still stalls, the
-          # cap isn't firing (deeper bug).
           BRUTALIST_TIMEOUT: "90000"
-          # DIAGNOSTIC (v1.14.4): trace each orchestrator-brain SDK message
-          # to stderr (which roast call, timings, where it hangs) and cap the
-          # orchestrator wall-clock low so a stall fails in 12 min, not 30.
+          BRUTALIST_LOG_LEVEL: "debug"            # verbose per-critic logs (timing/slots/timeouts)
           BRUTALIST_ORCHESTRATOR_TRACE: "1"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "720000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "600000"   # 10 min — fail faster
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
+
+      - name: Dump brutalist-mcp stderr (diagnostic)
+        if: always()
+        run: |
+          echo "===== brutalist-mcp captured stderr (per-critic timing / slots / timeouts) ====="
+          if [ -f /tmp/bmcp-stderr.log ]; then
+            grep -iE "Executing|Released CLI|Waiting for|timed out|Default timeout|slot|Working directory|chunk received|execution failed|completed|roast|panel|stdout|stderr bytes" /tmp/bmcp-stderr.log | tail -200
+            echo "----- (full log line count: $(wc -l < /tmp/bmcp-stderr.log)) -----"
+          else
+            echo "(no /tmp/bmcp-stderr.log — wrapper not invoked)"
+          fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install CLI critics
         run: |
           npm install -g @anthropic-ai/claude-code @openai/codex
-          npm install -g "github:ejmockler/brutalist-mcp#f401e085a60952fe70d70981d257ad72d6670e0d"
+          npm install -g "https://raw.githubusercontent.com/ejmockler/brutalist-mcp/422faf3013dfbe5c907be7d940a82bf53c524235/brutalist-mcp-1.14.5.tgz"
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           REAL_BMCP="$(command -v brutalist-mcp)"
@@ -27,7 +27,7 @@ jobs:
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@f401e085a60952fe70d70981d257ad72d6670e0d
+        uses: ejmockler/brutalist-mcp/packages/github-action@422faf3013dfbe5c907be7d940a82bf53c524235
         env:
           BRUTALIST_TIMEOUT: "90000"
           BRUTALIST_LOG_LEVEL: "debug"

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,76 +1,42 @@
 name: Brutalist Review
+
+# Multi-CLI adversarial code review on every PR (claude + agy), posted as
+# inline comments. Codex is intentionally NOT used in CI on public repos:
+# OpenAI's CI auth guide forbids ChatGPT-plan auth.json on public/open-source
+# repos, and codex-action is API-key-only (billing). Codex stays a local
+# critic; see docs/brutalist-review-setup.md to enable it on a private runner.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
 permissions:
   contents: read
   pull-requests: write
-# Serialize runs: codex/OpenAI uses refresh-token reuse-detection (RTR). Two
-# concurrent runs refreshing the same token would revoke the whole token
-# family. cancel-in-progress:false so an in-flight run finishes (and writes
-# back its rotated token) before the next starts.
-concurrency:
-  group: brutalist-review-codex-auth
-  cancel-in-progress: false
+
 jobs:
   brutalist:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 35
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v6
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@v6
-        with: { node-version: '20' }
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Install CLI critics
         run: |
-          npm install -g @anthropic-ai/claude-code @openai/codex
-          npm install -g "https://raw.githubusercontent.com/ejmockler/brutalist-mcp/422faf3013dfbe5c907be7d940a82bf53c524235/brutalist-mcp-1.14.5.tgz"   # patched brutalist-mcp (config.defaultTimeout honors BRUTALIST_TIMEOUT)
+          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          REAL_BMCP="$(command -v brutalist-mcp)"
-          mkdir -p /tmp/bin
-          printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
-          chmod +x /tmp/bin/brutalist-mcp
-          echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@422faf3013dfbe5c907be7d940a82bf53c524235
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.7
         env:
-          BRUTALIST_TIMEOUT: "600000"                 # 10 min per critic
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "1200000" # 20 min brain budget
-          BRUTALIST_LOG_LEVEL: "debug"
-          BRUTALIST_ORCHESTRATOR_TRACE: "1"
+          BRUTALIST_TIMEOUT: "900000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "1500000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
-          codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
-      - name: Persist refreshed codex OAuth token (self-healing)
-        # codex rotates its OAuth token in place when the access_token expires
-        # (~every 10 days). Write the refreshed ~/.codex/auth.json back to the
-        # CODEX_AUTH secret so the next run starts fresh — indefinite OAuth, no
-        # API key, no manual re-capture. Safely no-ops until CODEX_AUTH_WRITER_PAT
-        # (a fine-grained PAT with Secrets:write on this repo) is provisioned.
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.CODEX_AUTH_WRITER_PAT }}
-        run: |
-          if [ -z "$GH_TOKEN" ]; then echo "No CODEX_AUTH_WRITER_PAT — skipping token write-back."; exit 0; fi
-          AUTH="$HOME/.codex/auth.json"
-          if [ ! -f "$AUTH" ]; then echo "No $AUTH — skipping."; exit 0; fi
-          if ! node -e "const t=require('$AUTH')?.tokens?.refresh_token; if(!t)process.exit(1)" 2>/dev/null; then
-            echo "auth.json has no refresh_token (codex may have failed) — skipping write-back."; exit 0
-          fi
-          if gh secret set CODEX_AUTH --repo "${{ github.repository }}" < "$AUTH"; then
-            echo "Persisted refreshed CODEX_AUTH for the next run."
-          else
-            echo "::warning::Failed to persist refreshed CODEX_AUTH (check CODEX_AUTH_WRITER_PAT scope)."
-          fi
-      - name: Dump brutalist-mcp stderr (diagnostic)
-        if: always()
-        run: |
-          if [ -f /tmp/bmcp-stderr.log ]; then
-            echo "===== brutalist-mcp stderr ====="
-            grep -iE "analysis with timeout|Executing|Released CLI|timed out|execution (failed|completed)" /tmp/bmcp-stderr.log | tail -50
-          else echo "(no log)"; fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,17 +1,21 @@
 name: Brutalist Review
 
-# claude + codex + agy review on every PR, posted as inline comments.
+# claude + codex review on every PR, posted as inline comments.
 # Codex auth: the noot-1 broker pushes a fresh ChatGPT-plan access_token
 # (refresh blanked) to the CODEX_AUTH secret out-of-band (no tailnet, no
 # inbound). CI just reads it; codex never refreshes. The image_generation
 # tool is disabled (codex#21952 gpt-image-2 bug).
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  group: brutalist-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   brutalist:
@@ -22,6 +26,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
@@ -30,15 +35,12 @@ jobs:
           # Pin every critic CLI — an unpinned @latest runs before secrets exist,
           # but a planted binary persists and later receives the OAuth tokens.
           npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code@2.1.162 @openai/codex@0.136.0
-          # NOTE: agy installer is unpinned upstream (no published checksum) — residual supply-chain surface.
-          curl -fsSL https://antigravity.google/cli/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
         # Pinned to the immutable v1.14.7 commit SHA, not the mutable tag — this
-        # action receives all four credentials below, so it must not move.
+        # action receives credentials below, so it must not move.
         uses: ejmockler/brutalist-mcp/packages/github-action@15cedc8159a54662fa741395746d4aa0e161a3b4 # v1.14.7
         env:
           BRUTALIST_TIMEOUT: "900000"
@@ -47,5 +49,4 @@ jobs:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
-          agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   brutalist:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
@@ -29,10 +30,10 @@ jobs:
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@422faf3013dfbe5c907be7d940a82bf53c524235
         env:
-          BRUTALIST_TIMEOUT: "240000"
+          BRUTALIST_TIMEOUT: "3600000"
           BRUTALIST_LOG_LEVEL: "debug"
           BRUTALIST_ORCHESTRATOR_TRACE: "1"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "4200000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -17,18 +17,17 @@ jobs:
       - name: Install CLI critics
         run: |
           npm install -g @anthropic-ai/claude-code @openai/codex
-          # patched brutalist-mcp from branch, committed dist, no build:
-          npm install -g --ignore-scripts "github:ejmockler/brutalist-mcp#746897dfb7da0b635027dc6574eb0e1d34850748"
+          npm install -g "github:ejmockler/brutalist-mcp#f401e085a60952fe70d70981d257ad72d6670e0d"
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           REAL_BMCP="$(command -v brutalist-mcp)"
-          echo "brutalist-mcp resolved: $REAL_BMCP -> $(node -e "console.log(require('@brutalist/mcp/package.json').version)" 2>/dev/null || echo '?')"
+          echo "brutalist-mcp resolved: $REAL_BMCP"
           mkdir -p /tmp/bin
           printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@746897dfb7da0b635027dc6574eb0e1d34850748
+        uses: ejmockler/brutalist-mcp/packages/github-action@f401e085a60952fe70d70981d257ad72d6670e0d
         env:
           BRUTALIST_TIMEOUT: "90000"
           BRUTALIST_LOG_LEVEL: "debug"
@@ -43,7 +42,7 @@ jobs:
       - name: Dump brutalist-mcp stderr
         if: always()
         run: |
-          echo "===== brutalist-mcp stderr ====="
           if [ -f /tmp/bmcp-stderr.log ]; then
+            echo "===== brutalist-mcp stderr ====="
             grep -iE "analysis with timeout|Executing|Released CLI|timed out|execution (failed|completed)" /tmp/bmcp-stderr.log | tail -50
           else echo "(no log)"; fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -2,23 +2,17 @@ name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
 # Powered by ejmockler/brutalist-mcp (pinned to v1.14.5).
-#
-# Critics: claude + codex + agy (Antigravity). Hard requirement is the
-# ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
-# AGY_OAUTH_TOKEN (agy) are optional — a critic whose auth secret is
-# absent is skipped with a warning rather than failing the run.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read          # actions/checkout
-  pull-requests: write    # post the review
+  contents: read
+  pull-requests: write
 
 jobs:
   brutalist:
     runs-on: ubuntu-latest
-    # Skip drafts and PRs from forks: forks can't read the OAuth secrets.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
@@ -30,24 +24,25 @@ jobs:
           node-version: '20'
 
       - name: Install CLI critics
-        # claude + brutalist-mcp are hard preflight requirements; codex and
-        # agy are soft critics (warn if their auth secret is missing).
         run: |
           npm install -g @brutalist/mcp@1.14.5 \
                          @anthropic-ai/claude-code \
                          @openai/codex
-          # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # CONFIRMATION: redirect brutalist-mcp stderr to a file (NOT debug —
+          # just the redirect). If stderr pipe-backpressure was the deadlock,
+          # this goes green; if it's intermittent, it won't.
+          REAL_BMCP="$(command -v brutalist-mcp)"
+          mkdir -p /tmp/bin
+          printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
+          chmod +x /tmp/bin/brutalist-mcp
+          echo "/tmp/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
         env:
-          # Per-critic spawn cap: kill a stalled critic so the review still
-          # posts from the others (executeMultiCLI uses allSettled).
           BRUTALIST_TIMEOUT: "90000"
-          # Orchestrator wall-clock backstop. One scoped roast completes in
-          # ~3-4 min; 15 min is generous headroom that still fails fast.
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,10 +1,9 @@
 name: Brutalist Review
 
-# claude + codex review on every PR, posted as inline comments.
-# Codex auth: the noot-1 broker pushes a fresh ChatGPT-plan access_token
-# (refresh blanked) to the CODEX_AUTH secret out-of-band (no tailnet, no
-# inbound). CI just reads it; codex never refreshes. The image_generation
-# tool is disabled (codex#21952 gpt-image-2 bug).
+# Claude + Codex review on trusted maintainer PRs, posted as inline comments.
+# CODEX_AUTH is the full ~/.codex/auth.json stored as a GitHub Actions secret.
+# Refresh it with `codex login` + `gh secret set CODEX_AUTH` if auth fails.
+# The image_generation tool is disabled (codex#21952 gpt-image-2 bug).
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -19,36 +18,43 @@ concurrency:
 
 jobs:
   brutalist:
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["vmihalis","ejmockler"]'), github.event.pull_request.user.login)
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install CLI critics
+        working-directory: .github/brutalist-tools
         run: |
-          # Pin every critic CLI — an unpinned @latest runs before secrets exist,
-          # but a planted binary persists and later receives the OAuth tokens.
-          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code@2.1.162 @openai/codex@0.136.0
+          npm ci
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
+        id: brutalist-review
         # Advisory reviewer only; CI remains the hard merge gate.
         continue-on-error: true
         # Pinned to the immutable v1.14.7 commit SHA, not the mutable tag — this
         # action receives credentials below, so it must not move.
         uses: ejmockler/brutalist-mcp/packages/github-action@15cedc8159a54662fa741395746d4aa0e161a3b4 # v1.14.7
         env:
-          BRUTALIST_TIMEOUT: "900000"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "1500000"
+          BRUTALIST_TIMEOUT: "600000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
           minimum-severity: medium
+      - name: Report advisory reviewer failure
+        if: steps.brutalist-review.outcome == 'failure'
+        run: echo "::warning title=Brutalist Review::Advisory review failed; CI remains the hard merge gate."

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,49 +1,36 @@
 name: Brutalist Review
-
-# Multi-CLI adversarial code review on every PR, posted as inline comments.
-# Powered by ejmockler/brutalist-mcp (pinned to v1.14.5).
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-
 permissions:
   contents: read
   pull-requests: write
-
 jobs:
   brutalist:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
+        with: { fetch-depth: 0 }
       - uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
+        with: { node-version: '20' }
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.14.5 \
-                         @anthropic-ai/claude-code \
-                         @openai/codex
+          npm install -g @brutalist/mcp@1.14.5 @anthropic-ai/claude-code @openai/codex
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          # CONFIRMATION: redirect brutalist-mcp stderr to a file (NOT debug —
-          # just the redirect). If stderr pipe-backpressure was the deadlock,
-          # this goes green; if it's intermittent, it won't.
           REAL_BMCP="$(command -v brutalist-mcp)"
           mkdir -p /tmp/bin
           printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
-
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
         env:
           BRUTALIST_TIMEOUT: "90000"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
+          BRUTALIST_LOG_LEVEL: "debug"
+          BRUTALIST_ORCHESTRATOR_TRACE: "1"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "600000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -39,6 +39,8 @@ jobs:
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
+        # Advisory reviewer only; CI remains the hard merge gate.
+        continue-on-error: true
         # Pinned to the immutable v1.14.7 commit SHA, not the mutable tag — this
         # action receives credentials below, so it must not move.
         uses: ejmockler/brutalist-mcp/packages/github-action@15cedc8159a54662fa741395746d4aa0e161a3b4 # v1.14.7

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -16,16 +16,18 @@ jobs:
         with: { node-version: '20' }
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.14.5 @anthropic-ai/claude-code @openai/codex
+          # install the PATCHED brutalist-mcp straight from the branch (prepare builds it) — no release
+          npm install -g "github:ejmockler/brutalist-mcp#43626e65dd6900be1a694f3292caad6cf8f50888" @anthropic-ai/claude-code @openai/codex
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           REAL_BMCP="$(command -v brutalist-mcp)"
+          echo "brutalist-mcp resolved: $REAL_BMCP"
           mkdir -p /tmp/bin
           printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@90d77d503224896a5563c37accfd9b0cfd7831d0
+        uses: ejmockler/brutalist-mcp/packages/github-action@43626e65dd6900be1a694f3292caad6cf8f50888
         env:
           BRUTALIST_TIMEOUT: "90000"
           BRUTALIST_LOG_LEVEL: "debug"
@@ -40,8 +42,7 @@ jobs:
       - name: Dump brutalist-mcp stderr
         if: always()
         run: |
-          echo "===== brutalist-mcp stderr (roast internals at the hang) ====="
+          echo "===== brutalist-mcp stderr ====="
           if [ -f /tmp/bmcp-stderr.log ]; then
-            grep -iE "Executing|Released CLI|Waiting for|timed out|execution (failed|completed)|cli=|roast|Working directory|chunk|panel|slot" /tmp/bmcp-stderr.log | tail -120
-            echo "----- total lines: $(wc -l < /tmp/bmcp-stderr.log) -----"
+            grep -iE "analysis with timeout|Executing|Released CLI|timed out|execution (failed|completed)|Working directory" /tmp/bmcp-stderr.log | tail -60
           else echo "(no log)"; fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -2,17 +2,23 @@ name: Brutalist Review
 
 # Multi-CLI adversarial code review on every PR, posted as inline comments.
 # Powered by ejmockler/brutalist-mcp (pinned to v1.14.5).
+#
+# Critics: claude + codex + agy (Antigravity). Hard requirement is the
+# ANTHROPIC_OAUTH_TOKEN secret (claude). CODEX_AUTH (codex) and
+# AGY_OAUTH_TOKEN (agy) are optional — a critic whose auth secret is
+# absent is skipped with a warning rather than failing the run.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: read          # actions/checkout
+  pull-requests: write    # post the review
 
 jobs:
   brutalist:
     runs-on: ubuntu-latest
+    # Skip drafts and PRs from forks: forks can't read the OAuth secrets.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
@@ -24,44 +30,28 @@ jobs:
           node-version: '20'
 
       - name: Install CLI critics
+        # claude + brutalist-mcp are hard preflight requirements; codex and
+        # agy are soft critics (warn if their auth secret is missing).
         run: |
           npm install -g @brutalist/mcp@1.14.5 \
                          @anthropic-ai/claude-code \
                          @openai/codex
+          # agy (Antigravity) installs to ~/.local/bin/agy; put it on PATH.
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          # DIAGNOSTIC (workflow-only, no package release): shadow brutalist-mcp
-          # with a wrapper that captures its stderr (swallowed by the MCP stdio
-          # transport in CI) to a file, so we can finally see per-critic timing,
-          # slot use, and timeouts inside the roast.
-          REAL_BMCP="$(command -v brutalist-mcp)"
-          echo "real brutalist-mcp: $REAL_BMCP"
-          mkdir -p /tmp/bin
-          printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
-          chmod +x /tmp/bin/brutalist-mcp
-          echo "/tmp/bin" >> "$GITHUB_PATH"
 
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.5
         env:
+          # Per-critic spawn cap: kill a stalled critic so the review still
+          # posts from the others (executeMultiCLI uses allSettled).
           BRUTALIST_TIMEOUT: "90000"
-          BRUTALIST_LOG_LEVEL: "debug"            # verbose per-critic logs (timing/slots/timeouts)
-          BRUTALIST_ORCHESTRATOR_TRACE: "1"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "600000"   # 10 min — fail faster
+          # Orchestrator wall-clock backstop. One scoped roast completes in
+          # ~3-4 min; 15 min is generous headroom that still fails fast.
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
-
-      - name: Dump brutalist-mcp stderr (diagnostic)
-        if: always()
-        run: |
-          echo "===== brutalist-mcp captured stderr (per-critic timing / slots / timeouts) ====="
-          if [ -f /tmp/bmcp-stderr.log ]; then
-            grep -iE "Executing|Released CLI|Waiting for|timed out|Default timeout|slot|Working directory|chunk received|execution failed|completed|roast|panel|stdout|stderr bytes" /tmp/bmcp-stderr.log | tail -200
-            echo "----- (full log line count: $(wc -l < /tmp/bmcp-stderr.log)) -----"
-          else
-            echo "(no /tmp/bmcp-stderr.log — wrapper not invoked)"
-          fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,10 +1,10 @@
 name: Brutalist Review
 
-# Multi-CLI adversarial code review on every PR (claude + agy), posted as
-# inline comments. Codex is intentionally NOT used in CI on public repos:
-# OpenAI's CI auth guide forbids ChatGPT-plan auth.json on public/open-source
-# repos, and codex-action is API-key-only (billing). Codex stays a local
-# critic; see docs/brutalist-review-setup.md to enable it on a private runner.
+# claude + codex + agy review on every PR, posted as inline comments.
+# Codex auth: the noot-1 broker pushes a fresh ChatGPT-plan access_token
+# (refresh blanked) to the CODEX_AUTH secret out-of-band (no tailnet, no
+# inbound). CI just reads it; codex never refreshes. The image_generation
+# tool is disabled (codex#21952 gpt-image-2 bug).
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -27,9 +27,12 @@ jobs:
           node-version: '20'
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code
+          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code @openai/codex
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # codex: disable the broken built-in image_generation tool (gpt-image-2)
+          mkdir -p "$HOME/.codex"
+          printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.7
         env:
@@ -38,5 +41,6 @@ jobs:
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 35
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install CLI critics

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -16,18 +16,19 @@ jobs:
         with: { node-version: '20' }
       - name: Install CLI critics
         run: |
-          # install the PATCHED brutalist-mcp straight from the branch (prepare builds it) — no release
-          npm install -g "github:ejmockler/brutalist-mcp#43626e65dd6900be1a694f3292caad6cf8f50888" @anthropic-ai/claude-code @openai/codex
+          npm install -g @anthropic-ai/claude-code @openai/codex
+          # patched brutalist-mcp from branch, committed dist, no build:
+          npm install -g --ignore-scripts "github:ejmockler/brutalist-mcp#746897dfb7da0b635027dc6574eb0e1d34850748"
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           REAL_BMCP="$(command -v brutalist-mcp)"
-          echo "brutalist-mcp resolved: $REAL_BMCP"
+          echo "brutalist-mcp resolved: $REAL_BMCP -> $(node -e "console.log(require('@brutalist/mcp/package.json').version)" 2>/dev/null || echo '?')"
           mkdir -p /tmp/bin
           printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
           chmod +x /tmp/bin/brutalist-mcp
           echo "/tmp/bin" >> "$GITHUB_PATH"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@43626e65dd6900be1a694f3292caad6cf8f50888
+        uses: ejmockler/brutalist-mcp/packages/github-action@746897dfb7da0b635027dc6574eb0e1d34850748
         env:
           BRUTALIST_TIMEOUT: "90000"
           BRUTALIST_LOG_LEVEL: "debug"
@@ -44,5 +45,5 @@ jobs:
         run: |
           echo "===== brutalist-mcp stderr ====="
           if [ -f /tmp/bmcp-stderr.log ]; then
-            grep -iE "analysis with timeout|Executing|Released CLI|timed out|execution (failed|completed)|Working directory" /tmp/bmcp-stderr.log | tail -60
+            grep -iE "analysis with timeout|Executing|Released CLI|timed out|execution (failed|completed)" /tmp/bmcp-stderr.log | tail -50
           else echo "(no log)"; fi

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -27,14 +27,19 @@ jobs:
           node-version: '20'
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code @openai/codex
+          # Pin every critic CLI — an unpinned @latest runs before secrets exist,
+          # but a planted binary persists and later receives the OAuth tokens.
+          npm install -g @brutalist/mcp@1.14.7 @anthropic-ai/claude-code@2.1.162 @openai/codex@0.136.0
+          # NOTE: agy installer is unpinned upstream (no published checksum) — residual supply-chain surface.
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@v1.14.7
+        # Pinned to the immutable v1.14.7 commit SHA, not the mutable tag — this
+        # action receives all four credentials below, so it must not move.
+        uses: ejmockler/brutalist-mcp/packages/github-action@15cedc8159a54662fa741395746d4aa0e161a3b4 # v1.14.7
         env:
           BRUTALIST_TIMEOUT: "900000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "1500000"

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -5,10 +5,17 @@ on:
 permissions:
   contents: read
   pull-requests: write
+# Serialize runs: codex/OpenAI uses refresh-token reuse-detection (RTR). Two
+# concurrent runs refreshing the same token would revoke the whole token
+# family. cancel-in-progress:false so an in-flight run finishes (and writes
+# back its rotated token) before the next starts.
+concurrency:
+  group: brutalist-review-codex-auth
+  cancel-in-progress: false
 jobs:
   brutalist:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
@@ -18,11 +25,10 @@ jobs:
       - name: Install CLI critics
         run: |
           npm install -g @anthropic-ai/claude-code @openai/codex
-          npm install -g "https://raw.githubusercontent.com/ejmockler/brutalist-mcp/422faf3013dfbe5c907be7d940a82bf53c524235/brutalist-mcp-1.14.5.tgz"
+          npm install -g "https://raw.githubusercontent.com/ejmockler/brutalist-mcp/422faf3013dfbe5c907be7d940a82bf53c524235/brutalist-mcp-1.14.5.tgz"   # patched brutalist-mcp (config.defaultTimeout honors BRUTALIST_TIMEOUT)
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           REAL_BMCP="$(command -v brutalist-mcp)"
-          echo "brutalist-mcp resolved: $REAL_BMCP"
           mkdir -p /tmp/bin
           printf '#!/usr/bin/env bash\nexec "%s" "$@" 2>>/tmp/bmcp-stderr.log\n' "$REAL_BMCP" > /tmp/bin/brutalist-mcp
           chmod +x /tmp/bin/brutalist-mcp
@@ -30,17 +36,38 @@ jobs:
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@422faf3013dfbe5c907be7d940a82bf53c524235
         env:
-          BRUTALIST_TIMEOUT: "3600000"
+          BRUTALIST_TIMEOUT: "600000"                 # 10 min per critic
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "1200000" # 20 min brain budget
           BRUTALIST_LOG_LEVEL: "debug"
           BRUTALIST_ORCHESTRATOR_TRACE: "1"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "4200000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
-      - name: Dump brutalist-mcp stderr
+      - name: Persist refreshed codex OAuth token (self-healing)
+        # codex rotates its OAuth token in place when the access_token expires
+        # (~every 10 days). Write the refreshed ~/.codex/auth.json back to the
+        # CODEX_AUTH secret so the next run starts fresh — indefinite OAuth, no
+        # API key, no manual re-capture. Safely no-ops until CODEX_AUTH_WRITER_PAT
+        # (a fine-grained PAT with Secrets:write on this repo) is provisioned.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_AUTH_WRITER_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then echo "No CODEX_AUTH_WRITER_PAT — skipping token write-back."; exit 0; fi
+          AUTH="$HOME/.codex/auth.json"
+          if [ ! -f "$AUTH" ]; then echo "No $AUTH — skipping."; exit 0; fi
+          if ! node -e "const t=require('$AUTH')?.tokens?.refresh_token; if(!t)process.exit(1)" 2>/dev/null; then
+            echo "auth.json has no refresh_token (codex may have failed) — skipping write-back."; exit 0
+          fi
+          if gh secret set CODEX_AUTH --repo "${{ github.repository }}" < "$AUTH"; then
+            echo "Persisted refreshed CODEX_AUTH for the next run."
+          else
+            echo "::warning::Failed to persist refreshed CODEX_AUTH (check CODEX_AUTH_WRITER_PAT scope)."
+          fi
+      - name: Dump brutalist-mcp stderr (diagnostic)
         if: always()
         run: |
           if [ -f /tmp/bmcp-stderr.log ]; then

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Brutalist review
         uses: ejmockler/brutalist-mcp/packages/github-action@422faf3013dfbe5c907be7d940a82bf53c524235
         env:
-          BRUTALIST_TIMEOUT: "90000"
+          BRUTALIST_TIMEOUT: "240000"
           BRUTALIST_LOG_LEVEL: "debug"
           BRUTALIST_ORCHESTRATOR_TRACE: "1"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "600000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}


### PR DESCRIPTION
## Brutalist Review on trusted PRs

Adds `.github/workflows/brutalist-review.yml` — a multi-CLI adversarial code review that runs on PR `opened`, `synchronize`, `reopened`, and `ready_for_review` events, then posts findings as inline comments.

The workflow is restricted to non-draft, same-repo PRs opened by explicitly trusted maintainers (`vmihalis`, `ejmockler`) so OAuth-backed reviewers do not process arbitrary fork or collaborator PR content.

**Critics:** Claude + Codex, via [`ejmockler/brutalist-mcp`](https://github.com/ejmockler/brutalist-mcp), pinned to the immutable v1.14.7 action commit.

**Secrets**:
- `ANTHROPIC_OAUTH_TOKEN` — Claude
- `CODEX_AUTH` — Codex `~/.codex/auth.json`

Agy/Antigravity was removed because it repeatedly timed out without contributing findings while adding an unpinned installer and another OAuth credential path.

**Guards and hardening:** per-PR concurrency cancellation, fixed Ubuntu runner image, shallow checkout without persisted credentials, SHA-pinned actions, SHA256-checked lockfile-backed critic CLI install, `npm ci --ignore-scripts` with only Claude's pinned installer run explicitly, patched MCP SDK override with a successful live workflow run, shorter credential-bearing timeout, and a PR-visible warning/comment if the advisory reviewer fails.

**Accepted risk:** the pinned Brutalist action and the trusted maintainer allowlist are part of the same trust boundary, and the action receives the Claude/Codex OAuth material needed to run the review. This PR treats that action SHA and the allowlisted maintainers as trusted. Future hardening can vendor or independently audit the action and move Codex to a narrower scoped credential.

`minimum-severity: medium` — lower-severity findings remain in the review summary rather than inline comments.