### PR TITLE
Harden installer writes against symlinks

### DIFF
--- a/adapters/claude/index.js
+++ b/adapters/claude/index.js
@@ -12,6 +12,7 @@ const {
 const {
   updateClaudeRoleFiles,
 } = require("../../scripts/lib/claude-role-renderer.js");
+const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
 
 const id = "claude";
 const DEFAULT_ROOT = path.join(__dirname, "..", "..");
@@ -351,54 +352,65 @@ function install({
   removeIfExists,
   serverPath,
   writeJson,
+  installFs,
 }) {
+  const safeFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
+  const safeReadJsonIfExists = readJsonIfExists || ((filePath, fallback) => safeFs.readJsonIfExists(filePath, fallback, {
+    kind: "config file",
+    symlink: "reject",
+  }));
+  const safeWriteJson = writeJson || ((filePath, value, optionsForFile = {}) => safeFs.writeJson(filePath, value, optionsForFile));
+  const safeRemoveIfExists = removeIfExists || ((filePath) => safeFs.removePath(filePath));
+  const safeCopyDirFiles = copyDirFiles || ((sourceDir, destinationDir, predicate) => safeFs.copyDirFiles(sourceDir, destinationDir, predicate));
+  const safeCopyFile = copyFile || ((source, destination, mode) => safeFs.copyFile(source, destination, mode));
   const claudeDir = path.join(targetAbs, ".claude");
-  fsSafeMkdir(claudeDir);
+  safeFs.mkdirp(claudeDir);
   for (const dirname of ["agents", "commands", "rules", "hooks", "skills", "bob"]) {
-    fsSafeMkdir(path.join(claudeDir, dirname));
+    safeFs.mkdirp(path.join(claudeDir, dirname));
   }
   for (const hook of STALE_HOOK_FILES) {
-    removeIfExists(path.join(claudeDir, "hooks", hook));
+    safeRemoveIfExists(path.join(claudeDir, "hooks", hook));
   }
 
-  const agents = copyDirFiles(
+  const agents = safeCopyDirFiles(
     path.join(sourceRoot, ".claude", "agents"),
     path.join(claudeDir, "agents"),
     (name) => name.endsWith(".md"),
   );
 
-  removeIfExists(path.join(claudeDir, "commands", "bountyagent.md"));
-  removeIfExists(path.join(claudeDir, "commands", "bountyagentdebug.md"));
+  safeRemoveIfExists(path.join(claudeDir, "commands", "bountyagent.md"));
+  safeRemoveIfExists(path.join(claudeDir, "commands", "bountyagentdebug.md"));
   for (const legacyCommand of LEGACY_BOB_COMMAND_FILES) {
-    removeIfExists(path.join(claudeDir, "commands", "bob", legacyCommand));
+    safeRemoveIfExists(path.join(claudeDir, "commands", "bob", legacyCommand));
   }
-  removeEmptyDirIfExists(path.join(claudeDir, "commands", "bob"));
+  safeFs.removeEmptyDirIfExists(path.join(claudeDir, "commands", "bob"));
   for (const legacySkill of LEGACY_BOB_SKILLS) {
-    fs.rmSync(path.join(claudeDir, "skills", legacySkill), { force: true, recursive: true });
+    safeFs.removePath(path.join(claudeDir, "skills", legacySkill), { recursive: true });
   }
   for (const commandId of commandIds()) {
-    writeTextFile(
+    safeFs.writeTextFile(
       path.join(claudeDir, "commands", commandSpec(commandId).file),
       renderCommand(commandId),
+      { kind: "generated file" },
     );
   }
 
   // Copy static command files (not renderer-driven). bob-egress.md is hand-
   // authored and shipped verbatim; the renderer pattern is only used for
   // commands that have dynamic per-host content like bob-update.md.
-  copyFile(
+  safeCopyFile(
     path.join(sourceRoot, ".claude", "commands", "bob-egress.md"),
     path.join(claudeDir, "commands", "bob-egress.md"),
   );
 
   for (const skill of BOB_SKILLS) {
-    copyFile(
+    safeCopyFile(
       path.join(sourceRoot, ".claude", "skills", skill, "SKILL.md"),
       path.join(claudeDir, "skills", skill, "SKILL.md"),
     );
   }
 
-  const rules = copyDirFiles(
+  const rules = safeCopyDirFiles(
     path.join(sourceRoot, ".claude", "rules"),
     path.join(claudeDir, "rules"),
     (name) => name.endsWith(".md"),
@@ -406,7 +418,7 @@ function install({
 
   for (const hook of HOOK_FILES) {
     const mode = EXECUTABLE_HOOKS.includes(hook) ? 0o755 : undefined;
-    copyFile(
+    safeCopyFile(
       path.join(sourceRoot, ".claude", "hooks", hook),
       path.join(claudeDir, "hooks", hook),
       mode,
@@ -421,22 +433,30 @@ function install({
     ensureEgressProfilesConfig,
     ensureEgressProfilesExample,
   } = require("../../mcp/lib/egress-profiles.js");
-  ensureEgressProfilesExample(targetAbs);
-  ensureEgressProfilesConfig(targetAbs);
+  ensureEgressProfilesExample(targetAbs, { installFs: safeFs });
+  ensureEgressProfilesConfig(targetAbs, { installFs: safeFs });
 
   const mcpPath = path.join(targetAbs, ".mcp.json");
   const settingsPath = path.join(claudeDir, "settings.json");
   const mergedConfig = mergeConfig({
-    existingMcp: readJsonIfExists(mcpPath, {}),
-    existingSettings: readJsonIfExists(settingsPath, {}),
+    existingMcp: safeReadJsonIfExists(mcpPath, {}),
+    existingSettings: safeReadJsonIfExists(settingsPath, {}),
     serverPath,
   });
-  writeJson(mcpPath, mergedConfig.mcp);
-  writeJson(settingsPath, mergedConfig.settings);
+  safeWriteJson(mcpPath, mergedConfig.mcp, {
+    kind: ".mcp.json",
+    rejectExistingSymlink: true,
+  });
+  safeWriteJson(settingsPath, mergedConfig.settings, {
+    kind: ".claude/settings.json",
+    rejectExistingSymlink: true,
+  });
 
   const installManifest = manifest || {};
-  fs.writeFileSync(path.join(claudeDir, "bob", "VERSION"), `${installManifest.version || "0.0.0"}\n`, "utf8");
-  writeJson(path.join(claudeDir, "bob", "install.json"), {
+  safeFs.writeTextFile(path.join(claudeDir, "bob", "VERSION"), `${installManifest.version || "0.0.0"}\n`, {
+    kind: ".claude/bob/VERSION",
+  });
+  safeWriteJson(path.join(claudeDir, "bob", "install.json"), {
     schema_version: 1,
     bob_version: installManifest.version || "0.0.0",
     installed_at: installedAt || new Date().toISOString(),
@@ -814,12 +834,3 @@ module.exports = {
   uninstall,
   updateCommandFiles,
 };
-
-function fsSafeMkdir(dirPath) {
-  fs.mkdirSync(dirPath, { recursive: true });
-}
-
-function removeEmptyDirIfExists(dirPath) {
-  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) return;
-  if (fs.readdirSync(dirPath).length === 0) fs.rmdirSync(dirPath);
-}

--- a/adapters/codex/index.js
+++ b/adapters/codex/index.js
@@ -7,6 +7,7 @@ const {
   CODEX_SKILL_SPECS,
   updateCodexSkillFiles,
 } = require("../../scripts/lib/codex-role-renderer.js");
+const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
 
 const id = "codex";
 const PLUGIN_NAME = "hacker-bob";
@@ -106,11 +107,6 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-function writeText(filePath, value) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, value, "utf8");
-}
-
 function fileExists(filePath) {
   try {
     return fs.statSync(filePath).isFile();
@@ -143,35 +139,6 @@ function sourceTreeFiles(sourceRoot, relativeDir) {
   };
   visit(root);
   return files.sort();
-}
-
-function copyTree(sourceDir, destinationDir) {
-  const copied = [];
-  const visit = (current) => {
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      const source = path.join(current, entry.name);
-      const relative = path.relative(sourceDir, source);
-      const destination = path.join(destinationDir, relative);
-      if (entry.isDirectory()) {
-        fs.mkdirSync(destination, { recursive: true });
-        visit(source);
-      } else if (entry.isFile()) {
-        fs.mkdirSync(path.dirname(destination), { recursive: true });
-        fs.copyFileSync(source, destination);
-        copied.push(relative);
-      }
-    }
-  };
-  fs.mkdirSync(destinationDir, { recursive: true });
-  visit(sourceDir);
-  return copied.sort();
-}
-
-function removeDirContents(dirPath) {
-  if (!dirExists(dirPath)) return;
-  for (const entry of fs.readdirSync(dirPath)) {
-    fs.rmSync(path.join(dirPath, entry), { recursive: true, force: true });
-  }
 }
 
 function managedFiles(sourceRoot) {
@@ -257,9 +224,13 @@ function renderCommand(commandId) {
   ].join("\n");
 }
 
-function writeCommandFiles(pluginDir) {
+function writeCommandFiles(pluginDir, installFs) {
   for (const commandId of commandIds()) {
-    writeText(path.join(pluginDir, "commands", commandSpec(commandId).file), renderCommand(commandId));
+    installFs.writeTextFile(
+      path.join(pluginDir, "commands", commandSpec(commandId).file),
+      renderCommand(commandId),
+      { kind: "generated file" },
+    );
   }
 }
 
@@ -310,10 +281,16 @@ function mergeMarketplace(existing) {
   };
 }
 
-function installMarketplace(targetAbs) {
+function installMarketplace(targetAbs, installFs) {
   const marketplacePath = path.join(targetAbs, MARKETPLACE_PATH);
-  const existing = fileExists(marketplacePath) ? readJson(marketplacePath) : null;
-  writeJson(marketplacePath, mergeMarketplace(existing));
+  const existing = installFs.readJsonIfExists(marketplacePath, null, {
+    kind: MARKETPLACE_PATH,
+    symlink: "reject",
+  });
+  installFs.writeJson(marketplacePath, mergeMarketplace(existing), {
+    kind: MARKETPLACE_PATH,
+    rejectExistingSymlink: true,
+  });
 }
 
 function codexHome() {
@@ -332,27 +309,26 @@ function directSkillTargetPath(spec, home = codexHome()) {
   return path.join(directSkillTargetDir(spec, home), "SKILL.md");
 }
 
-function removeStalePluginSurfaces(pluginDir) {
-  fs.rmSync(path.join(pluginDir, "skills"), { recursive: true, force: true });
+function removeStalePluginSurfaces(pluginDir, installFs) {
+  installFs.removePath(path.join(pluginDir, "skills"), { recursive: true });
   for (const file of STALE_COMMAND_FILES) {
-    fs.rmSync(path.join(pluginDir, "commands", file), { force: true });
+    installFs.removePath(path.join(pluginDir, "commands", file));
   }
 }
 
-function removeLegacyDirectSkillDirs(home = codexHome()) {
+function removeLegacyDirectSkillDirs(home = codexHome(), installFs = createSafeInstallFs(home, { label: "CODEX_HOME", createRoot: true })) {
   for (const dir of LEGACY_SKILL_DIRS) {
-    fs.rmSync(path.join(directSkillTargetRoot(home), dir), { recursive: true, force: true });
+    installFs.removePath(path.join(directSkillTargetRoot(home), dir), { recursive: true });
   }
 }
 
-function installDirectSkills(sourceRoot, home = codexHome()) {
+function installDirectSkills(sourceRoot, home = codexHome(), installFs = createSafeInstallFs(home, { label: "CODEX_HOME", createRoot: true })) {
   const copied = [];
-  removeLegacyDirectSkillDirs(home);
+  removeLegacyDirectSkillDirs(home, installFs);
   for (const spec of Object.values(CODEX_SKILL_SPECS)) {
     const source = path.join(sourceRoot, spec.output_path);
     const destination = directSkillTargetPath(spec, home);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.copyFileSync(source, destination);
+    installFs.copyFile(source, destination);
     copied.push(destination);
   }
   return copied.sort();
@@ -457,17 +433,21 @@ function codexCacheRoot({ home = codexHome(), version }) {
   return path.join(home, "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME, version);
 }
 
-function activateCodexPlugin({ targetAbs, pluginDir }) {
+function activateCodexPlugin({ targetAbs, pluginDir, homeFs }) {
   const home = codexHome();
   const configPath = codexConfigPath(home);
   const version = pluginVersion(pluginDir);
   const cacheBase = path.join(home, "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME);
   const cacheDir = codexCacheRoot({ home, version });
-  fs.mkdirSync(cacheBase, { recursive: true });
-  removeDirContents(cacheBase);
-  copyTree(pluginDir, cacheDir);
+  const safeHomeFs = homeFs || createSafeInstallFs(home, { label: "CODEX_HOME", createRoot: true });
+  safeHomeFs.mkdirp(cacheBase);
+  safeHomeFs.removeDirContents(cacheBase);
+  safeHomeFs.copyTree(pluginDir, cacheDir);
 
-  const existingConfig = fileExists(configPath) ? fs.readFileSync(configPath, "utf8") : "";
+  const existingConfig = safeHomeFs.readTextIfExists(configPath, "", {
+    kind: "Codex config",
+    symlink: "reject",
+  });
   const withPlugin = upsertTomlSection(existingConfig, `[plugins.${tomlString(PLUGIN_CONFIG_ID)}]`, [
     "enabled = true",
   ]);
@@ -476,8 +456,10 @@ function activateCodexPlugin({ targetAbs, pluginDir }) {
     "source_type = \"local\"",
     `source = ${tomlString(targetAbs)}`,
   ]);
-  fs.mkdirSync(path.dirname(configPath), { recursive: true });
-  fs.writeFileSync(configPath, withMarketplace, "utf8");
+  safeHomeFs.writeTextFile(configPath, withMarketplace, {
+    kind: "Codex config",
+    rejectExistingSymlink: true,
+  });
   return {
     ok: true,
     cacheDir,
@@ -486,12 +468,12 @@ function activateCodexPlugin({ targetAbs, pluginDir }) {
   };
 }
 
-function maybeActivateCodexPlugin({ activate, targetAbs, pluginDir }) {
+function maybeActivateCodexPlugin({ activate, targetAbs, pluginDir, homeFs }) {
   if (!activate) {
     return { ok: false, skipped: true, reason: "activation disabled" };
   }
   try {
-    return activateCodexPlugin({ targetAbs, pluginDir });
+    return activateCodexPlugin({ targetAbs, pluginDir, homeFs });
   } catch (error) {
     return {
       ok: false,
@@ -526,20 +508,25 @@ function codexActivationStatus(targetAbs) {
   };
 }
 
-function install({ sourceRoot, targetAbs, serverPath, activate = false }) {
+function install({ sourceRoot, targetAbs, serverPath, activate = false, installFs }) {
+  const projectFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
+  const home = codexHome();
+  const homeFs = createSafeInstallFs(home, { label: "CODEX_HOME", createRoot: true });
   const source = pluginSourceRoot(sourceRoot);
   const destination = pluginTargetRoot(targetAbs);
-  removeStalePluginSurfaces(destination);
-  const copied = copyTree(source, destination);
-  writeCommandFiles(destination);
-  writeJson(path.join(destination, ".mcp.json"), mergeConfig({ serverPath }));
-  installMarketplace(targetAbs);
-  const directSkills = installDirectSkills(sourceRoot);
-  const activation = maybeActivateCodexPlugin({ activate, targetAbs, pluginDir: destination });
+  removeStalePluginSurfaces(destination, projectFs);
+  const copied = projectFs.copyTree(source, destination);
+  writeCommandFiles(destination, projectFs);
+  projectFs.writeJson(path.join(destination, ".mcp.json"), mergeConfig({ serverPath }), {
+    kind: "generated file",
+  });
+  installMarketplace(targetAbs, projectFs);
+  const directSkills = installDirectSkills(sourceRoot, home, homeFs);
+  const activation = maybeActivateCodexPlugin({ activate, targetAbs, pluginDir: destination, homeFs });
   return {
     activation,
     commands: commandIds().length,
-    codexSkillDir: directSkillTargetRoot(),
+    codexSkillDir: directSkillTargetRoot(home),
     pluginDir: destination,
     files: copied.length,
     skills: directSkills.length,

--- a/adapters/generic-mcp/index.js
+++ b/adapters/generic-mcp/index.js
@@ -3,6 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
+const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
 
 const id = "generic-mcp";
 const PROMPT_SOURCE_DIR = path.join("adapters", "generic-mcp", "prompts");
@@ -73,21 +74,25 @@ function managedDirs() {
   ];
 }
 
-function copyPromptDocs(sourceRoot, targetAbs) {
+function copyPromptDocs(sourceRoot, targetAbs, installFs) {
   let copied = 0;
   for (const name of PROMPT_FILES) {
     const source = path.join(sourceRoot, PROMPT_SOURCE_DIR, name);
     const destination = path.join(targetAbs, PROMPT_TARGET_DIR, name);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.copyFileSync(source, destination);
+    installFs.copyFile(source, destination);
     copied += 1;
   }
   return copied;
 }
 
-function install({ sourceRoot, targetAbs, serverPath, readJsonIfExists }) {
+function install({ sourceRoot, targetAbs, serverPath, readJsonIfExists, installFs }) {
+  const safeFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
+  const safeReadJsonIfExists = readJsonIfExists || ((filePath, fallback) => safeFs.readJsonIfExists(filePath, fallback, {
+    kind: "config file",
+    symlink: "reject",
+  }));
   const mcpPath = path.join(targetAbs, ".mcp.json");
-  const existing = readJsonIfExists ? readJsonIfExists(mcpPath, {}) : fileExists(mcpPath) ? readJson(mcpPath) : {};
+  const existing = safeReadJsonIfExists(mcpPath, {});
   const next = {
     ...existing,
     mcpServers: {
@@ -95,9 +100,12 @@ function install({ sourceRoot, targetAbs, serverPath, readJsonIfExists }) {
       ...mergeConfig({ serverPath }).mcpServers,
     },
   };
-  writeJson(mcpPath, next);
+  safeFs.writeJson(mcpPath, next, {
+    kind: ".mcp.json",
+    rejectExistingSymlink: true,
+  });
   return {
-    promptDocs: copyPromptDocs(sourceRoot, targetAbs),
+    promptDocs: copyPromptDocs(sourceRoot, targetAbs, safeFs),
     mcpPath,
   };
 }

--- a/adapters/kimi/index.js
+++ b/adapters/kimi/index.js
@@ -7,6 +7,7 @@ const config = require("./config.js");
 const {
   updateKimiSkillFiles,
 } = require("../../scripts/lib/kimi-role-renderer.js");
+const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
 
 const id = "kimi";
 const DEFAULT_ROOT = path.join(__dirname, "..", "..");
@@ -69,31 +70,6 @@ function render(options = {}) {
   return updateKimiSkillFiles(options);
 }
 
-function copyFile(source, destination, mode) {
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
-  fs.copyFileSync(source, destination);
-  if (mode != null) fs.chmodSync(destination, mode);
-}
-
-function copyDirFiles(sourceDir, destinationDir, predicate) {
-  fs.mkdirSync(destinationDir, { recursive: true });
-  const copied = [];
-  for (const name of fs.readdirSync(sourceDir).sort()) {
-    const source = path.join(sourceDir, name);
-    if (!fs.statSync(source).isFile()) continue;
-    if (predicate && !predicate(name)) continue;
-    const destination = path.join(destinationDir, name);
-    copyFile(source, destination);
-    copied.push(name);
-  }
-  return copied;
-}
-
-function readJsonIfExists(filePath, fallback) {
-  if (!fs.existsSync(filePath)) return fallback;
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
-}
-
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
@@ -117,25 +93,30 @@ function install({
   commitSha,
   installedAt,
   installerSource,
+  installFs,
   manifest,
   packageName,
 }) {
+  const safeFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
   const kimiDir = path.join(targetAbs, ".kimi");
-  fs.mkdirSync(kimiDir, { recursive: true });
+  safeFs.mkdirp(kimiDir);
   for (const dirname of ["skills", "bob"]) {
-    fs.mkdirSync(path.join(kimiDir, dirname), { recursive: true });
+    safeFs.mkdirp(path.join(kimiDir, dirname));
   }
 
   for (const skill of BOB_SKILLS) {
     const sourceSkillDir = path.join(sourceRoot, "adapters", "kimi", "skills", skill);
     const targetSkillDir = path.join(kimiDir, "skills", skill);
     if (fs.existsSync(sourceSkillDir)) {
-      copyDirFiles(sourceSkillDir, targetSkillDir, () => true);
+      safeFs.copyDirFiles(sourceSkillDir, targetSkillDir, () => true);
     }
   }
 
   const mcpPath = path.join(targetAbs, ".kimi", "mcp.json");
-  const existingMcp = readJsonIfExists(mcpPath, {});
+  const existingMcp = safeFs.readJsonIfExists(mcpPath, {}, {
+    kind: ".kimi/mcp.json",
+    symlink: "reject",
+  });
   const nextMcp = {
     ...existingMcp,
     mcpServers: {
@@ -143,11 +124,16 @@ function install({
       ...mergeConfig({ serverPath }).mcpServers,
     },
   };
-  writeJson(mcpPath, nextMcp);
+  safeFs.writeJson(mcpPath, nextMcp, {
+    kind: ".kimi/mcp.json",
+    rejectExistingSymlink: true,
+  });
 
   const installManifest = manifest || {};
-  fs.writeFileSync(path.join(kimiDir, "bob", "VERSION"), `${installManifest.version || "0.0.0"}\n`, "utf8");
-  writeJson(path.join(kimiDir, "bob", "install.json"), {
+  safeFs.writeTextFile(path.join(kimiDir, "bob", "VERSION"), `${installManifest.version || "0.0.0"}\n`, {
+    kind: ".kimi/bob/VERSION",
+  });
+  safeFs.writeJson(path.join(kimiDir, "bob", "install.json"), {
     schema_version: 1,
     bob_version: installManifest.version || "0.0.0",
     installed_at: installedAt || new Date().toISOString(),

--- a/mcp/lib/egress-profiles.js
+++ b/mcp/lib/egress-profiles.js
@@ -209,7 +209,7 @@ function ensureEgressProfilesConfig(projectRoot = projectRootFromMcp(), options 
       kind: EGRESS_PROFILES_FILE,
       symlink: "reject",
     });
-    if (!existing) {
+    if (existing == null) {
       writeEgressProfilesDocument(projectRoot, defaultEgressProfilesDocument(), options);
       return { created: true, path: filePath };
     }
@@ -229,6 +229,7 @@ function ensureEgressProfilesExample(projectRoot = projectRootFromMcp(), options
   if (options.installFs) {
     options.installFs.writeJson(filePath, exampleEgressProfilesDocument(), {
       kind: EGRESS_PROFILES_EXAMPLE_FILE,
+      rejectExistingSymlink: true,
     });
   } else {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/mcp/lib/egress-profiles.js
+++ b/mcp/lib/egress-profiles.js
@@ -187,28 +187,53 @@ function readEgressProfilesDocument(projectRoot = projectRootFromMcp()) {
   return normalizeEgressProfilesDocument(parsed);
 }
 
-function writeEgressProfilesDocument(projectRoot, document) {
+function writeEgressProfilesDocument(projectRoot, document, options = {}) {
   const normalized = normalizeEgressProfilesDocument(document);
   const filePath = egressProfilesPath(projectRoot);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+  if (options.installFs) {
+    options.installFs.writeJson(filePath, normalized, {
+      kind: EGRESS_PROFILES_FILE,
+      rejectExistingSymlink: true,
+    });
+  } else {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+  }
   return normalized;
 }
 
-function ensureEgressProfilesConfig(projectRoot = projectRootFromMcp()) {
+function ensureEgressProfilesConfig(projectRoot = projectRootFromMcp(), options = {}) {
   const filePath = egressProfilesPath(projectRoot);
+  if (options.installFs) {
+    const existing = options.installFs.readJsonIfExists(filePath, null, {
+      kind: EGRESS_PROFILES_FILE,
+      symlink: "reject",
+    });
+    if (!existing) {
+      writeEgressProfilesDocument(projectRoot, defaultEgressProfilesDocument(), options);
+      return { created: true, path: filePath };
+    }
+    normalizeEgressProfilesDocument(existing);
+    return { created: false, path: filePath };
+  }
   if (!fs.existsSync(filePath)) {
-    writeEgressProfilesDocument(projectRoot, defaultEgressProfilesDocument());
+    writeEgressProfilesDocument(projectRoot, defaultEgressProfilesDocument(), options);
     return { created: true, path: filePath };
   }
   normalizeEgressProfilesDocument(readJsonFile(filePath, { label: EGRESS_PROFILES_FILE }));
   return { created: false, path: filePath };
 }
 
-function ensureEgressProfilesExample(projectRoot = projectRootFromMcp()) {
+function ensureEgressProfilesExample(projectRoot = projectRootFromMcp(), options = {}) {
   const filePath = egressProfilesExamplePath(projectRoot);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(exampleEgressProfilesDocument(), null, 2)}\n`, "utf8");
+  if (options.installFs) {
+    options.installFs.writeJson(filePath, exampleEgressProfilesDocument(), {
+      kind: EGRESS_PROFILES_EXAMPLE_FILE,
+    });
+  } else {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(exampleEgressProfilesDocument(), null, 2)}\n`, "utf8");
+  }
   return filePath;
 }
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -12,6 +12,7 @@ const {
   getAdapter,
 } = require("../adapters/index.js");
 const { clearUpdateCache } = require("../mcp/lib/update-check.js");
+const { createSafeInstallFs } = require("./lib/install-fs.js");
 
 const BOB_RESOURCE_DIR = ".hacker-bob";
 const NEUTRAL_INSTALL_SCHEMA_VERSION = 2;
@@ -52,13 +53,12 @@ function readJsonIfExists(filePath, fallback) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
-function writeJson(filePath, value) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-function readNeutralInstallMetadata(targetAbs, fallback = null) {
-  return readJsonIfExists(neutralInstallMetadataPath(targetAbs), fallback);
+function readNeutralInstallMetadata(targetAbs, fallback = null, installFs = null) {
+  const safeFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
+  return safeFs.readJsonIfExists(neutralInstallMetadataPath(targetAbs), fallback, {
+    kind: ".hacker-bob/install.json",
+    symlink: "missing",
+  });
 }
 
 function detectInstalledAdapterIds(targetAbs) {
@@ -86,10 +86,10 @@ function detectInstalledAdapterIds(targetAbs) {
   return normalizeAdapterIdList(ids);
 }
 
-function installedAdapterIds(targetAbs) {
+function installedAdapterIds(targetAbs, installFs = null) {
   let metadata = null;
   try {
-    metadata = readNeutralInstallMetadata(targetAbs, null);
+    metadata = readNeutralInstallMetadata(targetAbs, null, installFs);
   } catch {
     metadata = null;
   }
@@ -103,6 +103,7 @@ function installedAdapterIds(targetAbs) {
 }
 
 function writeNeutralInstallMetadata({
+  installFs,
   targetAbs,
   manifest,
   installedAt,
@@ -114,10 +115,15 @@ function writeNeutralInstallMetadata({
   const installManifest = manifest || {};
   const version = installManifest.version || "0.0.0";
   const metadataPath = neutralInstallMetadataPath(targetAbs);
-  const existing = readJsonIfExists(metadataPath, {});
-  fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
-  fs.writeFileSync(neutralVersionPath(targetAbs), `${version}\n`, "utf8");
-  writeJson(metadataPath, {
+  const safeFs = installFs || createSafeInstallFs(targetAbs, { label: "install target" });
+  const existing = safeFs.readJsonIfExists(metadataPath, {}, {
+    kind: ".hacker-bob/install.json",
+    symlink: "missing",
+  });
+  safeFs.writeTextFile(neutralVersionPath(targetAbs), `${version}\n`, {
+    kind: ".hacker-bob/VERSION",
+  });
+  safeFs.writeJson(metadataPath, {
     schema_version: NEUTRAL_INSTALL_SCHEMA_VERSION,
     bob_version: version,
     installed_at: existing.installed_at || installedAt || new Date().toISOString(),
@@ -130,53 +136,25 @@ function writeNeutralInstallMetadata({
   });
 }
 
-function copyFile(source, destination, mode) {
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
-  fs.copyFileSync(source, destination);
-  if (mode != null) fs.chmodSync(destination, mode);
+function copyFile(installFs, source, destination, mode) {
+  installFs.copyFile(source, destination, mode);
 }
 
-function copyDirRecursive(sourceDir, destinationDir, predicate) {
-  fs.mkdirSync(destinationDir, { recursive: true });
-  const copied = [];
-  for (const name of fs.readdirSync(sourceDir).sort()) {
-    const source = path.join(sourceDir, name);
-    const destination = path.join(destinationDir, name);
-    const stat = fs.statSync(source);
-    if (stat.isDirectory()) {
-      if (name === "node_modules") continue;
-      copied.push(...copyDirRecursive(source, destination, predicate));
-      continue;
-    }
-    if (!stat.isFile()) continue;
-    const relative = path.relative(sourceDir, source);
-    if (predicate && !predicate(relative, name)) continue;
-    copyFile(source, destination);
-    copied.push(path.relative(destinationDir, destination));
-  }
-  return copied;
+function copyDirRecursive(installFs, sourceDir, destinationDir, predicate) {
+  return installFs.copyDirRecursive(sourceDir, destinationDir, predicate);
 }
 
-function copyDirFiles(sourceDir, destinationDir, predicate) {
-  fs.mkdirSync(destinationDir, { recursive: true });
-  const copied = [];
-  for (const name of fs.readdirSync(sourceDir).sort()) {
-    const source = path.join(sourceDir, name);
-    if (!fs.statSync(source).isFile()) continue;
-    if (predicate && !predicate(name)) continue;
-    const destination = path.join(destinationDir, name);
-    copyFile(source, destination);
-    copied.push(name);
-  }
-  return copied;
+function copyDirFiles(installFs, sourceDir, destinationDir, predicate) {
+  return installFs.copyDirFiles(sourceDir, destinationDir, predicate);
 }
 
-function copyResourceSet(sourceRoot, targetAbs, resourceSet) {
+function copyResourceSet(installFs, sourceRoot, targetAbs, resourceSet) {
   const sourceDir = path.join(sourceRoot, resourceSet.source);
   if (!fs.existsSync(sourceDir)) {
     throw new Error(resourceSet.missingMessage);
   }
   const copied = copyDirFiles(
+    installFs,
     sourceDir,
     path.join(targetAbs, resourceSet.destination),
     resourceSet.predicate,
@@ -187,7 +165,7 @@ function copyResourceSet(sourceRoot, targetAbs, resourceSet) {
   return copied;
 }
 
-function copyRuntimeNodeDependencies(sourceRoot, mcpDir) {
+function copyRuntimeNodeDependencies(installFs, sourceRoot, mcpDir) {
   const manifest = packageManifest(sourceRoot);
   const copied = [];
   const queued = [];
@@ -217,8 +195,8 @@ function copyRuntimeNodeDependencies(sourceRoot, mcpDir) {
     }
     const destinationDir = path.join(targetNodeModules, packageName);
     if (path.resolve(sourceDir) === path.resolve(destinationDir)) continue;
-    fs.rmSync(destinationDir, { recursive: true, force: true });
-    copied.push(...copyDirRecursive(sourceDir, destinationDir).map((file) => path.join(packageName, file)));
+    installFs.removePath(destinationDir, { recursive: true });
+    copied.push(...copyDirRecursive(installFs, sourceDir, destinationDir).map((file) => path.join(packageName, file)));
   }
   return copied;
 }
@@ -234,29 +212,28 @@ function sourceResourceNames(sourceRoot, resourceSet) {
     });
 }
 
-function removeEmptyDirIfExists(dirPath) {
-  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) return;
-  if (fs.readdirSync(dirPath).length === 0) fs.rmdirSync(dirPath);
+function removeEmptyDirIfExists(installFs, dirPath) {
+  installFs.removeEmptyDirIfExists(dirPath);
 }
 
-function removeLegacyResourceCopies(sourceRoot, targetAbs) {
+function removeLegacyResourceCopies(installFs, sourceRoot, targetAbs) {
   let removed = 0;
   for (const resourceSet of RESOURCE_SETS) {
     const legacyDir = path.join(targetAbs, ".claude", path.basename(resourceSet.destination));
     for (const name of sourceResourceNames(sourceRoot, resourceSet)) {
       const legacyPath = path.join(legacyDir, name);
-      if (fs.existsSync(legacyPath) && fs.statSync(legacyPath).isFile()) {
-        fs.rmSync(legacyPath, { force: true });
+      if (installFs.fileExists(legacyPath)) {
+        installFs.removePath(legacyPath);
         removed += 1;
       }
     }
-    removeEmptyDirIfExists(legacyDir);
+    removeEmptyDirIfExists(installFs, legacyDir);
   }
   return removed;
 }
 
-function removeIfExists(filePath) {
-  fs.rmSync(filePath, { force: true });
+function removeIfExists(installFs, filePath) {
+  installFs.removePath(filePath);
 }
 
 function packageManifest(sourceRoot) {
@@ -317,7 +294,7 @@ function resolveInstallAdapters(targetAbs, options = {}) {
 
   let existing = [];
   try {
-    existing = installedAdapterIds(targetAbs);
+    existing = installedAdapterIds(targetAbs, options.installFs || null);
   } catch {
     existing = [];
   }
@@ -348,35 +325,39 @@ function installProject(projectDir, options = {}) {
   if (!fs.existsSync(targetAbs) || !fs.statSync(targetAbs).isDirectory()) {
     throw new Error(`Install target does not exist or is not a directory: ${targetAbs}`);
   }
+  const installFs = createSafeInstallFs(targetAbs, { label: "install target" });
 
-  const adapterResolution = resolveInstallAdapters(targetAbs, options);
+  const adapterResolution = resolveInstallAdapters(targetAbs, {
+    ...options,
+    installFs,
+  });
   const adapterIds = adapterResolution.ids;
   const logResolution = options.onAdapterResolution || defaultLogResolution;
   logResolution(adapterResolution);
 
-  const existingAdapters = installedAdapterIds(targetAbs);
-  fs.mkdirSync(bobResourceDir, { recursive: true });
+  const existingAdapters = installedAdapterIds(targetAbs, installFs);
+  installFs.mkdirp(bobResourceDir);
 
   const copiedResources = {};
   for (const resourceSet of RESOURCE_SETS) {
-    copiedResources[resourceSet.name] = copyResourceSet(sourceRoot, targetAbs, resourceSet);
+    copiedResources[resourceSet.name] = copyResourceSet(installFs, sourceRoot, targetAbs, resourceSet);
   }
-  const legacyResourcesRemoved = removeLegacyResourceCopies(sourceRoot, targetAbs);
+  const legacyResourcesRemoved = removeLegacyResourceCopies(installFs, sourceRoot, targetAbs);
 
   const mcpDir = path.join(targetAbs, "mcp");
-  fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
+  installFs.mkdirp(path.join(mcpDir, "lib", "tools"));
   for (const file of ["server.js", "auto-signup.js", "redaction.js"]) {
-    copyFile(path.join(sourceRoot, "mcp", file), path.join(mcpDir, file));
+    const mode = file === "server.js" ? 0o755 : undefined;
+    copyFile(installFs, path.join(sourceRoot, "mcp", file), path.join(mcpDir, file), mode);
   }
-  fs.chmodSync(path.join(mcpDir, "server.js"), 0o755);
-  copyDirFiles(path.join(sourceRoot, "mcp", "lib"), path.join(mcpDir, "lib"), (name) => name.endsWith(".js"));
+  copyDirFiles(installFs, path.join(sourceRoot, "mcp", "lib"), path.join(mcpDir, "lib"), (name) => name.endsWith(".js"));
   const sourceToolsDir = path.join(sourceRoot, "mcp", "lib", "tools");
   const targetToolsDir = path.join(mcpDir, "lib", "tools");
   if (path.resolve(sourceToolsDir) !== path.resolve(targetToolsDir)) {
-    fs.rmSync(targetToolsDir, { recursive: true, force: true });
-    copyDirFiles(sourceToolsDir, targetToolsDir, (name) => name.endsWith(".js"));
+    installFs.removePath(targetToolsDir, { recursive: true });
+    copyDirFiles(installFs, sourceToolsDir, targetToolsDir, (name) => name.endsWith(".js"));
   }
-  const copiedRuntimeDependencies = copyRuntimeNodeDependencies(sourceRoot, mcpDir);
+  const copiedRuntimeDependencies = copyRuntimeNodeDependencies(installFs, sourceRoot, mcpDir);
 
   // Policy-replay diagnostic harness. Adapter-agnostic tooling under
   // testing/policy-replay/ in the target. Skip node_modules to avoid bloat.
@@ -384,6 +365,7 @@ function installProject(projectDir, options = {}) {
   const targetPolicyReplayDir = path.join(targetAbs, "testing", "policy-replay");
   if (fs.existsSync(sourcePolicyReplayDir) && path.resolve(sourcePolicyReplayDir) !== path.resolve(targetPolicyReplayDir)) {
     copyDirRecursive(
+      installFs,
       sourcePolicyReplayDir,
       targetPolicyReplayDir,
       (relative) => /\.(?:mjs|md|json)$/.test(relative) && !relative.split(path.sep).includes("node_modules"),
@@ -401,34 +383,43 @@ function installProject(projectDir, options = {}) {
       adapterResults[adapterId] = adapter.install({
         sourceRoot,
         targetAbs,
-        copyDirFiles,
-        copyFile,
+        copyDirFiles: (...args) => copyDirFiles(installFs, ...args),
+        copyFile: (...args) => copyFile(installFs, ...args),
         commitSha,
         installedAt,
         installerSource,
+        installFs,
         manifest,
         packageName,
-        readJsonIfExists,
-        removeIfExists,
+        readJsonIfExists: (filePath, fallback) => installFs.readJsonIfExists(filePath, fallback, {
+          kind: "config file",
+          symlink: "reject",
+        }),
+        removeIfExists: (filePath) => removeIfExists(installFs, filePath),
         serverPath,
-        writeJson,
+        writeJson: (filePath, value, optionsForFile = {}) => installFs.writeJson(filePath, value, optionsForFile),
       });
     } else if (adapterId === "generic-mcp") {
       adapterResults[adapterId] = adapter.install({
+        installFs,
         sourceRoot,
         targetAbs,
-        readJsonIfExists,
+        readJsonIfExists: (filePath, fallback) => installFs.readJsonIfExists(filePath, fallback, {
+          kind: "config file",
+          symlink: "reject",
+        }),
         serverPath,
       });
     } else if (adapterId === "kimi") {
       adapterResults[adapterId] = adapter.install({
         sourceRoot,
         targetAbs,
-        copyDirFiles,
-        copyFile,
+        copyDirFiles: (...args) => copyDirFiles(installFs, ...args),
+        copyFile: (...args) => copyFile(installFs, ...args),
         commitSha,
         installedAt,
         installerSource,
+        installFs,
         manifest,
         packageName,
         serverPath,
@@ -436,6 +427,7 @@ function installProject(projectDir, options = {}) {
     } else {
       adapterResults[adapterId] = adapter.install({
         activate: options.activateCodex !== false && process.env.HACKER_BOB_CODEX_AUTO_INSTALL !== "0",
+        installFs,
         sourceRoot,
         targetAbs,
         serverPath,
@@ -448,6 +440,7 @@ function installProject(projectDir, options = {}) {
     ...adapterIds,
   ]);
   writeNeutralInstallMetadata({
+    installFs,
     targetAbs,
     manifest,
     installedAt,

--- a/scripts/lib/install-fs.js
+++ b/scripts/lib/install-fs.js
@@ -1,0 +1,345 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function pathForMessage(root, candidate) {
+  const relative = path.relative(root, candidate);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) return relative;
+  if (relative === "") return ".";
+  return candidate;
+}
+
+function defaultLabel(label) {
+  return label || "install root";
+}
+
+function lstatIfExists(candidate) {
+  try {
+    return fs.lstatSync(candidate);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function createSafeInstallFs(rootPath, options = {}) {
+  const root = path.resolve(rootPath);
+  const label = defaultLabel(options.label);
+  if (options.createRoot) {
+    fs.mkdirSync(root, { recursive: true });
+  }
+  const rootStat = lstatIfExists(root);
+  if (rootStat && rootStat.isSymbolicLink()) {
+    throw new Error(`${label} must be a real directory, not a symlink: ${root}`);
+  }
+  if (!rootStat || !rootStat.isDirectory()) {
+    throw new Error(`${label} does not exist or is not a directory: ${root}`);
+  }
+
+  function resolveInside(candidate) {
+    const absolute = path.resolve(path.isAbsolute(String(candidate))
+      ? String(candidate)
+      : path.join(root, String(candidate)));
+    if (!isInside(root, absolute)) {
+      throw new Error(`Refusing to access path outside ${label}: ${absolute}`);
+    }
+    return absolute;
+  }
+
+  function checkExistingParents(absPath) {
+    const parent = path.dirname(absPath);
+    if (parent === root) return true;
+    if (!isInside(root, parent)) {
+      throw new Error(`Refusing to access path outside ${label}: ${absPath}`);
+    }
+    const relative = path.relative(root, parent);
+    if (!relative) return true;
+    let current = root;
+    for (const part of relative.split(path.sep)) {
+      if (!part) continue;
+      current = path.join(current, part);
+      const stat = lstatIfExists(current);
+      if (!stat) return false;
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Refusing to use symlinked parent directory under ${label}: ${pathForMessage(root, current)}`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`Expected parent directory under ${label}: ${pathForMessage(root, current)}`);
+      }
+    }
+    return true;
+  }
+
+  function mkdirp(dirPath) {
+    const dir = resolveInside(dirPath);
+    if (dir === root) return dir;
+    const relative = path.relative(root, dir);
+    let current = root;
+    for (const part of relative.split(path.sep)) {
+      if (!part) continue;
+      current = path.join(current, part);
+      let stat = lstatIfExists(current);
+      if (!stat) {
+        fs.mkdirSync(current);
+        stat = fs.lstatSync(current);
+      }
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Refusing to use symlinked parent directory under ${label}: ${pathForMessage(root, current)}`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`Expected directory under ${label}: ${pathForMessage(root, current)}`);
+      }
+    }
+    return dir;
+  }
+
+  function leafStat(absPath) {
+    const parentsExist = checkExistingParents(absPath);
+    if (!parentsExist) return null;
+    return lstatIfExists(absPath);
+  }
+
+  function assertReadableFile(filePath, optionsForFile = {}) {
+    const abs = resolveInside(filePath);
+    const stat = leafStat(abs);
+    if (!stat) return null;
+    const kind = optionsForFile.kind || "file";
+    if (stat.isSymbolicLink()) {
+      if (optionsForFile.symlink === "missing") return null;
+      throw new Error(`Refusing to read symlinked ${kind}: ${pathForMessage(root, abs)}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`Expected ${kind} to be a file: ${pathForMessage(root, abs)}`);
+    }
+    return { abs, stat };
+  }
+
+  function readTextIfExists(filePath, fallback = null, optionsForFile = {}) {
+    const readable = assertReadableFile(filePath, optionsForFile);
+    if (!readable) return fallback;
+    return fs.readFileSync(readable.abs, "utf8");
+  }
+
+  function readJsonIfExists(filePath, fallback, optionsForFile = {}) {
+    const text = readTextIfExists(filePath, null, optionsForFile);
+    if (text == null) return fallback;
+    return JSON.parse(text);
+  }
+
+  function assertWritableLeaf(absPath, optionsForFile = {}) {
+    mkdirp(path.dirname(absPath));
+    const stat = lstatIfExists(absPath);
+    const kind = optionsForFile.kind || "file";
+    if (!stat) return null;
+    if (stat.isSymbolicLink()) {
+      if (optionsForFile.rejectExistingSymlink) {
+        throw new Error(`Refusing to write symlinked ${kind}: ${pathForMessage(root, absPath)}`);
+      }
+      return stat;
+    }
+    if (stat.isDirectory()) {
+      throw new Error(`Refusing to replace directory with ${kind}: ${pathForMessage(root, absPath)}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`Refusing to replace non-file ${kind}: ${pathForMessage(root, absPath)}`);
+    }
+    return stat;
+  }
+
+  function tempPathFor(absPath) {
+    const dir = path.dirname(absPath);
+    const base = path.basename(absPath);
+    return path.join(dir, `.${base}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  }
+
+  function writeFileAtomic(filePath, content, optionsForFile = {}) {
+    const abs = resolveInside(filePath);
+    const existing = assertWritableLeaf(abs, optionsForFile);
+    const mode = optionsForFile.mode != null
+      ? optionsForFile.mode
+      : existing && !existing.isSymbolicLink()
+        ? existing.mode & 0o777
+        : 0o666;
+    const tempPath = tempPathFor(abs);
+    let fd = null;
+    try {
+      fd = fs.openSync(tempPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, mode);
+      fs.writeFileSync(fd, content, optionsForFile.encoding || (Buffer.isBuffer(content) ? undefined : "utf8"));
+      fs.closeSync(fd);
+      fd = null;
+      fs.chmodSync(tempPath, mode);
+      fs.renameSync(tempPath, abs);
+    } catch (error) {
+      if (fd != null) {
+        try {
+          fs.closeSync(fd);
+        } catch {}
+      }
+      try {
+        fs.rmSync(tempPath, { force: true });
+      } catch {}
+      throw error;
+    }
+    return abs;
+  }
+
+  function writeTextFile(filePath, content, optionsForFile = {}) {
+    return writeFileAtomic(filePath, content, { ...optionsForFile, encoding: "utf8" });
+  }
+
+  function writeJson(filePath, value, optionsForFile = {}) {
+    return writeTextFile(filePath, `${JSON.stringify(value, null, 2)}\n`, optionsForFile);
+  }
+
+  function copyFile(source, destination, mode) {
+    const sourceStat = fs.statSync(source);
+    if (!sourceStat.isFile()) {
+      throw new Error(`Expected source file: ${source}`);
+    }
+    const fileMode = mode != null ? mode : sourceStat.mode & 0o777;
+    return writeFileAtomic(destination, fs.readFileSync(source), {
+      kind: "generated file",
+      mode: fileMode,
+    });
+  }
+
+  function copyDirFiles(sourceDir, destinationDir, predicate) {
+    mkdirp(destinationDir);
+    const copied = [];
+    for (const name of fs.readdirSync(sourceDir).sort()) {
+      const source = path.join(sourceDir, name);
+      if (!fs.statSync(source).isFile()) continue;
+      if (predicate && !predicate(name)) continue;
+      const destination = path.join(destinationDir, name);
+      copyFile(source, destination);
+      copied.push(name);
+    }
+    return copied;
+  }
+
+  function copyDirRecursive(sourceDir, destinationDir, predicate) {
+    mkdirp(destinationDir);
+    const copied = [];
+    for (const name of fs.readdirSync(sourceDir).sort()) {
+      const source = path.join(sourceDir, name);
+      const destination = path.join(destinationDir, name);
+      const stat = fs.statSync(source);
+      if (stat.isDirectory()) {
+        if (name === "node_modules") continue;
+        copied.push(...copyDirRecursive(source, destination, predicate));
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      const relative = path.relative(sourceDir, source);
+      if (predicate && !predicate(relative, name)) continue;
+      copyFile(source, destination);
+      copied.push(path.relative(destinationDir, destination));
+    }
+    return copied;
+  }
+
+  function copyTree(sourceDir, destinationDir) {
+    mkdirp(destinationDir);
+    const copied = [];
+    const visit = (current) => {
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const source = path.join(current, entry.name);
+        const relative = path.relative(sourceDir, source);
+        const destination = path.join(destinationDir, relative);
+        if (entry.isDirectory()) {
+          mkdirp(destination);
+          visit(source);
+        } else if (entry.isFile()) {
+          copyFile(source, destination);
+          copied.push(relative);
+        }
+      }
+    };
+    visit(sourceDir);
+    return copied.sort();
+  }
+
+  function removePath(targetPath, optionsForRemove = {}) {
+    const abs = resolveInside(targetPath);
+    if (!checkExistingParents(abs)) return;
+    fs.rmSync(abs, {
+      force: optionsForRemove.force !== false,
+      recursive: !!optionsForRemove.recursive,
+    });
+  }
+
+  function removeDirContents(dirPath) {
+    const dir = resolveInside(dirPath);
+    const stat = leafStat(dir);
+    if (!stat) return;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked directory under ${label}: ${pathForMessage(root, dir)}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`Expected directory under ${label}: ${pathForMessage(root, dir)}`);
+    }
+    for (const entry of fs.readdirSync(dir)) {
+      removePath(path.join(dir, entry), { recursive: true });
+    }
+  }
+
+  function removeEmptyDirIfExists(dirPath) {
+    const dir = resolveInside(dirPath);
+    const stat = leafStat(dir);
+    if (!stat) return;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked directory under ${label}: ${pathForMessage(root, dir)}`);
+    }
+    if (!stat.isDirectory()) return;
+    if (fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);
+  }
+
+  function fileExists(filePath, optionsForFile = {}) {
+    return !!assertReadableFile(filePath, {
+      kind: optionsForFile.kind || "file",
+      symlink: optionsForFile.symlink || "missing",
+    });
+  }
+
+  function dirExists(dirPath) {
+    const dir = resolveInside(dirPath);
+    const stat = leafStat(dir);
+    if (!stat) return false;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked directory under ${label}: ${pathForMessage(root, dir)}`);
+    }
+    return stat.isDirectory();
+  }
+
+  return {
+    root,
+    label,
+    resolveInside,
+    mkdirp,
+    readJsonIfExists,
+    readTextIfExists,
+    writeFileAtomic,
+    writeTextFile,
+    writeJson,
+    copyFile,
+    copyDirFiles,
+    copyDirRecursive,
+    copyTree,
+    removePath,
+    removeDirContents,
+    removeEmptyDirIfExists,
+    fileExists,
+    dirExists,
+  };
+}
+
+module.exports = {
+  createSafeInstallFs,
+};

--- a/scripts/lib/install-fs.js
+++ b/scripts/lib/install-fs.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 function isInside(root, candidate) {
   const relative = path.relative(root, candidate);
-  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
 function pathForMessage(root, candidate) {

--- a/scripts/lib/install-fs.js
+++ b/scripts/lib/install-fs.js
@@ -233,7 +233,9 @@ function createSafeInstallFs(rootPath, options = {}) {
       const stat = fs.statSync(source);
       if (stat.isDirectory()) {
         if (name === "node_modules") continue;
-        copied.push(...copyDirRecursive(source, destination, predicate));
+        for (const nested of copyDirRecursive(source, destination, predicate)) {
+          copied.push(path.join(name, nested));
+        }
         continue;
       }
       if (!stat.isFile()) continue;

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("node:child_process");
+const { execFileSync, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -13,6 +13,10 @@ const PACKAGE_VERSION = require("../package.json").version;
 const CODEX_ADAPTER = getAdapter("codex");
 const GENERIC_MCP_ADAPTER = getAdapter("generic-mcp");
 const KIMI_ADAPTER = getAdapter("kimi");
+
+function assertRegularFile(filePath) {
+  assert.equal(fs.lstatSync(filePath).isFile(), true);
+}
 
 test("installer copies a require-able complete MCP runtime", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-"));
@@ -207,6 +211,137 @@ test("installer copies a require-able complete MCP runtime", () => {
       ].join(" "),
       installedServer,
     ], { env: { ...process.env, HOME: tempHome }, stdio: "pipe" });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("installer replaces symlinked generated runtime leaves without following them", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-symlink-runtime-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  const victim = path.join(tempRoot, "victim-server.js");
+  fs.mkdirSync(path.join(workspace, "mcp"), { recursive: true });
+  fs.writeFileSync(victim, "victim stays\n", "utf8");
+  fs.symlinkSync(victim, path.join(workspace, "mcp", "server.js"));
+
+  try {
+    execFileSync(process.execPath, [CLI, "install", workspace, "--adapter", "claude"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome },
+      stdio: "pipe",
+    });
+
+    assert.equal(fs.readFileSync(victim, "utf8"), "victim stays\n");
+    assertRegularFile(path.join(workspace, "mcp", "server.js"));
+    assert.match(fs.readFileSync(path.join(workspace, "mcp", "server.js"), "utf8"), /startStdioServer/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("installer replaces symlinked adapter-owned generated leaves without following them", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-symlink-adapter-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  const victim = path.join(tempRoot, "victim-command.md");
+  const commandPath = path.join(workspace, ".claude", "commands", "bob-egress.md");
+  fs.mkdirSync(path.dirname(commandPath), { recursive: true });
+  fs.writeFileSync(victim, "victim stays\n", "utf8");
+  fs.symlinkSync(victim, commandPath);
+
+  try {
+    execFileSync(process.execPath, [CLI, "install", workspace, "--adapter", "claude"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome },
+      stdio: "pipe",
+    });
+
+    assert.equal(fs.readFileSync(victim, "utf8"), "victim stays\n");
+    assertRegularFile(commandPath);
+    assert.match(fs.readFileSync(commandPath, "utf8"), /bob-egress/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("installer rejects symlinked generated parent directories without writing through them", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-symlink-parent-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  const outsideKnowledge = path.join(tempRoot, "outside-knowledge");
+  fs.mkdirSync(path.join(workspace, ".hacker-bob"), { recursive: true });
+  fs.mkdirSync(outsideKnowledge, { recursive: true });
+  fs.writeFileSync(path.join(outsideKnowledge, "hunter-techniques.json"), "victim stays\n", "utf8");
+  fs.symlinkSync(outsideKnowledge, path.join(workspace, ".hacker-bob", "knowledge"));
+
+  try {
+    const result = spawnSync(process.execPath, [CLI, "install", workspace, "--adapter", "claude"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+
+    assert.notEqual(result.status, 0, `install unexpectedly succeeded: ${result.stdout}`);
+    assert.match(result.stderr, /symlinked parent directory|symlinked directory/);
+    assert.equal(fs.readFileSync(path.join(outsideKnowledge, "hunter-techniques.json"), "utf8"), "victim stays\n");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("installer rejects symlinked merged config without writing through it", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-symlink-config-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  const victim = path.join(tempRoot, "victim-mcp.json");
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.writeFileSync(victim, `${JSON.stringify({ mcpServers: { outside: { command: "node" } } }, null, 2)}\n`, "utf8");
+  fs.symlinkSync(victim, path.join(workspace, ".mcp.json"));
+
+  try {
+    const result = spawnSync(process.execPath, [CLI, "install", workspace, "--adapter", "claude"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+
+    assert.notEqual(result.status, 0, `install unexpectedly succeeded: ${result.stdout}`);
+    assert.match(result.stderr, /symlinked .*\.mcp\.json/);
+    const outside = JSON.parse(fs.readFileSync(victim, "utf8"));
+    assert.deepEqual(outside, { mcpServers: { outside: { command: "node" } } });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("codex installer replaces symlinked direct skill leaves under CODEX_HOME", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-symlink-codex-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  const codexHome = path.join(tempHome, ".codex");
+  const victim = path.join(tempRoot, "victim-skill.md");
+  const skillPath = path.join(codexHome, "skills", "bob-hunt", "SKILL.md");
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+  fs.writeFileSync(victim, "victim stays\n", "utf8");
+  fs.symlinkSync(victim, skillPath);
+
+  try {
+    execFileSync(process.execPath, [CLI, "install", workspace, "--adapter", "codex"], {
+      cwd: ROOT,
+      env: { ...process.env, HOME: tempHome, CODEX_HOME: codexHome },
+      stdio: "pipe",
+    });
+
+    assert.equal(fs.readFileSync(victim, "utf8"), "victim stays\n");
+    assertRegularFile(skillPath);
+    assert.match(fs.readFileSync(skillPath, "utf8"), /bob-hunt/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(tempHome, { recursive: true, force: true });

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { getAdapter } = require("../adapters/index.js");
 const update = require("../mcp/lib/update-check.js");
+const { createSafeInstallFs } = require("../scripts/lib/install-fs.js");
 
 const ROOT = path.join(__dirname, "..");
 const CLI = path.join(ROOT, "bin", "hacker-bob.js");
@@ -345,6 +346,25 @@ test("codex installer replaces symlinked direct skill leaves under CODEX_HOME", 
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("install filesystem recursive copies return nested relative paths", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bountyagent-install-fs-copy-"));
+  const source = path.join(tempRoot, "source");
+  const destination = path.join(tempRoot, "destination");
+  fs.mkdirSync(path.join(source, "sub"), { recursive: true });
+  fs.writeFileSync(path.join(source, "top.txt"), "top\n", "utf8");
+  fs.writeFileSync(path.join(source, "sub", "nested.txt"), "nested\n", "utf8");
+
+  try {
+    const installFs = createSafeInstallFs(tempRoot, { label: "test install root" });
+    const copied = installFs.copyDirRecursive(source, destination);
+
+    assert.deepEqual(copied.sort(), ["sub/nested.txt", "top.txt"]);
+    assert.equal(fs.readFileSync(path.join(destination, "sub", "nested.txt"), "utf8"), "nested\n");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a root-scoped safe install filesystem helper for generated installer writes
- route installer, adapter, Codex global, and install-time egress profile writes through safe no-follow paths
- add symlink regression coverage for runtime files, adapter files, parent directories, merged config, and Codex direct skills

## Verification
- npm run test:install
- npm run test:cli
- npm run check:syntax
- git diff --check

Note: local full npm test was blocked by an ignored operator config at .claude/bob/egress-profiles.json in this checkout, which triggers unrelated egress validation failures in broad runtime tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installers now reject and avoid following unsafe symlinks, preventing accidental changes outside the target and refusing symlinked merged configs/examples.

* **Infrastructure**
  * Installation and adapter activation now use a root-scoped, injectable safe filesystem for contained, atomic reads/writes and guarded copy/remove operations.

* **Tests**
  * Added regression tests covering symlink safety and safe recursive copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->