### PR TITLE
fix: label role markdown fences

### DIFF
--- a/.claude/skills/bob-debug/SKILL.md
+++ b/.claude/skills/bob-debug/SKILL.md
@@ -44,7 +44,7 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Required First Calls
 After resolving `target_domain`, call both telemetry MCPs before drawing conclusions:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: true, limit: 100 })
 bounty_read_tool_telemetry({ target_domain, include_agent_runs: true, limit: 100 })
 bounty_read_session_summary({ target_domain })

--- a/.claude/skills/bob-status/SKILL.md
+++ b/.claude/skills/bob-status/SKILL.md
@@ -40,13 +40,13 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Read Order
 First, read the passive update cache if the helper is installed:
-```
+```bash
 node "${CLAUDE_PROJECT_DIR:-$PWD}/.claude/hooks/bob-update.js" status "${CLAUDE_PROJECT_DIR:-$PWD}" --json
 ```
 This command must only read the local update cache. Do not run network update checks from `/bob-status`.
 
 After resolving `target_domain`, call:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: false, limit: 20 })
 bounty_read_session_summary({ target_domain })
 bounty_read_state_summary({ target_domain })

--- a/adapters/codex/skills/bob-debug/SKILL.md
+++ b/adapters/codex/skills/bob-debug/SKILL.md
@@ -24,7 +24,7 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Required First Calls
 After resolving `target_domain`, call both telemetry MCPs before drawing conclusions:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: true, limit: 100 })
 bounty_read_tool_telemetry({ target_domain, include_agent_runs: true, limit: 100 })
 bounty_read_session_summary({ target_domain })

--- a/adapters/codex/skills/bob-status/SKILL.md
+++ b/adapters/codex/skills/bob-status/SKILL.md
@@ -22,13 +22,13 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Read Order
 First, read the passive update cache if the helper is installed:
-```
+```bash
 node -e "const update=require('./mcp/lib/update-check.js'); console.log(JSON.stringify(update.readUpdateCache(process.cwd()) || null, null, 2));"
 ```
 This command must only read the local update cache. Do not run network update checks from `$bob-status`.
 
 After resolving `target_domain`, call:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: false, limit: 20 })
 bounty_read_session_summary({ target_domain })
 bounty_read_state_summary({ target_domain })

--- a/adapters/kimi/skills/bob-debug/SKILL.md
+++ b/adapters/kimi/skills/bob-debug/SKILL.md
@@ -25,7 +25,7 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Required First Calls
 After resolving `target_domain`, call both telemetry MCPs before drawing conclusions:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: true, limit: 100 })
 bounty_read_tool_telemetry({ target_domain, include_agent_runs: true, limit: 100 })
 bounty_read_session_summary({ target_domain })

--- a/adapters/kimi/skills/bob-status/SKILL.md
+++ b/adapters/kimi/skills/bob-status/SKILL.md
@@ -23,13 +23,13 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Read Order
 First, read the passive update cache if the helper is installed:
-```
+```bash
 node -e "const update=require('./mcp/lib/update-check.js'); console.log(JSON.stringify(update.readUpdateCache(process.cwd()) || null, null, 2));"
 ```
 This command must only read the local update cache. Do not run network update checks from `/skill:bob-status`.
 
 After resolving `target_domain`, call:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: false, limit: 20 })
 bounty_read_session_summary({ target_domain })
 bounty_read_state_summary({ target_domain })

--- a/prompts/roles/debug.md
+++ b/prompts/roles/debug.md
@@ -19,7 +19,7 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Required First Calls
 After resolving `target_domain`, call both telemetry MCPs before drawing conclusions:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: true, limit: 100 })
 bounty_read_tool_telemetry({ target_domain, include_agent_runs: true, limit: 100 })
 bounty_read_session_summary({ target_domain })

--- a/prompts/roles/status.md
+++ b/prompts/roles/status.md
@@ -17,13 +17,13 @@ Latest-session detection must pick the newest target directory by `pipeline-even
 
 ## Read Order
 First, read the passive update cache if the helper is installed:
-```
+```bash
 {{STATUS_UPDATE_CACHE_COMMAND}}
 ```
 This command must only read the local update cache. Do not run network update checks from `/bob-status`.
 
 After resolving `target_domain`, call:
-```
+```text
 bounty_read_pipeline_analytics({ target_domain, include_events: false, limit: 20 })
 bounty_read_session_summary({ target_domain })
 bounty_read_state_summary({ target_domain })


### PR DESCRIPTION
## Summary
- label shared debug/status role code fences with explicit markdown languages
- regenerate Claude, Codex, and Kimi skill outputs from the shared role templates

## Test Plan
- node scripts/generate-claude-roles.js --check
- node scripts/generate-codex-skills.js --check
- node scripts/generate-kimi-roles.js --check
- npm run test:prompts
- node bin/hacker-bob.js --help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced markdown formatting in skill documentation with proper code fence language specifications
  * Reorganized instruction flow and removed duplicate content for improved clarity
  * Updated documentation structure to improve readability across multiple configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->