### PR TITLE
Wire CVE feed matching into public intel

### DIFF
--- a/mcp/lib/public-intel.js
+++ b/mcp/lib/public-intel.js
@@ -501,10 +501,14 @@ async function bountyPublicIntel(args, { rankAttackSurfaces = null } = {}) {
   }
 
   if (args.cve_feed_json != null) {
-    result.cve_matches = buildCveScopeMatches(domain, args.cve_feed_json, {
-      limit: cveLimit,
-      source_uri: args.cve_source_uri,
-    });
+    try {
+      result.cve_matches = buildCveScopeMatches(domain, args.cve_feed_json, {
+        limit: cveLimit,
+        source_uri: args.cve_source_uri,
+      });
+    } catch (error) {
+      result.errors.push(`cve_feed_json: ${error.message || String(error)}`);
+    }
   }
 
   writeFileAtomic(publicIntelPath(domain), `${JSON.stringify(result, null, 2)}\n`);

--- a/mcp/lib/public-intel.js
+++ b/mcp/lib/public-intel.js
@@ -8,6 +8,7 @@ const {
 const {
   assertInteger,
   assertNonEmptyString,
+  assertRequiredText,
   normalizeOptionalText,
   normalizeStringArray,
 } = require("./validation.js");
@@ -21,6 +22,18 @@ const {
 const {
   hostnamesForSurface,
 } = require("./url-surface.js");
+const {
+  readAttackSurfaceStrict,
+} = require("./attack-surface.js");
+const {
+  parseCveFeed,
+} = require("./cve-feed-parser.js");
+const {
+  matchCveBatch,
+} = require("./cve-scope-matcher.js");
+const {
+  querySchemaContracts,
+} = require("./schema-contracts-store.js");
 
 function stringArray(value) {
   if (value == null) return [];
@@ -51,6 +64,7 @@ function summarizePublicIntelForSurface(domain, surface, limit = PUBLIC_INTEL_MA
     return {
       available: false,
       reports: [],
+      cve_matches: [],
       policy_summary: null,
       program_stats: null,
       errors: [],
@@ -73,10 +87,23 @@ function summarizePublicIntelForSurface(domain, surface, limit = PUBLIC_INTEL_MA
       return surfaceTextValue.split(/[^a-z0-9]+/).some((token) => token.length >= 4 && text.includes(token));
     })
     .slice(0, limit);
+  const surfaceId = surface && typeof surface.id === "string" ? surface.id : null;
+  const cveMatches = (Array.isArray(intel.cve_matches && intel.cve_matches.records)
+    ? intel.cve_matches.records
+    : [])
+    .filter((record) => record && typeof record === "object")
+    .filter((record) => {
+      if (!surfaceId) return true;
+      return Array.isArray(record.matches) && record.matches.some((match) => (
+        match && match.surface_id === surfaceId
+      ));
+    })
+    .slice(0, limit);
 
   return {
     available: true,
     reports,
+    cve_matches: cveMatches,
     policy_summary: intel.policy_summary || null,
     program_stats: intel.program_stats || null,
     structured_scopes: Array.isArray(intel.structured_scopes) ? intel.structured_scopes.slice(0, limit) : [],
@@ -269,12 +296,130 @@ function parseHacktivityReportsFromHtml(html, query, limit) {
   return reports;
 }
 
+function cveSeverityRank(severity) {
+  const value = String(severity || "").toLowerCase();
+  if (value === "critical") return 0;
+  if (value === "high") return 1;
+  if (value === "medium") return 2;
+  if (value === "low") return 3;
+  if (value === "informational") return 4;
+  return 5;
+}
+
+function compactText(value, maxChars) {
+  if (typeof value !== "string") return null;
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (!compact) return null;
+  return compact.length > maxChars ? compact.slice(0, maxChars) : compact;
+}
+
+function compactCveRecord(record, matchResult) {
+  const references = Array.isArray(record.references)
+    ? record.references.slice(0, 3).map((reference) => ({
+        url: typeof reference.url === "string" ? reference.url : null,
+        tags: Array.isArray(reference.tags) ? reference.tags.slice(0, 5) : [],
+      }))
+    : [];
+  return {
+    cve_id: record.cve_id,
+    severity: record.severity || null,
+    cvss_score: typeof record.cvss_score === "number" ? record.cvss_score : null,
+    vulnerability_class: record.vulnerability_class || null,
+    description: compactText(record.description, 600),
+    published_at: record.published_at || null,
+    references,
+    match_count: matchResult.match_count,
+    match_hash: matchResult.match_hash,
+    matches: matchResult.matches.slice(0, PUBLIC_INTEL_MAX_ITEMS).map((match) => ({
+      surface_id: match.surface_id,
+      confidence: match.confidence,
+      surface_field: match.surface_field,
+      surface_raw_token: match.surface_raw_token,
+      token: match.token,
+      cve_vendor: match.cve_vendor,
+      cve_product: match.cve_product,
+      cve_version: match.cve_version,
+      cve_version_range: match.cve_version_range,
+      notes: match.notes || null,
+    })),
+  };
+}
+
+function buildCveScopeMatches(domain, rawFeed, options = {}) {
+  const feedText = assertRequiredText(rawFeed, "cve_feed_json");
+  if (Buffer.byteLength(feedText, "utf8") > PUBLIC_INTEL_MAX_RESPONSE_BYTES) {
+    throw new Error(`cve_feed_json exceeds read cap of ${PUBLIC_INTEL_MAX_RESPONSE_BYTES} bytes`);
+  }
+  const limit = options.limit == null
+    ? PUBLIC_INTEL_MAX_ITEMS
+    : assertInteger(options.limit, "cve_limit", { min: 1, max: PUBLIC_INTEL_MAX_ITEMS });
+  const sourceUri = normalizeOptionalText(options.source_uri, "cve_source_uri");
+  const parsed = parseCveFeed(feedText);
+  const result = {
+    version: 1,
+    source_uri: sourceUri,
+    schema_format: parsed.schema_format,
+    total_records: parsed.records.length,
+    total_with_matches: 0,
+    parser_warnings: parsed.parser_warnings,
+    errors: [],
+    records: [],
+  };
+  if (parsed.records.length === 0) {
+    return result;
+  }
+
+  let attackSurface;
+  try {
+    attackSurface = readAttackSurfaceStrict(domain);
+  } catch (error) {
+    result.errors.push(`attack_surface: ${error.message || String(error)}`);
+    return result;
+  }
+
+  let schemaContracts = [];
+  try {
+    schemaContracts = querySchemaContracts({ target_domain: domain }).contracts;
+  } catch (error) {
+    result.errors.push(`schema_contracts: ${error.message || String(error)}`);
+  }
+
+  const byId = new Map(parsed.records.map((record) => [record.cve_id, record]));
+  const batch = matchCveBatch({
+    cve_records: parsed.records,
+    surfaces: attackSurface.document.surfaces,
+    schema_contracts: schemaContracts,
+  });
+  const matched = batch.records
+    .filter((record) => record.match_count > 0)
+    .sort((a, b) => {
+      const ar = byId.get(a.cve_id) || {};
+      const br = byId.get(b.cve_id) || {};
+      const bySeverity = cveSeverityRank(ar.severity) - cveSeverityRank(br.severity);
+      if (bySeverity !== 0) return bySeverity;
+      const byCvss = (br.cvss_score || 0) - (ar.cvss_score || 0);
+      if (byCvss !== 0) return byCvss;
+      return a.cve_id.localeCompare(b.cve_id);
+    });
+
+  result.total_with_matches = matched.length;
+  result.records = matched
+    .slice(0, limit)
+    .map((matchResult) => compactCveRecord(byId.get(matchResult.cve_id) || {}, matchResult));
+  result.truncated = matched.length > limit;
+  return result;
+}
+
 async function bountyPublicIntel(args, { rankAttackSurfaces = null } = {}) {
   const domain = assertNonEmptyString(args.target_domain, "target_domain");
   const programHandle = normalizeProgramHandle(args.program);
+  const existing = readPublicIntelDocument(domain);
   const limit = args.limit == null
     ? PUBLIC_INTEL_MAX_ITEMS
     : assertInteger(args.limit, "limit", { min: 1, max: PUBLIC_INTEL_MAX_ITEMS });
+  const cveLimit = args.cve_limit == null
+    ? limit
+    : assertInteger(args.cve_limit, "cve_limit", { min: 1, max: PUBLIC_INTEL_MAX_ITEMS });
   const keywords = args.keywords == null
     ? []
     : (Array.isArray(args.keywords)
@@ -292,68 +437,74 @@ async function bountyPublicIntel(args, { rankAttackSurfaces = null } = {}) {
     policy_summary: null,
     structured_scopes: [],
     disclosed_reports: [],
+    cve_matches: existing && existing.cve_matches ? existing.cve_matches : null,
     errors: [],
   };
 
   if (typeof fetch !== "function") {
     result.errors.push("fetch is unavailable in this Node runtime");
-    writeFileAtomic(publicIntelPath(domain), `${JSON.stringify(result, null, 2)}\n`);
-    return JSON.stringify(result, null, 2);
-  }
-
-  if (programHandle) {
-    try {
-      const programUrl = `https://hackerone.com/${encodeURIComponent(programHandle)}.json`;
-      const fetched = await fetchTextWithTimeout(programUrl);
-      if (!fetched.ok) {
-        result.errors.push(`program ${programHandle}: HTTP ${fetched.status}`);
-      } else {
-        const programJson = JSON.parse(fetched.text);
-        result.program_stats = pickProgramStats(programJson);
-        result.policy_summary = compactPolicyText(
-          programJson.policy ||
-          programJson.program?.policy ||
-          programJson.profile?.policy ||
-          programJson.policy_html,
-        );
-        result.structured_scopes = extractStructuredScopes(programJson, limit);
+  } else {
+    if (programHandle) {
+      try {
+        const programUrl = `https://hackerone.com/${encodeURIComponent(programHandle)}.json`;
+        const fetched = await fetchTextWithTimeout(programUrl);
+        if (!fetched.ok) {
+          result.errors.push(`program ${programHandle}: HTTP ${fetched.status}`);
+        } else {
+          const programJson = JSON.parse(fetched.text);
+          result.program_stats = pickProgramStats(programJson);
+          result.policy_summary = compactPolicyText(
+            programJson.policy ||
+            programJson.program?.policy ||
+            programJson.profile?.policy ||
+            programJson.policy_html,
+          );
+          result.structured_scopes = extractStructuredScopes(programJson, limit);
+        }
+      } catch (error) {
+        result.errors.push(`program ${programHandle}: ${error.message || String(error)}`);
       }
-    } catch (error) {
-      result.errors.push(`program ${programHandle}: ${error.message || String(error)}`);
     }
-  }
 
-  for (const keyword of keywords) {
-    if (result.disclosed_reports.length >= limit) break;
-    try {
-      const query = keyword || domain;
-      const url = `https://hackerone.com/hacktivity?querystring=${encodeURIComponent(query)}`;
-      const fetched = await fetchTextWithTimeout(url);
-      if (!fetched.ok) {
-        result.errors.push(`hacktivity ${query}: HTTP ${fetched.status}`);
-        continue;
-      }
-      let reports = [];
-      if (fetched.content_type.includes("json") || /^[\s{[]/.test(fetched.text)) {
-        try {
-          reports = parseHacktivityReportsFromJson(JSON.parse(fetched.text), query, limit - result.disclosed_reports.length);
-        } catch {
+    for (const keyword of keywords) {
+      if (result.disclosed_reports.length >= limit) break;
+      try {
+        const query = keyword || domain;
+        const url = `https://hackerone.com/hacktivity?querystring=${encodeURIComponent(query)}`;
+        const fetched = await fetchTextWithTimeout(url);
+        if (!fetched.ok) {
+          result.errors.push(`hacktivity ${query}: HTTP ${fetched.status}`);
+          continue;
+        }
+        let reports = [];
+        if (fetched.content_type.includes("json") || /^[\s{[]/.test(fetched.text)) {
+          try {
+            reports = parseHacktivityReportsFromJson(JSON.parse(fetched.text), query, limit - result.disclosed_reports.length);
+          } catch {
+            reports = parseHacktivityReportsFromHtml(fetched.text, query, limit - result.disclosed_reports.length);
+          }
+        } else {
           reports = parseHacktivityReportsFromHtml(fetched.text, query, limit - result.disclosed_reports.length);
         }
-      } else {
-        reports = parseHacktivityReportsFromHtml(fetched.text, query, limit - result.disclosed_reports.length);
+        const seen = new Set(result.disclosed_reports.map((report) => report.url || report.title));
+        for (const report of reports) {
+          const key = report.url || report.title;
+          if (!key || seen.has(key)) continue;
+          seen.add(key);
+          result.disclosed_reports.push(report);
+          if (result.disclosed_reports.length >= limit) break;
+        }
+      } catch (error) {
+        result.errors.push(`hacktivity ${keyword}: ${error.message || String(error)}`);
       }
-      const seen = new Set(result.disclosed_reports.map((report) => report.url || report.title));
-      for (const report of reports) {
-        const key = report.url || report.title;
-        if (!key || seen.has(key)) continue;
-        seen.add(key);
-        result.disclosed_reports.push(report);
-        if (result.disclosed_reports.length >= limit) break;
-      }
-    } catch (error) {
-      result.errors.push(`hacktivity ${keyword}: ${error.message || String(error)}`);
     }
+  }
+
+  if (args.cve_feed_json != null) {
+    result.cve_matches = buildCveScopeMatches(domain, args.cve_feed_json, {
+      limit: cveLimit,
+      source_uri: args.cve_source_uri,
+    });
   }
 
   writeFileAtomic(publicIntelPath(domain), `${JSON.stringify(result, null, 2)}\n`);
@@ -377,5 +528,6 @@ module.exports = {
   pickProgramStats,
   readPublicIntelDocument,
   readResponseTextCapped,
+  buildCveScopeMatches,
   summarizePublicIntelForSurface,
 };

--- a/mcp/lib/public-intel.js
+++ b/mcp/lib/public-intel.js
@@ -34,6 +34,9 @@ const {
 const {
   querySchemaContracts,
 } = require("./schema-contracts-store.js");
+const {
+  hashCanonicalJson,
+} = require("./verification-contracts.js");
 
 function stringArray(value) {
   if (value == null) return [];
@@ -92,12 +95,17 @@ function summarizePublicIntelForSurface(domain, surface, limit = PUBLIC_INTEL_MA
     ? intel.cve_matches.records
     : [])
     .filter((record) => record && typeof record === "object")
-    .filter((record) => {
-      if (!surfaceId) return true;
-      return Array.isArray(record.matches) && record.matches.some((match) => (
-        match && match.surface_id === surfaceId
-      ));
+    .map((record) => {
+      if (!surfaceId) return record;
+      // Scope matches to this assignment so one hunter's brief never exposes
+      // CVE hints, surface IDs, or tech tokens belonging to other surfaces.
+      const scoped = Array.isArray(record.matches)
+        ? record.matches.filter((match) => match && match.surface_id === surfaceId)
+        : [];
+      if (scoped.length === 0) return null;
+      return { ...record, matches: scoped, match_count: scoped.length };
     })
+    .filter(Boolean)
     .slice(0, limit);
 
   return {
@@ -320,6 +328,17 @@ function compactCveRecord(record, matchResult) {
         tags: Array.isArray(reference.tags) ? reference.tags.slice(0, 5) : [],
       }))
     : [];
+  // Keep the strongest match per distinct surface before truncating. matches
+  // are already confidence-sorted, so the first row for a surface is its best.
+  // Capping raw rows could drop whole surfaces (and their per-surface hint and
+  // ranking boost) when one CVE matches many surfaces via repeated tokens.
+  const matchedSurfaces = new Set();
+  const distinctSurfaceMatches = [];
+  for (const match of matchResult.matches) {
+    if (matchedSurfaces.has(match.surface_id)) continue;
+    matchedSurfaces.add(match.surface_id);
+    distinctSurfaceMatches.push(match);
+  }
   return {
     cve_id: record.cve_id,
     severity: record.severity || null,
@@ -329,8 +348,9 @@ function compactCveRecord(record, matchResult) {
     published_at: record.published_at || null,
     references,
     match_count: matchResult.match_count,
+    matched_surface_count: matchedSurfaces.size,
     match_hash: matchResult.match_hash,
-    matches: matchResult.matches.slice(0, PUBLIC_INTEL_MAX_ITEMS).map((match) => ({
+    matches: distinctSurfaceMatches.slice(0, PUBLIC_INTEL_MAX_ITEMS).map((match) => ({
       surface_id: match.surface_id,
       confidence: match.confidence,
       surface_field: match.surface_field,
@@ -343,6 +363,17 @@ function compactCveRecord(record, matchResult) {
       notes: match.notes || null,
     })),
   };
+}
+
+function attackSurfaceFingerprint(domain) {
+  // Stable hash of the surfaces that CVE matching reads from. Used as a
+  // freshness key so preserved matches are dropped once the surface changes.
+  try {
+    const attackSurface = readAttackSurfaceStrict(domain);
+    return hashCanonicalJson(attackSurface.document.surfaces);
+  } catch {
+    return null;
+  }
 }
 
 function buildCveScopeMatches(domain, rawFeed, options = {}) {
@@ -376,6 +407,7 @@ function buildCveScopeMatches(domain, rawFeed, options = {}) {
     result.errors.push(`attack_surface: ${error.message || String(error)}`);
     return result;
   }
+  result.attack_surface_hash = hashCanonicalJson(attackSurface.document.surfaces);
 
   let schemaContracts = [];
   try {
@@ -437,7 +469,7 @@ async function bountyPublicIntel(args, { rankAttackSurfaces = null } = {}) {
     policy_summary: null,
     structured_scopes: [],
     disclosed_reports: [],
-    cve_matches: existing && existing.cve_matches ? existing.cve_matches : null,
+    cve_matches: null,
     errors: [],
   };
 
@@ -508,6 +540,19 @@ async function bountyPublicIntel(args, { rankAttackSurfaces = null } = {}) {
       });
     } catch (error) {
       result.errors.push(`cve_feed_json: ${error.message || String(error)}`);
+    }
+  } else if (existing && existing.cve_matches) {
+    // Carry prior CVE matches forward only when the attack surface is unchanged
+    // since they were computed; otherwise drop them so hunters never inherit
+    // stale hints or ranking boosts after recon reroutes or reuses surface IDs.
+    const stampedHash = existing.cve_matches.attack_surface_hash || null;
+    const currentHash = attackSurfaceFingerprint(domain);
+    if (stampedHash && currentHash && stampedHash === currentHash) {
+      result.cve_matches = existing.cve_matches;
+    } else {
+      result.errors.push(
+        "cve_matches: dropped stale prior matches (no cve_feed_json supplied and the attack surface changed or could not be verified); re-supply the feed to recompute",
+      );
     }
   }
 

--- a/mcp/lib/public-intel.js
+++ b/mcp/lib/public-intel.js
@@ -334,7 +334,8 @@ function compactCveRecord(record, matchResult) {
   // ranking boost) when one CVE matches many surfaces via repeated tokens.
   const matchedSurfaces = new Set();
   const distinctSurfaceMatches = [];
-  for (const match of matchResult.matches) {
+  const sourceMatches = Array.isArray(matchResult.matches) ? matchResult.matches : [];
+  for (const match of sourceMatches) {
     if (matchedSurfaces.has(match.surface_id)) continue;
     matchedSurfaces.add(match.surface_id);
     distinctSurfaceMatches.push(match);

--- a/mcp/lib/ranking.js
+++ b/mcp/lib/ranking.js
@@ -92,6 +92,9 @@ function scoreSurfaceRanking(surface, { trafficSummary = null, intelSummary = nu
   if (intelSummary && intelSummary.available && intelSummary.reports && intelSummary.reports.length > 0) {
     add(12, "disclosed_report_hints");
   }
+  if (intelSummary && intelSummary.available && Array.isArray(intelSummary.cve_matches) && intelSummary.cve_matches.length > 0) {
+    add(18, "matched_cve_hints");
+  }
 
   return {
     score,

--- a/mcp/lib/tools/public-intel.js
+++ b/mcp/lib/tools/public-intel.js
@@ -9,7 +9,7 @@ async function bountyPublicIntel(args) {
 module.exports = Object.freeze({
   name: "bounty_public_intel",
   description:
-    "Fetch optional public bug bounty intel: HackerOne-style program policy summary, stats, structured scopes, and disclosed report hints. Network/API failures degrade to empty results with errors.",
+    "Fetch optional public bug bounty intel: HackerOne-style program policy summary, stats, structured scopes, disclosed report hints, and operator-provided NVD/CVE JSON matched against the current attack surface. Network/API failures degrade to empty results with errors.",
   inputSchema: {
     "type": "object",
     "properties": {
@@ -36,6 +36,19 @@ module.exports = Object.freeze({
       },
       "limit": {
         "type": "number"
+      },
+      "cve_feed_json": {
+        "type": "string",
+        "maxLength": 300000,
+        "description": "Optional operator-provided NVD 2.0/1.x JSON or a single CVE JSON record. Bob does not fetch this URL; pass the feed content directly."
+      },
+      "cve_source_uri": {
+        "type": "string",
+        "description": "Optional display-only source label for cve_feed_json."
+      },
+      "cve_limit": {
+        "type": "number",
+        "description": "Maximum matched CVE records to retain, capped at the public intel item limit."
       }
     },
     "required": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -754,9 +754,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -929,9 +929,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1010,9 +1010,9 @@
       "peer": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17498,6 +17498,53 @@ test("bounty_public_intel caps output, persists optional intel, handles API fail
   });
 });
 
+test("bounty_public_intel degrades a malformed cve_feed_json into errors without discarding network intel", async () => {
+  await withTempHome(async () => {
+    const domain = "example.com";
+    const previousFetch = global.fetch;
+    try {
+      global.fetch = async (url) => {
+        if (String(url).includes("/example-program.json")) {
+          return new Response(JSON.stringify({
+            handle: "example-program",
+            name: "Example Program",
+            policy: "Only test owned assets.",
+            offers_bounties: true,
+            resolved_report_count: 7,
+          }), { status: 200, headers: { "content-type": "application/json" } });
+        }
+        return new Response("no", { status: 500 });
+      };
+
+      seedSessionState(domain, { phase: "HUNT", hunt_wave: 1, pending_wave: 1 });
+      seedAttackSurfaces(domain, [{
+        id: "surface-api",
+        hosts: [`https://app.${domain}`],
+        tech_stack: ["GraphQL"],
+        endpoints: ["/graphql"],
+        nuclei_hits: [],
+        priority: "LOW",
+      }]);
+
+      // Single-record feed shaped like NVD but missing cve.id: parseCveFeed
+      // throws on this branch, which previously bubbled up and skipped the
+      // persist, discarding the program intel fetched above.
+      const result = JSON.parse(await bountyPublicIntel({
+        target_domain: domain,
+        program: "https://hackerone.com/example-program",
+        cve_feed_json: JSON.stringify({ cve: { descriptions: [{ lang: "en", value: "no id here" }] } }),
+      }));
+
+      assert.equal(result.program_stats.resolved_report_count, 7);
+      assert.equal(result.cve_matches, null);
+      assert.ok(result.errors.some((error) => /^cve_feed_json:/.test(error)));
+      assert.ok(fs.existsSync(publicIntelPath(domain)));
+    } finally {
+      global.fetch = previousFetch;
+    }
+  });
+});
+
 test("public intel fetch helper enforces HackerOne allowlist and response cap", async () => {
   const previousFetch = global.fetch;
   let called = false;

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17545,6 +17545,108 @@ test("bounty_public_intel degrades a malformed cve_feed_json into errors without
   });
 });
 
+test("bounty_public_intel scopes per-surface CVE hints and dedupes matches by surface", async () => {
+  await withTempHome(async () => {
+    const domain = "scoped.example";
+    const previousFetch = global.fetch;
+    try {
+      global.fetch = async () => new Response("no", { status: 500 });
+
+      seedSessionState(domain, { phase: "HUNT", hunt_wave: 1, pending_wave: 1 });
+      // Both surfaces run GraphQL; surface-a also exposes "graphql" as a host
+      // token, so one CVE matches surface-a twice (tech_stack + host) and
+      // surface-b once.
+      seedAttackSurfaces(domain, [
+        { id: "surface-a", hosts: ["https://graphql.scoped.example"], tech_stack: ["GraphQL"], endpoints: ["/graphql"], nuclei_hits: [], priority: "LOW" },
+        { id: "surface-b", hosts: ["https://app.scoped.example"], tech_stack: ["GraphQL"], endpoints: ["/graphql"], nuclei_hits: [], priority: "LOW" },
+      ]);
+      seedAssignments(domain, 1, [
+        { agent: "a1", surface_id: "surface-a" },
+        { agent: "a2", surface_id: "surface-b" },
+      ]);
+
+      const cveFeed = JSON.stringify({
+        vulnerabilities: [
+          {
+            cve: {
+              id: "CVE-2026-2000",
+              descriptions: [{ lang: "en", value: "Auth bypass in GraphQL." }],
+              metrics: { cvssMetricV31: [{ cvssData: { baseScore: 8.0 } }] },
+              configurations: [{ nodes: [{ cpeMatch: [{ vulnerable: true, criteria: "cpe:2.3:a:graphql:graphql:1.0:*:*:*:*:*:*:*" }] }] }],
+            },
+          },
+        ],
+      });
+
+      const result = JSON.parse(await bountyPublicIntel({ target_domain: domain, cve_feed_json: cveFeed }));
+      const record = result.cve_matches.records[0];
+      assert.equal(record.cve_id, "CVE-2026-2000");
+      // Two distinct surfaces matched; the duplicate surface-a row is collapsed.
+      assert.equal(record.matched_surface_count, 2);
+      const surfaceIds = record.matches.map((match) => match.surface_id).sort();
+      assert.deepEqual(surfaceIds, ["surface-a", "surface-b"]);
+
+      // Each hunter brief only sees its own surface's match rows.
+      const briefA = JSON.parse(readHunterBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+      assert.equal(briefA.intel_hints.cve_matches.length, 1);
+      assert.deepEqual(briefA.intel_hints.cve_matches[0].matches.map((match) => match.surface_id), ["surface-a"]);
+      assert.equal(briefA.intel_hints.cve_matches[0].match_count, 1);
+
+      const briefB = JSON.parse(readHunterBrief({ target_domain: domain, wave: "w1", agent: "a2" }));
+      assert.equal(briefB.intel_hints.cve_matches.length, 1);
+      assert.deepEqual(briefB.intel_hints.cve_matches[0].matches.map((match) => match.surface_id), ["surface-b"]);
+    } finally {
+      global.fetch = previousFetch;
+    }
+  });
+});
+
+test("bounty_public_intel drops carried-forward CVE matches when the attack surface changes", async () => {
+  await withTempHome(async () => {
+    const domain = "stale.example";
+    const previousFetch = global.fetch;
+    try {
+      global.fetch = async () => new Response("no", { status: 500 });
+
+      seedAttackSurfaces(domain, [
+        { id: "surface-a", hosts: ["https://app.stale.example"], tech_stack: ["GraphQL"], nuclei_hits: [], priority: "LOW" },
+      ]);
+      const cveFeed = JSON.stringify({
+        vulnerabilities: [
+          {
+            cve: {
+              id: "CVE-2026-3000",
+              descriptions: [{ lang: "en", value: "GraphQL bug." }],
+              metrics: { cvssMetricV31: [{ cvssData: { baseScore: 7.5 } }] },
+              configurations: [{ nodes: [{ cpeMatch: [{ vulnerable: true, criteria: "cpe:2.3:a:graphql:graphql:1.0:*:*:*:*:*:*:*" }] }] }],
+            },
+          },
+        ],
+      });
+
+      // Seed matches from a feed; the record is stamped with a surface fingerprint.
+      const seeded = JSON.parse(await bountyPublicIntel({ target_domain: domain, cve_feed_json: cveFeed }));
+      assert.equal(seeded.cve_matches.records.length, 1);
+      assert.equal(typeof seeded.cve_matches.attack_surface_hash, "string");
+
+      // No feed, unchanged surface -> matches carried forward.
+      const preserved = JSON.parse(await bountyPublicIntel({ target_domain: domain }));
+      assert.equal(preserved.cve_matches.records.length, 1);
+      assert.ok(!preserved.errors.some((error) => /dropped stale prior matches/.test(error)));
+
+      // No feed after the surface changes -> stale matches dropped.
+      seedAttackSurfaces(domain, [
+        { id: "surface-z", hosts: ["https://other.stale.example"], tech_stack: ["Express"], nuclei_hits: [], priority: "LOW" },
+      ]);
+      const dropped = JSON.parse(await bountyPublicIntel({ target_domain: domain }));
+      assert.equal(dropped.cve_matches, null);
+      assert.ok(dropped.errors.some((error) => /dropped stale prior matches/.test(error)));
+    } finally {
+      global.fetch = previousFetch;
+    }
+  });
+});
+
 test("public intel fetch helper enforces HackerOne allowlist and response cap", async () => {
   const previousFetch = global.fetch;
   let called = false;

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17434,10 +17434,48 @@ test("bounty_public_intel caps output, persists optional intel, handles API fail
         program: "https://hackerone.com/example-program",
         keywords: ["team export", "graphql"],
         limit: 1,
+        cve_source_uri: "fixture:nvd",
+        cve_feed_json: JSON.stringify({
+          vulnerabilities: [
+            {
+              cve: {
+                id: "CVE-2026-0001",
+                descriptions: [
+                  { lang: "en", value: "GraphQL authorization bypass in field-level resolver checks." },
+                ],
+                metrics: {
+                  cvssMetricV31: [{ cvssData: { baseScore: 8.1 } }],
+                },
+                configurations: [
+                  {
+                    nodes: [
+                      {
+                        cpeMatch: [
+                          {
+                            vulnerable: true,
+                            criteria: "cpe:2.3:a:graphql:graphql:1.0:*:*:*:*:*:*:*",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                references: {
+                  references: [
+                    { url: "https://example.com/advisory/CVE-2026-0001", tags: ["Vendor Advisory"] },
+                  ],
+                },
+              },
+            },
+          ],
+        }),
       }));
       assert.equal(result.disclosed_reports.length, 1);
       assert.equal(result.structured_scopes.length, 1);
       assert.equal(result.program_stats.resolved_report_count, 42);
+      assert.equal(result.cve_matches.total_records, 1);
+      assert.equal(result.cve_matches.records[0].cve_id, "CVE-2026-0001");
+      assert.equal(result.cve_matches.records[0].matches[0].surface_id, "surface-api");
       assert.match(result.policy_summary, /Only test owned assets/);
       assert.ok(fs.existsSync(publicIntelPath(domain)));
       assert.equal(fs.readFileSync(attackSurfacePath(domain), "utf8"), attackSurfaceBeforeIntel);
@@ -17445,6 +17483,8 @@ test("bounty_public_intel caps output, persists optional intel, handles API fail
       const brief = JSON.parse(readHunterBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
       assert.equal(brief.intel_hints.available, true);
       assert.equal(brief.intel_hints.reports.length, 1);
+      assert.equal(brief.intel_hints.cve_matches.length, 1);
+      assert.ok(brief.ranking_summary.reasons.includes("matched_cve_hints"));
       assert.ok(brief.ranking_summary.reasons.includes("disclosed_report_hints"));
       assert.equal(fs.readFileSync(attackSurfacePath(domain), "utf8"), attackSurfaceBeforeIntel);
 


### PR DESCRIPTION
## Summary
- extend `bounty_public_intel` to accept operator-provided NVD/CVE JSON and persist compact CVE-to-surface matches
- expose matched CVEs in hunter brief intel hints and add a ranking reason for matched CVE hints
- keep runtime dependency audit clean via lockfile transitive updates

## Validation
- `npm test`
- `npm audit --omit=dev`
- `npm run release:check:clean`
- `npm run release:check:dependencies` (passes with stale-current PSL warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CVE matching against your attack surface with severity-ranked, size-capped results and truncation metadata.
  * Accept operator-provided NVD/CVE JSON, an optional source label, and a configurable cap on retained matches.
  * Risk rankings now boost priority when matched CVE evidence exists.

* **Bug Fixes**
  * Graceful degradation: malformed feeds or missing fetch do not discard existing intel; parsing errors are reported and prior matches are cleared when surface fingerprint mismatches.

* **Tests**
  * End-to-end and error-path tests added for CVE matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->