### PR TITLE
feat: deeper + wider hunting and fix recon scan spin

### DIFF
--- a/.claude/agents/deep-recon-agent.md
+++ b/.claude/agents/deep-recon-agent.md
@@ -17,6 +17,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, amass, katana) can take many minutes, and waiting for them to complete is expected.
 - Keep bulky collection captures in temporary scratch outside `[SESSION]`; only compact derived artifacts belong in `[SESSION]`.
 - Do not dump raw URLs, JavaScript bodies, or scanner output into prose.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json`, `deep-summary.json`, `surface-leads.json`, or prose. Use counts and local artifact names instead.
@@ -196,7 +197,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
-while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -226,9 +227,9 @@ DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-deep-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "$SESSION/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
+while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 2000000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
 python3 - "$SESSION" "$js_capture" <<'PY'
 import pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -250,7 +251,7 @@ PY
 7. Compact summaries, ranked leads, and attack surface
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 120 > "$SESSION/live_urls.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 400 > "$SESSION/live_urls.txt"
 : > "$SESSION/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 720 nuclei -l "$SESSION/live_urls.txt" -severity medium,high,critical -silent -o "$SESSION/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 75 2>/dev/null || true; fi
 python3 - "$DOMAIN" "$SESSION" <<'PY'

--- a/.claude/agents/recon-agent.md
+++ b/.claude/agents/recon-agent.md
@@ -16,7 +16,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
-- Keep recon under 10 minutes and keep prompt-facing output compact.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, katana) can take many minutes, and waiting for them to complete is expected. Keep prompt-facing output compact.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json` or prose. Use counts and local artifact names instead.
 
 1. Binary check
@@ -28,7 +28,7 @@ mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v 
 : > "[SESSION]/subdomains.txt"
 timeout 45 sh -c 'command -v subfinder >/dev/null && subfinder -d "$1" -silent -all' sh "[DOMAIN]" 2>/dev/null >> "[SESSION]/subdomains.txt" || true
 printf "%s\nwww.%s\n" "[DOMAIN]" "[DOMAIN]" >> "[SESSION]/subdomains.txt"
-tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 800 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
+tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 5000 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
 ```
 3. Live hosts
 ```bash
@@ -71,7 +71,7 @@ if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
-while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
 { printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
 : > "[SESSION]/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -81,7 +81,7 @@ sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
 ```bash
-{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 60 > "[SESSION]/live_urls.txt"
+{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 250 > "[SESSION]/live_urls.txt"
 : > "[SESSION]/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls.txt" -severity medium,high,critical -silent -o "[SESSION]/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 100 2>/dev/null || true; fi
 ```
@@ -90,9 +90,9 @@ if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 8 > "[SESSION]/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "[SESSION]/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 250000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
+while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 1500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
 python3 - "[SESSION]" "$js_capture" <<'PY'
 import json, pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])

--- a/adapters/codex/skills/bob-hunt/SKILL.md
+++ b/adapters/codex/skills/bob-hunt/SKILL.md
@@ -321,7 +321,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
-- Keep recon under 10 minutes and keep prompt-facing output compact.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, katana) can take many minutes, and waiting for them to complete is expected. Keep prompt-facing output compact.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json` or prose. Use counts and local artifact names instead.
 
 1. Binary check
@@ -333,7 +333,7 @@ mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v 
 : > "[SESSION]/subdomains.txt"
 timeout 45 sh -c 'command -v subfinder >/dev/null && subfinder -d "$1" -silent -all' sh "[DOMAIN]" 2>/dev/null >> "[SESSION]/subdomains.txt" || true
 printf "%s\nwww.%s\n" "[DOMAIN]" "[DOMAIN]" >> "[SESSION]/subdomains.txt"
-tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 800 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
+tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 5000 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
 ```
 3. Live hosts
 ```bash
@@ -376,7 +376,7 @@ if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
-while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
 { printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
 : > "[SESSION]/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -386,7 +386,7 @@ sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
 ```bash
