### PR TITLE
Add local OSS session dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ hacker-bob doctor /path/to/your/project
 hacker-bob doctor /path/to/your/project --adapter codex
 ```
 
+For a local read-only dashboard over multiple concurrent sessions:
+
+```bash
+hacker-bob dashboard --repo-only
+```
+
+The dashboard binds to `127.0.0.1` by default and reads
+`~/bounty-agent-sessions`. It shows OSS/repo progress, pending handoffs,
+findings, verification/evidence/grade state, and cross-session bottlenecks.
+
 ## How A Hunt Works
 
 Bob follows a structured workflow:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For a local read-only dashboard over multiple concurrent sessions:
 hacker-bob dashboard --repo-only
 ```
 
-The dashboard binds to `127.0.0.1` by default and reads
+The dashboard binds to `127.0.0.1:4873` by default and reads
 `~/bounty-agent-sessions`. It shows OSS/repo progress, pending handoffs,
 findings, verification/evidence/grade state, and cross-session bottlenecks.
 

--- a/bin/hacker-bob.js
+++ b/bin/hacker-bob.js
@@ -13,6 +13,8 @@ const {
   printUninstallReport,
   uninstallProject,
 } = require("../scripts/lifecycle.js");
+const dashboard = require("../mcp/lib/dashboard.js");
+const { sessionsRoot } = require("../mcp/lib/paths.js");
 const update = require("../mcp/lib/update-check.js");
 
 function usageText() {
@@ -22,6 +24,7 @@ function usageText() {
   hacker-bob check-update <project-dir> [--json]
   hacker-bob doctor <project-dir> [--adapter claude|codex|generic-mcp|all] [--json]
   hacker-bob uninstall <project-dir> [--adapter claude|codex|generic-mcp|all] [--dry-run] [--yes] [--json]
+  hacker-bob dashboard [--host 127.0.0.1] [--port 4873] [--repo-only] [--window-days 30] [--limit 50] [--json]
 
 Installs Hacker Bob into one project directory per command. If --adapter is omitted,
 Bob auto-selects based on (1) prior install metadata, (2) host env markers
@@ -30,7 +33,8 @@ Bob auto-selects based on (1) prior install metadata, (2) host env markers
 The selected adapter and reason are logged to stderr; pass --adapter to override.
 Use --adapter codex, --adapter generic-mcp, or --adapter all for other host surfaces.
 Global npm install only adds this CLI to PATH; it does not install Bob into every project.
-Uninstall defaults to dry-run; pass --yes to remove Bob-managed files and config entries.`;
+Uninstall defaults to dry-run; pass --yes to remove Bob-managed files and config entries.
+Dashboard is a local read-only view over ~/bounty-agent-sessions; use --repo-only for OSS mode.`;
 }
 
 function usage(stream = process.stderr) {
@@ -108,6 +112,23 @@ async function main(argv) {
     } else {
       process.stdout.write(update.renderUpdateSummary(result));
     }
+    return;
+  }
+
+  if (command === "dashboard") {
+    const options = dashboard.parseDashboardArgs(args);
+    if (options.help) {
+      process.stdout.write(`${dashboard.dashboardUsageText()}\n`);
+      return;
+    }
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(dashboard.buildDashboardSnapshot(options), null, 2)}\n`);
+      return;
+    }
+    const started = await dashboard.startDashboardServer(options);
+    process.stdout.write(`Hacker Bob dashboard listening on ${started.url}\n`);
+    process.stdout.write(`Sessions root: ${sessionsRoot()}\n`);
+    process.stdout.write("Press Ctrl+C to stop.\n");
     return;
   }
 

--- a/docs/OSS_MODE_MVP.md
+++ b/docs/OSS_MODE_MVP.md
@@ -24,6 +24,27 @@ The first version is local-repo first:
 GitHub URL cloning, automatic PR creation, hosted scanning, and write-mode fixes
 are out of scope for this MVP.
 
+## Multi-Repo Dashboard
+
+Use the local dashboard when running several OSS sessions in parallel:
+
+```bash
+hacker-bob dashboard --repo-only
+```
+
+The command starts a read-only server on `127.0.0.1:4873` by default and reads
+the existing `~/bounty-agent-sessions` artifacts. It does not launch agents or
+mutate sessions. It shows each repo session's phase, wave handoff progress,
+coverage, technique attempts, findings, final reportable counts,
+evidence/grade/report state, and bottlenecks.
+
+For automation or tests, print the same cross-session snapshot without starting
+the UI:
+
+```bash
+hacker-bob dashboard --repo-only --json
+```
+
 ## Task Graph
 
 ```text

--- a/mcp/lib/dashboard.js
+++ b/mcp/lib/dashboard.js
@@ -1,0 +1,590 @@
+"use strict";
+
+const fs = require("fs");
+const http = require("http");
+const { URL } = require("url");
+const {
+  readPipelineAnalytics,
+} = require("./pipeline-analytics.js");
+const {
+  repoInventoryPath,
+  sessionsRoot,
+  statePath,
+} = require("./paths.js");
+
+const DASHBOARD_VERSION = 1;
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 4873;
+const DEFAULT_WINDOW_DAYS = 30;
+const MAX_WINDOW_DAYS = 365;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const JSON_READ_MAX_BYTES = 2 * 1024 * 1024;
+
+function dashboardUsageText() {
+  return `Usage:
+  hacker-bob dashboard [--host 127.0.0.1] [--port 4873] [--repo-only] [--window-days 30] [--limit 50] [--json]
+
+Starts a local read-only dashboard over ~/bounty-agent-sessions.
+Use --json to print the same dashboard snapshot without starting a server.`;
+}
+
+function readFlagValue(args, index, flag) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return { value, nextIndex: index + 1 };
+}
+
+function parseInteger(value, field, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const text = String(value);
+  if (!/^\d+$/.test(text)) {
+    throw new Error(`${field} must be an integer`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${field} must be between ${min} and ${max}`);
+  }
+  return parsed;
+}
+
+function parseHost(value) {
+  const host = String(value || "").trim();
+  if (!host) throw new Error("--host requires a value");
+  if (/[\s/]/.test(host)) throw new Error("--host must be a hostname or IP address");
+  return host;
+}
+
+function normalizeDashboardOptions(options = {}) {
+  return {
+    host: parseHost(options.host || DEFAULT_HOST),
+    port: options.port == null
+      ? DEFAULT_PORT
+      : parseInteger(options.port, "port", { min: 0, max: 65535 }),
+    repo_only: options.repo_only === true,
+    window_days: options.window_days == null
+      ? DEFAULT_WINDOW_DAYS
+      : parseInteger(options.window_days, "window_days", { min: 1, max: MAX_WINDOW_DAYS }),
+    limit: options.limit == null
+      ? DEFAULT_LIMIT
+      : parseInteger(options.limit, "limit", { min: 1, max: MAX_LIMIT }),
+    json: options.json === true,
+    help: options.help === true,
+  };
+}
+
+function parseDashboardArgs(args = []) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-h" || arg === "--help") {
+      options.help = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--repo-only") {
+      options.repo_only = true;
+    } else if (arg === "--host") {
+      const parsed = readFlagValue(args, index, "--host");
+      options.host = parsed.value;
+      index = parsed.nextIndex;
+    } else if (arg.startsWith("--host=")) {
+      options.host = arg.slice("--host=".length);
+    } else if (arg === "--port") {
+      const parsed = readFlagValue(args, index, "--port");
+      options.port = parsed.value;
+      index = parsed.nextIndex;
+    } else if (arg.startsWith("--port=")) {
+      options.port = arg.slice("--port=".length);
+    } else if (arg === "--window-days") {
+      const parsed = readFlagValue(args, index, "--window-days");
+      options.window_days = parsed.value;
+      index = parsed.nextIndex;
+    } else if (arg.startsWith("--window-days=")) {
+      options.window_days = arg.slice("--window-days=".length);
+    } else if (arg === "--limit") {
+      const parsed = readFlagValue(args, index, "--limit");
+      options.limit = parsed.value;
+      index = parsed.nextIndex;
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = arg.slice("--limit=".length);
+    } else {
+      throw new Error(`Unknown dashboard option: ${arg}`);
+    }
+  }
+  return normalizeDashboardOptions(options);
+}
+
+function readJsonFileSafe(filePath) {
+  try {
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) {
+      return { exists: true, document: null, error: "not a regular file" };
+    }
+    if (stats.size > JSON_READ_MAX_BYTES) {
+      return { exists: true, document: null, error: `exceeds ${JSON_READ_MAX_BYTES} byte read cap` };
+    }
+    return {
+      exists: true,
+      document: JSON.parse(fs.readFileSync(filePath, "utf8")),
+      error: null,
+    };
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return { exists: false, document: null, error: null };
+    }
+    return {
+      exists: true,
+      document: null,
+      error: error && error.message ? error.message : String(error),
+    };
+  }
+}
+
+function capArray(value, limit = 8) {
+  return Array.isArray(value) ? value.slice(0, limit) : [];
+}
+
+function readRepoDashboardInfo(targetDomain) {
+  const stateRead = readJsonFileSafe(statePath(targetDomain));
+  const state = stateRead.document && typeof stateRead.document === "object" && !Array.isArray(stateRead.document)
+    ? stateRead.document
+    : {};
+  const inventoryRead = readJsonFileSafe(repoInventoryPath(targetDomain));
+  const inventory = inventoryRead.document && typeof inventoryRead.document === "object" && !Array.isArray(inventoryRead.document)
+    ? inventoryRead.document
+    : {};
+  const repo = state.repo && typeof state.repo === "object" && !Array.isArray(state.repo) ? state.repo : null;
+  const isRepo = state.target_kind === "repo" || state.target_url === `repo://${targetDomain}` || inventoryRead.exists;
+  return {
+    is_repo: isRepo,
+    target_kind: state.target_kind || (isRepo ? "repo" : "web"),
+    root_path: repo && typeof repo.root_path === "string" ? repo.root_path : inventory.repo_path || null,
+    source_url: repo && typeof repo.source_url === "string" ? repo.source_url : null,
+    branch: repo && typeof repo.branch === "string" ? repo.branch : null,
+    commit: repo && typeof repo.commit === "string" ? repo.commit : null,
+    inventory: {
+      exists: inventoryRead.exists,
+      error: inventoryRead.error,
+      generated_at: typeof inventory.generated_at === "string" ? inventory.generated_at : null,
+      counts: inventory.counts && typeof inventory.counts === "object" && !Array.isArray(inventory.counts)
+        ? inventory.counts
+        : {},
+      tech_stack: capArray(inventory.tech_stack),
+      reachability: inventory.reachability && typeof inventory.reachability === "object" && !Array.isArray(inventory.reachability)
+        ? {
+            max_credible_severity_ceiling: inventory.reachability.max_credible_severity_ceiling || null,
+            network_reachable_surface_ids: capArray(inventory.reachability.network_reachable_surface_ids),
+          }
+        : null,
+    },
+  };
+}
+
+function compactDashboardSession(row) {
+  const repo = readRepoDashboardInfo(row.target_domain);
+  return {
+    target_domain: row.target_domain,
+    phase: row.phase || null,
+    health: row.health || { status: "unknown", reasons: [] },
+    latest_activity_ts: row.latest_activity_ts || null,
+    auth_status: row.auth_status || null,
+    waves: row.waves || {},
+    findings: row.findings || { total: 0, by_severity: {} },
+    chain_attempts_count: row.chain_attempts_count || 0,
+    technique_attempts: row.technique_attempts || { total: 0 },
+    final_verification_count: row.final_verification_count || 0,
+    final_reportable_count: row.final_reportable_count || 0,
+    evidence: row.evidence || { exists: false, valid: false },
+    grade_verdict: row.grade_verdict || null,
+    report_present: row.report_present === true,
+    egress: row.egress || {},
+    geofence_warnings: row.geofence_warnings || null,
+    repo,
+  };
+}
+
+function increment(bucket, key) {
+  const normalized = key || "unknown";
+  bucket[normalized] = (bucket[normalized] || 0) + 1;
+}
+
+function buildDashboardTotals(sessions) {
+  const totals = {
+    sessions: sessions.length,
+    repo_sessions: 0,
+    by_phase: {},
+    by_health: {},
+    findings: 0,
+    final_reportable: 0,
+    reports_present: 0,
+    grades_present: 0,
+    pending_handoffs_missing: 0,
+    pending_handoffs_invalid: 0,
+  };
+  for (const session of sessions) {
+    if (session.repo.is_repo) totals.repo_sessions += 1;
+    increment(totals.by_phase, session.phase);
+    increment(totals.by_health, session.health.status);
+    totals.findings += session.findings.total || 0;
+    totals.final_reportable += session.final_reportable_count || 0;
+    if (session.report_present) totals.reports_present += 1;
+    if (session.grade_verdict) totals.grades_present += 1;
+    totals.pending_handoffs_missing += session.waves.pending_handoffs_missing || 0;
+    totals.pending_handoffs_invalid += session.waves.pending_handoffs_invalid || 0;
+  }
+  return totals;
+}
+
+function buildDashboardBottlenecks(sessions) {
+  const grouped = new Map();
+  for (const session of sessions) {
+    const reasons = Array.isArray(session.health.reasons) ? session.health.reasons : [];
+    for (const reason of reasons) {
+      if (!grouped.has(reason)) {
+        grouped.set(reason, {
+          code: reason,
+          affected_count: 0,
+          affected_targets: [],
+        });
+      }
+      const group = grouped.get(reason);
+      group.affected_count += 1;
+      group.affected_targets.push(session.target_domain);
+    }
+  }
+  return Array.from(grouped.values())
+    .sort((a, b) => b.affected_count - a.affected_count || a.code.localeCompare(b.code));
+}
+
+function actionForDashboardBottleneck(bottleneck) {
+  const actionByCode = {
+    unreadable_artifacts: "Repair malformed session artifacts before resuming orchestration.",
+    hunter_handoff_failures: "Resume or reconcile the pending wave after hunter handoffs are complete.",
+    repeated_hunter_stops: "Inspect repeated SubagentStop blockers before launching more hunters.",
+    low_coverage: "Launch another wave for unexplored non-low surfaces before verification.",
+    chain_phase_no_attempts: "Run chain-builder until every required chain path has a terminal attempt.",
+    missing_verification: "Write a valid final verification round before grading.",
+    missing_evidence: "Run the evidence agent before grading or reporting.",
+    missing_grade: "Write a valid grade verdict before report completion.",
+    missing_report: "Write the canonical report.md or move the session out of REPORT.",
+    stale_pending_wave: "Re-enter the resume flow and reconcile the stale pending wave.",
+    delayed_wave_reconciliation: "Audit resume flow latency after hunter completion.",
+  };
+  return {
+    code: bottleneck.code,
+    action: actionByCode[bottleneck.code] || "Inspect this bottleneck before continuing.",
+    affected_count: bottleneck.affected_count,
+    affected_targets: bottleneck.affected_targets,
+  };
+}
+
+function buildDashboardNextActions(bottlenecks, limit) {
+  return bottlenecks.slice(0, limit).map(actionForDashboardBottleneck);
+}
+
+function buildDashboardSnapshot(options = {}, context = {}) {
+  const normalized = normalizeDashboardOptions(options);
+  const analytics = JSON.parse(readPipelineAnalytics({
+    window_days: normalized.window_days,
+    limit: normalized.limit,
+    include_events: false,
+  }, {
+    env: context.env || process.env,
+  }));
+  const matchedSessions = analytics.sessions
+    .map(compactDashboardSession)
+    .filter((session) => !normalized.repo_only || session.repo.is_repo);
+  const sessions = matchedSessions.slice(0, normalized.limit);
+  const bottlenecks = buildDashboardBottlenecks(sessions).slice(0, normalized.limit);
+  return {
+    version: DASHBOARD_VERSION,
+    generated_at: new Date().toISOString(),
+    sessions_root: sessionsRoot(),
+    filters: {
+      repo_only: normalized.repo_only,
+      window_days: normalized.window_days,
+      limit: normalized.limit,
+    },
+    totals: buildDashboardTotals(sessions),
+    bottlenecks,
+    next_actions: buildDashboardNextActions(bottlenecks, normalized.limit),
+    sessions,
+    analytics_bounds: {
+      ...(analytics.analytics_bounds || {}),
+      sessions_matched: matchedSessions.length,
+      sessions_displayed: sessions.length,
+    },
+  };
+}
+
+function booleanFromQuery(value) {
+  if (value == null) return false;
+  return value === "" || value === "1" || value === "true" || value === "yes";
+}
+
+function optionsFromUrl(url, baseOptions) {
+  return normalizeDashboardOptions({
+    ...baseOptions,
+    repo_only: url.searchParams.has("repo_only")
+      ? booleanFromQuery(url.searchParams.get("repo_only"))
+      : baseOptions.repo_only,
+    window_days: url.searchParams.get("window_days") || baseOptions.window_days,
+    limit: url.searchParams.get("limit") || baseOptions.limit,
+  });
+}
+
+function sendJson(res, statusCode, body, headOnly = false) {
+  const text = `${JSON.stringify(body, null, 2)}\n`;
+  res.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+    "content-length": Buffer.byteLength(text),
+  });
+  if (!headOnly) res.end(text);
+  else res.end();
+}
+
+function sendHtml(res, body, headOnly = false) {
+  res.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+    "content-length": Buffer.byteLength(body),
+  });
+  if (!headOnly) res.end(body);
+  else res.end();
+}
+
+function renderDashboardHtml(options) {
+  const initialOptions = {
+    repo_only: options.repo_only,
+    window_days: options.window_days,
+    limit: options.limit,
+  };
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hacker Bob Dashboard</title>
+  <style>
+    :root { color-scheme: light; --ink: #15191f; --muted: #5e6875; --line: #d9dee5; --soft: #f5f7fa; --ok: #0f7b4f; --warn: #9a5a00; --bad: #b42318; --accent: #2457d6; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); background: #ffffff; }
+    header { border-bottom: 1px solid var(--line); padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+    h1 { font-size: 20px; line-height: 1.2; margin: 0; letter-spacing: 0; }
+    main { padding: 20px 24px 28px; }
+    .toolbar { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+    label { color: var(--muted); font-size: 13px; display: inline-flex; align-items: center; gap: 6px; }
+    input[type="number"] { width: 72px; padding: 6px 8px; border: 1px solid var(--line); border-radius: 6px; font: inherit; }
+    button { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 6px; padding: 7px 10px; font: inherit; cursor: pointer; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; margin-bottom: 18px; }
+    .stat { border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; min-height: 72px; }
+    .stat .label { color: var(--muted); font-size: 12px; }
+    .stat .value { font-size: 26px; font-weight: 700; margin-top: 4px; }
+    .layout { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 18px; align-items: start; }
+    table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+    th, td { text-align: left; border-bottom: 1px solid var(--line); padding: 10px; vertical-align: top; font-size: 13px; }
+    th { background: var(--soft); color: var(--muted); font-weight: 600; }
+    tr:last-child td { border-bottom: 0; }
+    .badge { display: inline-flex; align-items: center; min-height: 22px; border-radius: 999px; padding: 2px 8px; font-size: 12px; border: 1px solid var(--line); background: #fff; }
+    .healthy { color: var(--ok); border-color: rgba(15, 123, 79, .35); background: rgba(15, 123, 79, .08); }
+    .needs_attention { color: var(--warn); border-color: rgba(154, 90, 0, .35); background: rgba(154, 90, 0, .08); }
+    .blocked { color: var(--bad); border-color: rgba(180, 35, 24, .35); background: rgba(180, 35, 24, .08); }
+    .muted { color: var(--muted); }
+    aside { border: 1px solid var(--line); border-radius: 8px; padding: 12px; }
+    aside h2 { font-size: 15px; margin: 0 0 10px; letter-spacing: 0; }
+    .list { display: grid; gap: 10px; }
+    .item { border-top: 1px solid var(--line); padding-top: 10px; }
+    .item:first-child { border-top: 0; padding-top: 0; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
+    @media (max-width: 860px) { header, main { padding-left: 14px; padding-right: 14px; } .layout { grid-template-columns: 1fr; } table { display: block; overflow-x: auto; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Hacker Bob Dashboard</h1>
+    <div class="toolbar">
+      <label><input id="repoOnly" type="checkbox"> Repo only</label>
+      <label>Days <input id="windowDays" type="number" min="1" max="${MAX_WINDOW_DAYS}"></label>
+      <label>Limit <input id="limit" type="number" min="1" max="${MAX_LIMIT}"></label>
+      <button id="refresh" type="button">Refresh</button>
+    </div>
+  </header>
+  <main>
+    <section id="stats" class="stats"></section>
+    <section class="layout">
+      <div>
+        <table>
+          <thead>
+            <tr><th>Session</th><th>Phase</th><th>Health</th><th>Findings</th><th>Verification</th><th>Activity</th></tr>
+          </thead>
+          <tbody id="sessions"></tbody>
+        </table>
+      </div>
+      <aside>
+        <h2>Bottlenecks</h2>
+        <div id="bottlenecks" class="list"></div>
+      </aside>
+    </section>
+  </main>
+  <script>
+    const initialOptions = ${JSON.stringify(initialOptions)};
+    const repoOnly = document.getElementById("repoOnly");
+    const windowDays = document.getElementById("windowDays");
+    const limit = document.getElementById("limit");
+    const stats = document.getElementById("stats");
+    const sessions = document.getElementById("sessions");
+    const bottlenecks = document.getElementById("bottlenecks");
+    repoOnly.checked = initialOptions.repo_only;
+    windowDays.value = initialOptions.window_days;
+    limit.value = initialOptions.limit;
+
+    function text(value) { return value == null || value === "" ? "-" : String(value); }
+    function clear(node) { while (node.firstChild) node.removeChild(node.firstChild); }
+    function cell(row, value) { const td = document.createElement("td"); td.textContent = text(value); row.appendChild(td); return td; }
+    function badge(value) { const span = document.createElement("span"); span.className = "badge " + text(value); span.textContent = text(value); return span; }
+    function stat(label, value) {
+      const node = document.createElement("div");
+      node.className = "stat";
+      const labelNode = document.createElement("div");
+      labelNode.className = "label";
+      labelNode.textContent = label;
+      const valueNode = document.createElement("div");
+      valueNode.className = "value";
+      valueNode.textContent = text(value);
+      node.append(labelNode, valueNode);
+      return node;
+    }
+    function formatActivity(ts) {
+      if (!ts) return "-";
+      const date = new Date(ts);
+      return Number.isNaN(date.getTime()) ? ts : date.toLocaleString();
+    }
+    async function load() {
+      const params = new URLSearchParams({
+        repo_only: repoOnly.checked ? "true" : "false",
+        window_days: windowDays.value,
+        limit: limit.value,
+      });
+      const response = await fetch("/api/snapshot?" + params.toString(), { cache: "no-store" });
+      if (!response.ok) throw new Error("snapshot failed: " + response.status);
+      render(await response.json());
+    }
+    function render(snapshot) {
+      clear(stats);
+      stats.append(
+        stat("Sessions", snapshot.totals.sessions),
+        stat("Findings", snapshot.totals.findings),
+        stat("Reportable", snapshot.totals.final_reportable),
+        stat("Missing Handoffs", snapshot.totals.pending_handoffs_missing)
+      );
+      clear(sessions);
+      for (const session of snapshot.sessions) {
+        const row = document.createElement("tr");
+        const name = cell(row, session.target_domain);
+        if (session.repo && session.repo.root_path) {
+          const path = document.createElement("div");
+          path.className = "muted";
+          path.textContent = session.repo.root_path;
+          name.appendChild(path);
+        }
+        cell(row, session.phase);
+        const healthCell = document.createElement("td");
+        healthCell.appendChild(badge(session.health && session.health.status));
+        row.appendChild(healthCell);
+        cell(row, session.findings ? session.findings.total : 0);
+        cell(row, String(session.final_verification_count || 0) + " / " + String(session.final_reportable_count || 0));
+        cell(row, formatActivity(session.latest_activity_ts));
+        sessions.appendChild(row);
+      }
+      if (!snapshot.sessions.length) {
+        const row = document.createElement("tr");
+        const empty = cell(row, "No sessions match the current filters.");
+        empty.colSpan = 6;
+        sessions.appendChild(row);
+      }
+      clear(bottlenecks);
+      for (const item of snapshot.bottlenecks) {
+        const node = document.createElement("div");
+        node.className = "item";
+        const title = document.createElement("div");
+        title.appendChild(badge(item.code));
+        const detail = document.createElement("div");
+        detail.className = "muted";
+        detail.textContent = String(item.affected_count) + " session(s): " + item.affected_targets.join(", ");
+        node.append(title, detail);
+        bottlenecks.appendChild(node);
+      }
+      if (!snapshot.bottlenecks.length) {
+        const empty = document.createElement("div");
+        empty.className = "muted";
+        empty.textContent = "No active bottlenecks.";
+        bottlenecks.appendChild(empty);
+      }
+    }
+    document.getElementById("refresh").addEventListener("click", () => load().catch((error) => alert(error.message)));
+    load().catch((error) => { sessions.innerHTML = "<tr><td colspan=\\"6\\"></td></tr>"; sessions.querySelector("td").textContent = error.message; });
+  </script>
+</body>
+</html>`;
+}
+
+function routeDashboardRequest(req, res, baseOptions) {
+  const headOnly = req.method === "HEAD";
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    sendJson(res, 405, { error: "method_not_allowed" }, headOnly);
+    return;
+  }
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+  if (url.pathname === "/" || url.pathname === "/index.html") {
+    sendHtml(res, renderDashboardHtml(baseOptions), headOnly);
+    return;
+  }
+  if (url.pathname === "/api/snapshot") {
+    try {
+      const options = optionsFromUrl(url, baseOptions);
+      sendJson(res, 200, buildDashboardSnapshot(options), headOnly);
+    } catch (error) {
+      sendJson(res, 400, { error: error && error.message ? error.message : String(error) }, headOnly);
+    }
+    return;
+  }
+  sendJson(res, 404, { error: "not_found" }, headOnly);
+}
+
+function hostForUrl(host) {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+function startDashboardServer(options = {}, context = {}) {
+  const normalized = normalizeDashboardOptions(options);
+  const server = http.createServer((req, res) => routeDashboardRequest(req, res, normalized));
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(normalized.port, normalized.host, () => {
+      server.off("error", reject);
+      const address = server.address();
+      const port = address && typeof address === "object" ? address.port : normalized.port;
+      resolve({
+        server,
+        options: normalized,
+        url: `http://${hostForUrl(normalized.host)}:${port}/`,
+      });
+    });
+    if (context.unref === true) server.unref();
+  });
+}
+
+module.exports = {
+  DASHBOARD_VERSION,
+  DEFAULT_HOST,
+  DEFAULT_PORT,
+  DEFAULT_WINDOW_DAYS,
+  DEFAULT_LIMIT,
+  buildDashboardSnapshot,
+  dashboardUsageText,
+  normalizeDashboardOptions,
+  parseDashboardArgs,
+  startDashboardServer,
+};

--- a/mcp/lib/dashboard.js
+++ b/mcp/lib/dashboard.js
@@ -56,6 +56,18 @@ function parseHost(value) {
   return host;
 }
 
+function isLoopbackHost(host) {
+  const normalized = String(host || "").toLowerCase();
+  if (normalized === "localhost" || normalized === "::1" || normalized === "[::1]") {
+    return true;
+  }
+  const ipv4Match = normalized.match(/^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  return !!ipv4Match && ipv4Match.slice(1).every((part) => {
+    const value = Number(part);
+    return value >= 0 && value <= 255;
+  });
+}
+
 function normalizeDashboardOptions(options = {}) {
   return {
     host: parseHost(options.host || DEFAULT_HOST),
@@ -296,7 +308,7 @@ function buildDashboardSnapshot(options = {}, context = {}) {
     .map(compactDashboardSession)
     .filter((session) => !normalized.repo_only || session.repo.is_repo);
   const sessions = matchedSessions.slice(0, normalized.limit);
-  const bottlenecks = buildDashboardBottlenecks(sessions).slice(0, normalized.limit);
+  const bottlenecks = buildDashboardBottlenecks(matchedSessions).slice(0, normalized.limit);
   return {
     version: DASHBOARD_VERSION,
     generated_at: new Date().toISOString(),
@@ -306,7 +318,7 @@ function buildDashboardSnapshot(options = {}, context = {}) {
       window_days: normalized.window_days,
       limit: normalized.limit,
     },
-    totals: buildDashboardTotals(sessions),
+    totals: buildDashboardTotals(matchedSessions),
     bottlenecks,
     next_actions: buildDashboardNextActions(bottlenecks, normalized.limit),
     sessions,
@@ -530,7 +542,7 @@ function renderDashboardHtml(options) {
 </html>`;
 }
 
-function routeDashboardRequest(req, res, baseOptions) {
+function routeDashboardRequest(req, res, baseOptions, context = {}) {
   const headOnly = req.method === "HEAD";
   if (req.method !== "GET" && req.method !== "HEAD") {
     sendJson(res, 405, { error: "method_not_allowed" }, headOnly);
@@ -544,7 +556,7 @@ function routeDashboardRequest(req, res, baseOptions) {
   if (url.pathname === "/api/snapshot") {
     try {
       const options = optionsFromUrl(url, baseOptions);
-      sendJson(res, 200, buildDashboardSnapshot(options), headOnly);
+      sendJson(res, 200, buildDashboardSnapshot(options, context), headOnly);
     } catch (error) {
       sendJson(res, 400, { error: error && error.message ? error.message : String(error) }, headOnly);
     }
@@ -559,7 +571,15 @@ function hostForUrl(host) {
 
 function startDashboardServer(options = {}, context = {}) {
   const normalized = normalizeDashboardOptions(options);
-  const server = http.createServer((req, res) => routeDashboardRequest(req, res, normalized));
+  if (!isLoopbackHost(normalized.host)) {
+    const warning = `warning: dashboard is unauthenticated and bound to ${normalized.host}; session analytics may be reachable from the network\n`;
+    if (context.stderr && typeof context.stderr.write === "function") {
+      context.stderr.write(warning);
+    } else {
+      process.stderr.write(warning);
+    }
+  }
+  const server = http.createServer((req, res) => routeDashboardRequest(req, res, normalized, context));
   return new Promise((resolve, reject) => {
     server.once("error", reject);
     server.listen(normalized.port, normalized.host, () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -19,7 +19,7 @@ test("CLI help explains per-project installs and global CLI behavior", () => {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
-  for (const command of ["install", "update", "check-update", "doctor", "uninstall"]) {
+  for (const command of ["install", "update", "check-update", "doctor", "uninstall", "dashboard"]) {
     assert.match(output, new RegExp(`hacker-bob ${command}`));
   }
   assert.match(output, /Bob auto-selects/);
@@ -29,6 +29,26 @@ test("CLI help explains per-project installs and global CLI behavior", () => {
   assert.match(output, /--adapter claude\|codex\|generic-mcp\|all/);
   assert.match(output, /Global npm install only adds this CLI to PATH/);
   assert.match(output, /Uninstall defaults to dry-run/);
+  assert.match(output, /Dashboard is a local read-only view/);
+});
+
+test("CLI dashboard --json emits a cross-session snapshot without starting a server", () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bob-cli-dashboard-home-"));
+  try {
+    const output = execFileSync(process.execPath, [CLI, "dashboard", "--repo-only", "--json"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.version, 1);
+    assert.equal(parsed.filters.repo_only, true);
+    assert.equal(parsed.totals.sessions, 0);
+    assert.deepEqual(parsed.sessions, []);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
 });
 
 test("CLI installs into a workspace", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,0 +1,155 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  buildDashboardSnapshot,
+  dashboardUsageText,
+  parseDashboardArgs,
+  startDashboardServer,
+} = require("../mcp/lib/dashboard.js");
+const {
+  repoInventoryPath,
+} = require("../mcp/lib/paths.js");
+const {
+  initSession,
+} = require("../mcp/lib/session-state.js");
+
+function withTempHome(fn) {
+  const previousHome = process.env.HOME;
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bob-dashboard-test-"));
+  process.env.HOME = tempHome;
+  const cleanup = () => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  };
+  try {
+    const result = fn(tempHome);
+    if (result && typeof result.then === "function") {
+      return result.finally(cleanup);
+    }
+    cleanup();
+    return result;
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}
+
+function requestText(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve({ statusCode: res.statusCode, body });
+      });
+    });
+    req.on("error", reject);
+  });
+}
+
+function seedRepoSession(domain, repoPath) {
+  JSON.parse(initSession({
+    target_domain: domain,
+    target_url: `repo://${domain}`,
+    target_kind: "repo",
+    repo: {
+      root_path: repoPath,
+      branch: "main",
+      commit: "abc1234",
+    },
+  }));
+  fs.writeFileSync(repoInventoryPath(domain), `${JSON.stringify({
+    version: 1,
+    target_domain: domain,
+    repo_path: repoPath,
+    generated_at: "2026-01-01T00:00:00.000Z",
+    counts: {
+      files: 12,
+      surfaces: 2,
+      native_source_files: 3,
+    },
+    tech_stack: ["C/C++", "Autotools"],
+    reachability: {
+      max_credible_severity_ceiling: "CRITICAL",
+      network_reachable_surface_ids: ["OSS-NATIVE-CODE"],
+    },
+  }, null, 2)}\n`);
+}
+
+test("dashboard arg parser handles local server and JSON flags", () => {
+  const parsed = parseDashboardArgs([
+    "--repo-only",
+    "--json",
+    "--host",
+    "127.0.0.1",
+    "--port=0",
+    "--window-days",
+    "14",
+    "--limit",
+    "25",
+  ]);
+  assert.equal(parsed.repo_only, true);
+  assert.equal(parsed.json, true);
+  assert.equal(parsed.host, "127.0.0.1");
+  assert.equal(parsed.port, 0);
+  assert.equal(parsed.window_days, 14);
+  assert.equal(parsed.limit, 25);
+  assert.match(dashboardUsageText(), /hacker-bob dashboard/);
+  assert.throws(() => parseDashboardArgs(["--port", "70000"]), /port must be between/);
+});
+
+test("dashboard snapshot filters repo sessions and keeps compact repo metadata", () => {
+  withTempHome((home) => {
+    const repoPath = path.join(home, "repo");
+    fs.mkdirSync(repoPath, { recursive: true });
+    seedRepoSession("repo-dashboard.example", repoPath);
+    JSON.parse(initSession({
+      target_domain: "web-dashboard.example",
+      target_url: "https://web-dashboard.example",
+    }));
+
+    const snapshot = buildDashboardSnapshot({ repo_only: true, window_days: 30, limit: 10 });
+    assert.equal(snapshot.version, 1);
+    assert.equal(snapshot.filters.repo_only, true);
+    assert.equal(snapshot.totals.sessions, 1);
+    assert.equal(snapshot.totals.repo_sessions, 1);
+    assert.equal(snapshot.sessions[0].target_domain, "repo-dashboard.example");
+    assert.equal(snapshot.sessions[0].repo.is_repo, true);
+    assert.equal(snapshot.sessions[0].repo.root_path, repoPath);
+    assert.equal(snapshot.sessions[0].repo.inventory.counts.files, 12);
+    assert.deepEqual(snapshot.sessions[0].repo.inventory.tech_stack, ["C/C++", "Autotools"]);
+  });
+});
+
+test("dashboard server serves HTML and API JSON", async () => {
+  await withTempHome(async () => {
+    const started = await startDashboardServer({ host: "127.0.0.1", port: 0, repo_only: true });
+    try {
+      const html = await requestText(started.url);
+      assert.equal(html.statusCode, 200);
+      assert.match(html.body, /Hacker Bob Dashboard/);
+
+      const api = await requestText(`${started.url}api/snapshot?repo_only=true&limit=5`);
+      assert.equal(api.statusCode, 200);
+      const parsed = JSON.parse(api.body);
+      assert.equal(parsed.version, 1);
+      assert.equal(parsed.filters.repo_only, true);
+      assert.equal(parsed.filters.limit, 5);
+    } finally {
+      await new Promise((resolve, reject) => {
+        started.server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+});

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -132,6 +132,28 @@ test("dashboard snapshot filters repo sessions and keeps compact repo metadata",
   });
 });
 
+test("dashboard snapshot totals use all matched sessions before display limit", () => {
+  withTempHome((home) => {
+    const firstRepoPath = path.join(home, "repo-one");
+    const secondRepoPath = path.join(home, "repo-two");
+    fs.mkdirSync(firstRepoPath, { recursive: true });
+    fs.mkdirSync(secondRepoPath, { recursive: true });
+    seedRepoSession("repo-dashboard-one.example", firstRepoPath);
+    seedRepoSession("repo-dashboard-two.example", secondRepoPath);
+    JSON.parse(initSession({
+      target_domain: "web-dashboard.example",
+      target_url: "https://web-dashboard.example",
+    }));
+
+    const snapshot = buildDashboardSnapshot({ repo_only: true, window_days: 30, limit: 1 });
+    assert.equal(snapshot.sessions.length, 1);
+    assert.equal(snapshot.analytics_bounds.sessions_matched, 2);
+    assert.equal(snapshot.analytics_bounds.sessions_displayed, 1);
+    assert.equal(snapshot.totals.sessions, 2);
+    assert.equal(snapshot.totals.repo_sessions, 2);
+  });
+});
+
 test("dashboard server serves HTML and API JSON", async () => {
   await withTempHome(async () => {
     const started = await startDashboardServer({ host: "127.0.0.1", port: 0, repo_only: true });
@@ -146,6 +168,31 @@ test("dashboard server serves HTML and API JSON", async () => {
       assert.equal(parsed.version, 1);
       assert.equal(parsed.filters.repo_only, true);
       assert.equal(parsed.filters.limit, 5);
+    } finally {
+      await new Promise((resolve, reject) => {
+        started.server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+});
+
+test("dashboard server warns when binding outside loopback", async () => {
+  await withTempHome(async () => {
+    let warning = "";
+    const started = await startDashboardServer({
+      host: "0.0.0.0",
+      port: 0,
+      repo_only: true,
+    }, {
+      stderr: {
+        write(chunk) {
+          warning += chunk;
+        },
+      },
+    });
+    try {
+      assert.match(warning, /unauthenticated/);
+      assert.match(warning, /0\.0\.0\.0/);
     } finally {
       await new Promise((resolve, reject) => {
         started.server.close((error) => error ? reject(error) : resolve());

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -39,5 +39,6 @@
   "test/unified-diff-parser.test.js",
   "test/cve-feed-parser.test.js",
   "test/cve-scope-matcher.test.js",
+  "test/dashboard.test.js",
   "test/mcp-test-discovery.test.js"
 ]


### PR DESCRIPTION
## Summary
- add a local read-only dashboard command for bounty-agent session analytics
- support compact JSON snapshots with repo-only filtering for OSS mode
- document the dashboard and add CLI/MCP coverage for parser, snapshot, and HTTP server paths

## Test Plan
- node --test test/dashboard.test.js test/cli.test.js test/mcp-test-discovery.test.js
- npm test
- browser smoke on http://127.0.0.1:4874/ desktop and mobile using explicit --port 4874; default remains 127.0.0.1:4873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `hacker-bob dashboard` to monitor multiple concurrent OSS review sessions locally (read-only), defaults to 127.0.0.1:4873 and reads sessions from ~/bounty-agent-sessions.
  * Supports `--repo-only` filtering and `--json` snapshot output for automation.

* **Documentation**
  * README and docs updated with Multi-Repo Dashboard usage and flags.

* **Tests**
  * New tests validating CLI help, JSON snapshot behavior, snapshot building, and local server responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->