### PR TITLE
Warn on stale current PSL dependency

### DIFF
--- a/scripts/dependency-freshness.js
+++ b/scripts/dependency-freshness.js
@@ -15,7 +15,6 @@ const CHECKS = Object.freeze([
     name: "psl",
     reason: "Public Suffix List scope ownership",
     warnAfterDays: 180,
-    failAfterDays: 540,
   }),
 ]);
 
@@ -173,10 +172,9 @@ function checkDependency(check, options, packageJson, packageLock) {
 
   const ageDays = daysBetween(options.now, publishedDate);
   const ageText = ageDays.toFixed(1);
-  if (ageDays > check.failAfterDays) {
-    fail(`${check.name}@${latest} latest publish age ${ageText} days exceeds failure threshold ${check.failAfterDays} days`);
-  } else if (ageDays > check.warnAfterDays) {
-    warn(`${check.name}@${latest} latest publish age ${ageText} days exceeds warning threshold ${check.warnAfterDays} days`);
+  if (ageDays > check.warnAfterDays) {
+    const latestText = latest === lockedVersion ? "; lockfile is still npm latest" : "";
+    warn(`${check.name}@${latest} latest publish age ${ageText} days exceeds warning threshold ${check.warnAfterDays} days${latestText}`);
   } else {
     pass(`${check.name}@${latest} latest publish age ${ageText} days is within ${check.warnAfterDays} day warning threshold`);
   }

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -57,7 +57,7 @@ test("dependency freshness check warns on stale but current PSL metadata", () =>
     "--metadata-file",
     fixturePath,
     "--now",
-    "2026-05-17T00:00:00.000Z",
+    "2026-06-10T00:00:00.000Z",
   ], {
     cwd: ROOT,
     encoding: "utf8",
@@ -66,11 +66,12 @@ test("dependency freshness check warns on stale but current PSL metadata", () =>
 
   assert.match(output, /OK PSL overlay escape hatch remains implemented without runtime network refresh/);
   assert.match(output, /OK psl lockfile version matches npm latest 1\.15\.0/);
-  assert.match(output, /WARN psl@1\.15\.0 latest publish age \d+\.\d days exceeds warning threshold 180 days/);
+  assert.match(output, /WARN psl@1\.15\.0 latest publish age \d+\.\d days exceeds warning threshold 180 days; lockfile is still npm latest/);
+  assert.match(output, /INFO psl freshness owner: Public Suffix List scope ownership/);
   assert.match(output, /Dependency freshness check passed with 1 warning\(s\)\./);
 });
 
-test("dependency freshness check fails when PSL is behind latest or too old", () => {
+test("dependency freshness check fails when PSL is behind latest", () => {
   assert.throws(() => withDependencyFreshnessFixture({
     version: "1.16.0",
     "dist-tags": { latest: "1.16.0" },
@@ -87,25 +88,6 @@ test("dependency freshness check fails when PSL is behind latest or too old", ()
     stdio: ["ignore", "pipe", "pipe"],
   })), (error) => {
     assert.match(String(error.stdout), /FAIL psl lockfile version 1\.15\.0 is behind npm latest 1\.16\.0/);
-    return true;
-  });
-
-  assert.throws(() => withDependencyFreshnessFixture({
-    version: "1.15.0",
-    "dist-tags": { latest: "1.15.0" },
-    time: { "1.15.0": "2024-12-02T10:16:04.251Z" },
-  }, (fixturePath) => execFileSync(process.execPath, [
-    "scripts/dependency-freshness.js",
-    "--metadata-file",
-    fixturePath,
-    "--now",
-    "2026-06-10T00:00:00.000Z",
-  ], {
-    cwd: ROOT,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  })), (error) => {
-    assert.match(String(error.stdout), /FAIL psl@1\.15\.0 latest publish age \d+\.\d days exceeds failure threshold 540 days/);
     return true;
   });
 });


### PR DESCRIPTION
## Summary
- change dependency freshness so stale publish age is warning-only when PSL is still npm latest
- keep lockfile drift behind npm latest as a hard release failure
- update package tests for stale-current and behind-latest PSL fixtures

## Verification
- npm run release:check:dependencies
- node --test test/package.test.js
- npm test (fails in pre-existing broader MCP/dashboard/repo-target areas, including egress profile fixture validation; dependency/package checks passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency freshness validation to emit warnings for age-based issues instead of causing script failures. Only registry lookup failures now trigger script exit status.

* **Tests**
  * Updated test cases to reflect the new dependency freshness validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->