-{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 60 > "[SESSION]/live_urls.txt"
+{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 250 > "[SESSION]/live_urls.txt"
 : > "[SESSION]/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls.txt" -severity medium,high,critical -silent -o "[SESSION]/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 100 2>/dev/null || true; fi
 ```
@@ -395,9 +395,9 @@ if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 8 > "[SESSION]/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "[SESSION]/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 250000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
+while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 1500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
 python3 - "[SESSION]" "$js_capture" <<'PY'
 import json, pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -464,6 +464,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, amass, katana) can take many minutes, and waiting for them to complete is expected.
 - Keep bulky collection captures in temporary scratch outside `[SESSION]`; only compact derived artifacts belong in `[SESSION]`.
 - Do not dump raw URLs, JavaScript bodies, or scanner output into prose.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json`, `deep-summary.json`, `surface-leads.json`, or prose. Use counts and local artifact names instead.
@@ -643,7 +644,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
-while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -673,9 +674,9 @@ DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-deep-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "$SESSION/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
+while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 2000000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
 python3 - "$SESSION" "$js_capture" <<'PY'
 import pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -697,7 +698,7 @@ PY
 7. Compact summaries, ranked leads, and attack surface
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 120 > "$SESSION/live_urls.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 400 > "$SESSION/live_urls.txt"
 : > "$SESSION/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 720 nuclei -l "$SESSION/live_urls.txt" -severity medium,high,critical -silent -o "$SESSION/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 75 2>/dev/null || true; fi
 python3 - "$DOMAIN" "$SESSION" <<'PY'

--- a/adapters/codex/skills/bob-oss/SKILL.md
+++ b/adapters/codex/skills/bob-oss/SKILL.md
@@ -123,7 +123,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
-- Keep recon under 10 minutes and keep prompt-facing output compact.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, katana) can take many minutes, and waiting for them to complete is expected. Keep prompt-facing output compact.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json` or prose. Use counts and local artifact names instead.
 
 1. Binary check
@@ -135,7 +135,7 @@ mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v 
 : > "[SESSION]/subdomains.txt"
 timeout 45 sh -c 'command -v subfinder >/dev/null && subfinder -d "$1" -silent -all' sh "[DOMAIN]" 2>/dev/null >> "[SESSION]/subdomains.txt" || true
 printf "%s\nwww.%s\n" "[DOMAIN]" "[DOMAIN]" >> "[SESSION]/subdomains.txt"
-tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 800 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
+tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 5000 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
 ```
 3. Live hosts
 ```bash
@@ -178,7 +178,7 @@ if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
-while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
 { printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
 : > "[SESSION]/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -188,7 +188,7 @@ sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
 ```bash
-{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 60 > "[SESSION]/live_urls.txt"
+{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 250 > "[SESSION]/live_urls.txt"
 : > "[SESSION]/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls.txt" -severity medium,high,critical -silent -o "[SESSION]/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 100 2>/dev/null || true; fi
 ```
@@ -197,9 +197,9 @@ if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 8 > "[SESSION]/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "[SESSION]/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 250000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
+while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 1500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
 python3 - "[SESSION]" "$js_capture" <<'PY'
 import json, pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -266,6 +266,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, amass, katana) can take many minutes, and waiting for them to complete is expected.
 - Keep bulky collection captures in temporary scratch outside `[SESSION]`; only compact derived artifacts belong in `[SESSION]`.
 - Do not dump raw URLs, JavaScript bodies, or scanner output into prose.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json`, `deep-summary.json`, `surface-leads.json`, or prose. Use counts and local artifact names instead.
@@ -445,7 +446,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
-while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -475,9 +476,9 @@ DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-deep-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "$SESSION/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
+while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 2000000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
 python3 - "$SESSION" "$js_capture" <<'PY'
 import pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -499,7 +500,7 @@ PY
 7. Compact summaries, ranked leads, and attack surface
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 120 > "$SESSION/live_urls.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 400 > "$SESSION/live_urls.txt"
 : > "$SESSION/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 720 nuclei -l "$SESSION/live_urls.txt" -severity medium,high,critical -silent -o "$SESSION/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 75 2>/dev/null || true; fi
 python3 - "$DOMAIN" "$SESSION" <<'PY'

--- a/adapters/kimi/skills/bob-hunt/SKILL.md
+++ b/adapters/kimi/skills/bob-hunt/SKILL.md
@@ -294,7 +294,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
-- Keep recon under 10 minutes and keep prompt-facing output compact.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, katana) can take many minutes, and waiting for them to complete is expected. Keep prompt-facing output compact.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json` or prose. Use counts and local artifact names instead.
 
 1. Binary check
@@ -306,7 +306,7 @@ mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v 
 : > "[SESSION]/subdomains.txt"
 timeout 45 sh -c 'command -v subfinder >/dev/null && subfinder -d "$1" -silent -all' sh "[DOMAIN]" 2>/dev/null >> "[SESSION]/subdomains.txt" || true
 printf "%s\nwww.%s\n" "[DOMAIN]" "[DOMAIN]" >> "[SESSION]/subdomains.txt"
-tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 800 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
+tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 5000 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
 ```
 3. Live hosts
 ```bash
@@ -349,7 +349,7 @@ if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
-while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
 { printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
 : > "[SESSION]/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -359,7 +359,7 @@ sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
 ```bash
-{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 60 > "[SESSION]/live_urls.txt"
+{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 250 > "[SESSION]/live_urls.txt"
 : > "[SESSION]/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls.txt" -severity medium,high,critical -silent -o "[SESSION]/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 100 2>/dev/null || true; fi
 ```
@@ -368,9 +368,9 @@ if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 8 > "[SESSION]/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "[SESSION]/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 250000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
+while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 1500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
 python3 - "[SESSION]" "$js_capture" <<'PY'
 import json, pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -437,6 +437,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, amass, katana) can take many minutes, and waiting for them to complete is expected.
 - Keep bulky collection captures in temporary scratch outside `[SESSION]`; only compact derived artifacts belong in `[SESSION]`.
 - Do not dump raw URLs, JavaScript bodies, or scanner output into prose.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json`, `deep-summary.json`, `surface-leads.json`, or prose. Use counts and local artifact names instead.
@@ -616,7 +617,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
-while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -646,9 +647,9 @@ DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-deep-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "$SESSION/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
+while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 2000000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
 python3 - "$SESSION" "$js_capture" <<'PY'
 import pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -670,7 +671,7 @@ PY
 7. Compact summaries, ranked leads, and attack surface
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 120 > "$SESSION/live_urls.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 400 > "$SESSION/live_urls.txt"
 : > "$SESSION/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 720 nuclei -l "$SESSION/live_urls.txt" -severity medium,high,critical -silent -o "$SESSION/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 75 2>/dev/null || true; fi
 python3 - "$DOMAIN" "$SESSION" <<'PY'

--- a/mcp/lib/phase-gates.js
+++ b/mcp/lib/phase-gates.js
@@ -252,11 +252,10 @@ function computeHuntToChainGate(domain, state) {
 
   if (state.deep_mode === true) {
     try {
-      const preview = surfaceLeadsLib().previewSurfaceLeadPromotion(domain, {
-        limit: 25,
-        min_score: 40,
-        include_medium: true,
-      });
+      const preview = surfaceLeadsLib().previewSurfaceLeadPromotion(
+        domain,
+        surfaceLeadsLib().DEEP_MODE_PROMOTION_POLICY,
+      );
       if (preview.would_promote_lead_ids.length > 0) {
         blockers.push(blocker(
           "promotable_surface_leads",

--- a/mcp/lib/phase-gates.js
+++ b/mcp/lib/phase-gates.js
@@ -136,6 +136,13 @@ function computeAttackSurfaceCoverage(surfaces, state, openRequeueSurfaceIds) {
       !terminallyBlockedSet.has(surface.id)
     ))
     .map((surface) => surface.id);
+  const unexploredMediumSurfaceIds = surfaces
+    .filter((surface) => (
+      String(surface.priority || "").toUpperCase() === "MEDIUM" &&
+      !exploredSet.has(surface.id) &&
+      !terminallyBlockedSet.has(surface.id)
+    ))
+    .map((surface) => surface.id);
   const blockedHighSurfaceIds = surfaces
     .filter((surface) => isHighOrCritical(surface) && terminallyBlockedSet.has(surface.id))
     .map((surface) => surface.id);
@@ -159,6 +166,8 @@ function computeAttackSurfaceCoverage(surfaces, state, openRequeueSurfaceIds) {
       : 100,
     unexplored_high: unexploredHighSurfaceIds.length,
     unexplored_high_surface_ids: unexploredHighSurfaceIds,
+    unexplored_medium: unexploredMediumSurfaceIds.length,
+    unexplored_medium_surface_ids: unexploredMediumSurfaceIds,
     blocked_high: blockedHighSurfaceIds.length,
     blocked_high_surface_ids: blockedHighSurfaceIds,
     open_requeue_surface_ids: openRequeueSurfaceIds,
@@ -224,6 +233,13 @@ function computeHuntToChainGate(domain, state) {
         { surface_ids: coverage.blocked_high_surface_ids },
       ));
     }
+    if (state.deep_mode === true && coverage.unexplored_medium_surface_ids.length > 0) {
+      blockers.push(blocker(
+        "unexplored_medium_surfaces",
+        "deep mode: MEDIUM attack surfaces remain unexplored; start the next wave to cover them, or accept the gap with override_reason",
+        { surface_ids: coverage.unexplored_medium_surface_ids },
+      ));
+    }
   }
 
   if (openRequeueSurfaceIds.length > 0) {
@@ -237,9 +253,9 @@ function computeHuntToChainGate(domain, state) {
   if (state.deep_mode === true) {
     try {
       const preview = surfaceLeadsLib().previewSurfaceLeadPromotion(domain, {
-        limit: 8,
-        min_score: 60,
-        include_medium: false,
+        limit: 25,
+        min_score: 40,
+        include_medium: true,
       });
       if (preview.would_promote_lead_ids.length > 0) {
         blockers.push(blocker(

--- a/mcp/lib/surface-leads.js
+++ b/mcp/lib/surface-leads.js
@@ -42,6 +42,16 @@ const SURFACE_LEAD_ARRAY_LIMITS = Object.freeze({
   evidence: 25,
 });
 const SURFACE_LEAD_ITEM_MAX_CHARS = 500;
+// Deep-mode surface-lead promotion policy. Single source of truth shared by the
+// gate preview (phase-gates.js), the start_next_wave dry-run preview, and the
+// promotion execution (waves.js). These three call sites MUST agree or the gate
+// preview will disagree with what actually gets promoted — keep them reading
+// from this constant rather than re-inlining the literal.
+const DEEP_MODE_PROMOTION_POLICY = Object.freeze({
+  limit: 25,
+  min_score: 40,
+  include_medium: true,
+});
 
 function clampStringArray(value, fieldName, limit) {
   return normalizeStringArray(value, fieldName)
@@ -473,6 +483,7 @@ function promoteSurfaceLeadsForWave(domain, options = {}) {
 }
 
 module.exports = {
+  DEEP_MODE_PROMOTION_POLICY,
   LEAD_CONFIDENCE_VALUES,
   LEAD_STATUS_VALUES,
   isAssignableSurfaceLead,

--- a/mcp/lib/wave-planner.js
+++ b/mcp/lib/wave-planner.js
@@ -8,10 +8,10 @@ const {
   priorityRank,
 } = require("./ranking.js");
 
-const STANDARD_WAVE_TARGET = 4;
-const STANDARD_WAVE_MAX = 6;
-const DEEP_WAVE_TARGET = 6;
-const DEEP_WAVE_MAX = 8;
+const STANDARD_WAVE_TARGET = 6;
+const STANDARD_WAVE_MAX = 9;
+const DEEP_WAVE_TARGET = 8;
+const DEEP_WAVE_MAX = 12;
 
 function surfaceIdOf(value) {
   if (value == null) return null;
@@ -197,6 +197,7 @@ function planNextWave({
         },
         {
           name: "medium",
+          overflow_to_max: true,
           surfaces: priorityBucket(openSurfaces, normalizedState, ["MEDIUM"]),
         },
         {
@@ -226,6 +227,7 @@ function planNextWave({
         },
         {
           name: "medium",
+          overflow_to_max: true,
           surfaces: priorityBucket(openSurfaces, normalizedState, ["MEDIUM"]),
         },
         {

--- a/mcp/lib/waves.js
+++ b/mcp/lib/waves.js
@@ -488,9 +488,9 @@ function startNextWave(args) {
 
     const basePromotionPreview = state.deep_mode === true
       ? previewSurfaceLeadPromotion(domain, {
-          limit: 8,
-          min_score: 60,
-          include_medium: false,
+          limit: 25,
+          min_score: 40,
+          include_medium: true,
         })
       : {
           would_promote: 0,
@@ -526,9 +526,9 @@ function startNextWave(args) {
           snapshotFileForRollback(surfaceRoutesPath(domain)),
         ];
         const promoted = promoteSurfaceLeadsForWave(domain, {
-          limit: 8,
-          min_score: 60,
-          include_medium: false,
+          limit: 25,
+          min_score: 40,
+          include_medium: true,
         });
         promotedForThisStart = promoted.promoted_surface_ids.length > 0;
         promotion = {

--- a/mcp/lib/waves.js
+++ b/mcp/lib/waves.js
@@ -48,6 +48,7 @@ const {
   routeSurfacesInternal,
 } = require("./surface-router.js");
 const {
+  DEEP_MODE_PROMOTION_POLICY,
   isAssignableSurfaceLead,
   previewSurfaceLeadPromotion,
   promoteSurfaceLeadsForWave,
@@ -487,11 +488,7 @@ function startNextWave(args) {
     }
 
     const basePromotionPreview = state.deep_mode === true
-      ? previewSurfaceLeadPromotion(domain, {
-          limit: 25,
-          min_score: 40,
-          include_medium: true,
-        })
+      ? previewSurfaceLeadPromotion(domain, DEEP_MODE_PROMOTION_POLICY)
       : {
           would_promote: 0,
           would_promote_lead_ids: [],
@@ -525,11 +522,7 @@ function startNextWave(args) {
           snapshotFileForRollback(surfaceLeadsPath(domain)),
           snapshotFileForRollback(surfaceRoutesPath(domain)),
         ];
-        const promoted = promoteSurfaceLeadsForWave(domain, {
-          limit: 25,
-          min_score: 40,
-          include_medium: true,
-        });
+        const promoted = promoteSurfaceLeadsForWave(domain, DEEP_MODE_PROMOTION_POLICY);
         promotedForThisStart = promoted.promoted_surface_ids.length > 0;
         promotion = {
           ...basePromotionPreview,

--- a/prompts/roles/deep-recon.md
+++ b/prompts/roles/deep-recon.md
@@ -10,6 +10,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, amass, katana) can take many minutes, and waiting for them to complete is expected.
 - Keep bulky collection captures in temporary scratch outside `[SESSION]`; only compact derived artifacts belong in `[SESSION]`.
 - Do not dump raw URLs, JavaScript bodies, or scanner output into prose.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json`, `deep-summary.json`, `surface-leads.json`, or prose. Use counts and local artifact names instead.
@@ -189,7 +190,7 @@ if [ -s "$SESSION/brand-sibling-probe-candidates.txt" ] && [ -n "$HTTPX" ]; then
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 { echo "$DOMAIN"; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##' | head -n 8; awk '{print $1}' "$SESSION/tlsx_sans.txt" 2>/dev/null | head -n 16; } | sort -u | head -n 16 > "$SESSION/cdx_roots.txt"
 : > "$SESSION/all_urls.txt"
-while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=5000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
+while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; timeout 50 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=20000" 2>/dev/null >> "$SESSION/all_urls.txt" || true; done < "$SESSION/cdx_roots.txt"
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -219,9 +220,9 @@ DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-deep-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "$SESSION/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "$SESSION/all_urls.txt" 2>/dev/null | sort -u | head -n 200 > "$SESSION/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
+while read -r u; do timeout 10 curl -ksSL "$u" 2>/dev/null | head -c 2000000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "$SESSION/js_urls.txt"
 python3 - "$SESSION" "$js_capture" <<'PY'
 import pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
@@ -243,7 +244,7 @@ PY
 7. Compact summaries, ranked leads, and attack surface
 ```bash
 DOMAIN="[DOMAIN]"; SESSION="[SESSION]"
-{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 120 > "$SESSION/live_urls.txt"
+{ awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 400 > "$SESSION/live_urls.txt"
 : > "$SESSION/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 720 nuclei -l "$SESSION/live_urls.txt" -severity medium,high,critical -silent -o "$SESSION/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 75 2>/dev/null || true; fi
 python3 - "$DOMAIN" "$SESSION" <<'PY'

--- a/prompts/roles/recon.md
+++ b/prompts/roles/recon.md
@@ -9,7 +9,7 @@ Execution contract:
 - Use exactly the 7 Bash calls below, in order. Do not make any additional Bash calls.
 - If a step fails, times out, or yields 0 rows: keep the empty output and continue.
 - Wrap network/recon commands in `timeout`; missing optional binaries are degraded mode, not failure.
-- Keep recon under 10 minutes and keep prompt-facing output compact.
+- Run each step's Bash block in the foreground and wait for it to finish. Never start a step as a detached background job and then poll its output file in a loop; long scans (nuclei, katana) can take many minutes, and waiting for them to complete is expected. Keep prompt-facing output compact.
 - Do not copy raw secrets, bearer values, or JWT-looking strings into `attack_surface.json` or prose. Use counts and local artifact names instead.
 
 1. Binary check
@@ -21,7 +21,7 @@ mkdir -p "[SESSION]" && { for t in subfinder nuclei curl python3; do command -v 
 : > "[SESSION]/subdomains.txt"
 timeout 45 sh -c 'command -v subfinder >/dev/null && subfinder -d "$1" -silent -all' sh "[DOMAIN]" 2>/dev/null >> "[SESSION]/subdomains.txt" || true
 printf "%s\nwww.%s\n" "[DOMAIN]" "[DOMAIN]" >> "[SESSION]/subdomains.txt"
-tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 800 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
+tmp="$(mktemp "${TMPDIR:-/tmp}/bob-recon-subdomains.XXXXXX")" && sort -u "[SESSION]/subdomains.txt" | head -n 5000 > "$tmp" && mv "$tmp" "[SESSION]/subdomains.txt"; rm -f "${tmp:-}"
 ```
 3. Live hosts
 ```bash
@@ -64,7 +64,7 @@ if [ -s "[SESSION]/family_candidates.txt" ] && [ -n "$HTTPX" ]; then timeout 30 
 ```bash
 { echo "[DOMAIN]"; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null | sed 's#^https\?://##; s#/.*##'; } | sort -u | head -n 3 > "[SESSION]/cdx_roots.txt"
 : > "[SESSION]/all_urls.txt"
-while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=1500" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
+while read -r root; do timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; timeout 30 curl -ks "https://web.archive.org/cdx/search/cdx?url=*.$root/*&output=text&fl=original&collapse=urlkey&limit=10000" 2>/dev/null >> "[SESSION]/all_urls.txt" || true; done < "[SESSION]/cdx_roots.txt"
 { printf "https://%s\nhttps://www.%s\n" "[DOMAIN]" "[DOMAIN]"; awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 20 > "[SESSION]/crawl_roots.txt"
 : > "[SESSION]/katana_urls.txt"
 KATANA="$(command -v katana 2>/dev/null || true)"; [ -z "$KATANA" ] && [ -x ~/go/bin/katana ] && KATANA="$HOME/go/bin/katana"
@@ -74,7 +74,7 @@ sort -u -o "[SESSION]/all_urls.txt" "[SESSION]/all_urls.txt"
 ```
 6. Safe nuclei pass
 ```bash
-{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 60 > "[SESSION]/live_urls.txt"
+{ awk '{print $1}' "[SESSION]/live_hosts.txt" 2>/dev/null; awk '{print $1}' "[SESSION]/family_live.txt" 2>/dev/null; } | sort -u | head -n 250 > "[SESSION]/live_urls.txt"
 : > "[SESSION]/nuclei_results.txt"
 if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls.txt" -severity medium,high,critical -silent -o "[SESSION]/nuclei_results.txt" -timeout 10 -retries 1 -rate-limit 100 2>/dev/null || true; fi
 ```
@@ -83,9 +83,9 @@ if command -v nuclei >/dev/null; then timeout 480 nuclei -l "[SESSION]/live_urls
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/bob-recon-js.XXXXXX")" || exit 0
 trap 'rm -rf "$scratch"' EXIT
 js_capture="$scratch/js-capture.txt"
-grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 8 > "[SESSION]/js_urls.txt" || true
+grep -Eai '\.js([?#].*)?$' "[SESSION]/all_urls.txt" 2>/dev/null | sort -u | head -n 60 > "[SESSION]/js_urls.txt" || true
 : > "$js_capture"
-while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 250000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
+while read -r u; do timeout 6 curl -ksSL "$u" 2>/dev/null | head -c 1500000 >> "$js_capture" || true; printf "\n/* %s */\n" "$u" >> "$js_capture"; done < "[SESSION]/js_urls.txt"
 python3 - "[SESSION]" "$js_capture" <<'PY'
 import json, pathlib, re, sys
 session, capture_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -5744,6 +5744,40 @@ test("HUNT -> CHAIN gate exposes blocked_high_surface_ids and blocks transition 
   });
 });
 
+test("HUNT -> CHAIN gate blocks deep-mode hunts on unexplored MEDIUM surfaces, but not normal hunts", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedAttackSurfaces(domain, [
+      { id: "surface-a", hosts: [`https://${domain}`], priority: "HIGH" },
+      { id: "surface-m", hosts: [`https://${domain}`], priority: "MEDIUM" },
+    ]);
+    seedSessionState(domain, {
+      phase: "HUNT",
+      hunt_wave: 1,
+      explored: ["surface-a"],
+      terminally_blocked: [],
+    });
+    const { computeHuntToChainGate } = require("../mcp/lib/phase-gates.js");
+    const baseState = JSON.parse(fs.readFileSync(statePath(domain), "utf8"));
+
+    // Coverage always tracks the unexplored MEDIUM surface in both modes.
+    const normal = computeHuntToChainGate(domain, { ...baseState, deep_mode: false });
+    assert.deepEqual(normal.coverage.unexplored_medium_surface_ids, ["surface-m"]);
+    // ...but only deep mode gates on it.
+    assert.ok(
+      !normal.transition_blockers.map((b) => b.code).includes("unexplored_medium_surfaces"),
+      "normal mode must NOT block HUNT -> CHAIN on unexplored MEDIUM",
+    );
+
+    const deep = computeHuntToChainGate(domain, { ...baseState, deep_mode: true });
+    assert.deepEqual(deep.coverage.unexplored_medium_surface_ids, ["surface-m"]);
+    assert.ok(
+      deep.transition_blockers.map((b) => b.code).includes("unexplored_medium_surfaces"),
+      "deep mode must block HUNT -> CHAIN until MEDIUM surfaces are explored",
+    );
+  });
+});
+
 test("bounty_start_wave rejects assignment of terminally_blocked surfaces", () => {
   withTempHome(() => {
     const domain = "example.com";

--- a/test/wave-planner.test.js
+++ b/test/wave-planner.test.js
@@ -36,6 +36,7 @@ test("planNextWave wave 1 orders buckets, fills to target, caps high-priority ov
     { agent: "a4", surface_id: "h4" },
     { agent: "a5", surface_id: "h5" },
     { agent: "a6", surface_id: "h6" },
+    { agent: "a7", surface_id: "h7" },
   ]);
 
   const fill = planNextWave({
@@ -53,6 +54,7 @@ test("planNextWave wave 1 orders buckets, fills to target, caps high-priority ov
     { agent: "a2", surface_id: "high-b" },
     { agent: "a3", surface_id: "med-a" },
     { agent: "a4", surface_id: "med-b" },
+    { agent: "a5", surface_id: "low-a" },
   ]);
 });
 
@@ -92,6 +94,7 @@ test("planNextWave wave 2+ prioritizes open requeue, lead IDs, remaining priorit
     { agent: "a2", surface_id: "lead-high" },
     { agent: "a3", surface_id: "critical" },
     { agent: "a4", surface_id: "medium" },
+    { agent: "a5", surface_id: "low" },
   ]);
 });
 


### PR DESCRIPTION
## Summary

Makes `/bob-hunt` (and `--deep`) hunt **deeper and wider**, and fixes the recon scan that could spin for ~20–30 min instead of running.

## Hunt depth

- **Bigger waves** — per-wave assignment caps raised (standard `4/6 → 6/9`, deep `6/8 → 8/12`), and the `MEDIUM` bucket now **overflows into the max slots** instead of being capped out by high-priority surfaces. The medium/low tail actually gets hunted.
- **More leads promoted** — deep-mode surface-lead promotion loosened `{limit 8, min_score 60, no-medium} → {25, 40, include-medium}` across the 3 coupled sites (gate preview + `start_next_wave`), kept in sync so the gate preview can't disagree with actual promotion.
- **Deep-only completeness gate** — `--deep` now refuses to transition `HUNT → CHAIN` while any **MEDIUM** surface is unexplored (new `unexplored_medium_surfaces` blocker). This mirrors the existing deep-only `promotable_surface_leads` gate, so **normal-mode behavior is unchanged**. It converges (an unexplored MEDIUM is always assignable, so the wave planner schedules it) and keeps the standard `override_reason` escape hatch.

## Recon breadth

- Raised surface-discovery caps: live URLs (`60/120 → 250/400`), JS files (`8/60 → 60/200`), per-file JS byte caps (`→ 1.5/2 MB`), subdomains (`800 → 5000`), archived-URL depth (`1500/5000 → 10k/20k`).
- **All rate-limit / concurrency / scan-timeout knobs left untouched** — breadth only, no added request-rate against targets, so no new WAF exposure.

## Recon scan spin fix

Each recon/deep-recon step now runs in the **foreground**; it must never background-and-poll an output file. Root cause: a **subagent** that backgrounds a long scan never receives a background-completion notification (those reach the main loop only), so it busy-polls the task output forever. The foreground rule eliminates the spin, and is phrased runtime-neutrally so it passes the codex/kimi adapter-purity contract.

> Operators who want a scan to run past the **10-minute** Bash default can raise `BASH_MAX_TIMEOUT_MS` (and `BASH_DEFAULT_TIMEOUT_MS`) in their `.claude/settings.json` `env` block — it is a configurable default, not a hard cap.

## Tests

- Updated 2 `wave-planner.test.js` cases to the hand-verified larger-wave output.
- Added an `mcp-server.test.js` case asserting the deep-only MEDIUM gate (deep blocks, normal does not).
- Regenerated claude / codex / kimi adapter surfaces.
- Local run: `test:mcp` 948 ✓, `test:prompts` 136 ✓, plus install / package / adapter / cli / update / policy-replay / hooks all green.

## Scope note

This makes Bob cover **more** surface; it does not by itself raise severity ceilings. Per recent outcome analysis, criticals are still capped by the lack of chain `elevated_severity` write-back and the unauthenticated-surface bias — separate follow-ups (the v2 graph/browser planes), not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded reconnaissance collection limits: more subdomains, archived URLs, live URLs, and JavaScript assets captured and retained across recon and deep-recon flows
  * Foreground execution: recon steps now run and wait to complete rather than using detached background execution
  * Deep-mode promotion and wave planning adjusted to leverage shared deep-mode promotion policy and allow more medium-priority selection

* **Tests**
  * Added/updated tests to verify deep-mode gating on medium-priority surfaces and wave-planner assignment sizing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->