### PR TITLE
release: v2.0.1 — first npm publish of the v2 line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.0.1] - 2026-06-08
+
+First npm publication of the v2 line. `v2.0.0` was tagged but never released to npm; the registry `latest` remained on the v1.3.x maintenance line. `2.0.1` publishes the accumulated v2.0.x work on top of the [2.0.0] topology.
+
+### OSS / repo-mode diff review
+
+- Repo-bound sessions accept the synthetic `repo-<name>-<sha8>` `target_domain` across the `initialized_session_read` and `initialized_session_mutation` session-authority classes, not only at bootstrap. `bob_extract_routes`, `bob_build_symbol_surface_index`, and `bob_summarize_diff_impact` now run against a locally checked-out repository instead of being rejected by the registrable-domain normalization that governs live-target sessions. This lets a headless diff-review build a real symbol-surface index and diff-impact map rather than falling back to heuristic dispatch.
+- `deriveRepoTargetDomain` emits an 8-character path hash that matches the `REPO_TARGET_DOMAIN_PATTERN` authority guard, so the deriver and the validator agree on the repo-session slug.
+- Structured OSS fuzz-seed paths and the repo reachability producer are exposed for evaluator dispatch.
+
+### Report and topology authority
+
+- Structured report composition (`bob_compose_report`, `bob_write_chain_rollup`, `bob_amend_report`) and the `AUDIT_GRADED_PATHS` registry are authoritative; the Write tool is removed from `report-writer` and `chain-builder`.
+- Frontier and scheduler coherence hardening: surface-leads producer rationale with orchestrator handoff receipts, an advance-session partial-surface runtime gate, and single-spawner topology enforcement.
+
+### CI / release
+
+- Tag-triggered release pipeline with clean-release and dependency-freshness audits and npm provenance.
+
 ## [2.0.0] - 2026-05-28
 
 ### Topology realization

--- a/adapters/codex/hacker-bob/.codex-plugin/plugin.json
+++ b/adapters/codex/hacker-bob/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Codex MCP wiring for the Hacker Bob bug bounty evaluating runtime.",
   "author": {
     "name": "Hacker Bob contributors",

--- a/docs/releases/v2.0.1.md
+++ b/docs/releases/v2.0.1.md
@@ -1,0 +1,25 @@
+# Hacker Bob v2.0.1 Release Notes
+
+`v2.0.1` is the first npm publication of the v2 line. `v2.0.0` was tagged but never released to npm; the registry `latest` remained on the v1.3.x maintenance line. `2.0.1` publishes the accumulated v2.0.x work on top of the [2.0.0] topology so the v2 runtime is installable (`npm i hacker-bob`, `npx hacker-bob install`).
+
+## Highlights
+
+### OSS / repo-mode diff review
+
+Repo-bound sessions now accept the synthetic `repo-<name>-<sha8>` `target_domain` across the `initialized_session_read` and `initialized_session_mutation` session-authority classes, not only at bootstrap. `bob_extract_routes`, `bob_build_symbol_surface_index`, and `bob_summarize_diff_impact` run against a locally checked-out repository instead of being rejected by the registrable-domain normalization that governs live-target sessions. A headless diff-review can therefore build a real symbol-surface index and diff-impact map rather than falling back to heuristic dispatch.
+
+`deriveRepoTargetDomain` emits an 8-character path hash that matches the `REPO_TARGET_DOMAIN_PATTERN` authority guard, so the deriver and the validator agree on the repo-session slug. Structured OSS fuzz-seed paths and the repo reachability producer are exposed for evaluator dispatch.
+
+### Report and topology authority
+
+Structured report composition (`bob_compose_report`, `bob_write_chain_rollup`, `bob_amend_report`) and the `AUDIT_GRADED_PATHS` registry are authoritative; the Write tool is removed from `report-writer` and `chain-builder`. Frontier and scheduler coherence is hardened with surface-leads producer rationale, orchestrator handoff receipts, an advance-session partial-surface runtime gate, and single-spawner topology enforcement.
+
+### CI / release
+
+Tag-triggered release pipeline with clean-release and dependency-freshness audits and npm provenance.
+
+## Upgrading from v1.x
+
+The v1 → v2 migration notes in the [2.0.0] changelog entry apply: the session root moved `~/bounty-agent-sessions/` → `~/hacker-bob-sessions/` (copied, not moved; legacy root remains a read fallback through v2.0.x), the MCP tool prefix moved `bounty_*` → `bob_*` (v1 aliases resolve through a deprecation window, removed in v2.1.0), the MCP server key moved `bountyagent` → `hacker-bob`, and the lifecycle FSM replaced the eight-phase model with `SETUP → OPEN_FRONTIER → CLAIM_FREEZE → VERIFY → GRADE → REPORT`.
+
+See `CHANGELOG.md` for the full entry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hacker-bob",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hacker-bob",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.167",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Portable autonomous bug bounty evaluating MCP framework with host adapters",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-cc/package.json
+++ b/packages/hacker-bob-cc/package.json
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "2.0.0"
+    "hacker-bob": "2.0.1"
   }
 }

--- a/packages/hacker-bob-cc/package.json
+++ b/packages/hacker-bob-cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-cc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Hacker Bob — Claude Code adapter wrapper. Pins --adapter claude and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-codex/package.json
+++ b/packages/hacker-bob-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-codex",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Hacker Bob — Codex adapter wrapper. Pins --adapter codex and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-codex/package.json
+++ b/packages/hacker-bob-codex/package.json
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "2.0.0"
+    "hacker-bob": "2.0.1"
   }
 }

--- a/packages/hacker-bob-kimi/package.json
+++ b/packages/hacker-bob-kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacker-bob-kimi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Hacker Bob — Kimi CLI adapter wrapper. Pins --adapter kimi and delegates to the canonical hacker-bob CLI.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/hacker-bob-kimi/package.json
+++ b/packages/hacker-bob-kimi/package.json
@@ -22,6 +22,6 @@
     "README.md"
   ],
   "dependencies": {
-    "hacker-bob": "2.0.0"
+    "hacker-bob": "2.0.1"
   }
 }


### PR DESCRIPTION
## What

Version bump + CHANGELOG for **v2.0.1**, the first npm publication of the v2 line. `v2.0.0` was tagged but never published; npm `latest` is still on v1.3.5. Bumps `hacker-bob` and the `-cc`/`-codex`/`-kimi` wrappers to `2.0.1`.

## Why now

The diff-anchored `bob-diff-review` GitHub bot depends on **v2-only repo-mode** (Plane O). The runner installs `hacker-bob@$BOB_VERSION` from npm, but only v1 is published — so PATH A (symbol-surface index + diff impact) is rejected by the v1 session authority and the bot degrades to PATH B heuristic dispatch. Publishing v2 lets the runner pin `BOB_VERSION=2.0.1` and run PATH A. Verified locally: against HEAD's MCP, `bob_init_repo_session` → `bob_repo_inventory` → `bob_extract_routes` → `bob_build_symbol_surface_index` → `bob_summarize_diff_impact` all pass the authority layer with the derived `repo-<name>-<sha8>` domain.

## ⚠️ Decision for the maintainer

- **This GAs v2.** `release.yml` runs `npm publish` (no dist-tag), so tagging `v2.0.1` flips npm `latest` from v1.3.5 → v2, with the v1→v2 migration impact documented in the [2.0.0] notes (session-root rename, `bounty_*`→`bob_*`, lifecycle FSM). If you want to stage v2 without flipping `latest`, publish under a dist-tag instead.
- **Review/expand the CHANGELOG.** The [2.0.1] entry summarizes themes across the 188 commits since the v2.0.0 tag (OSS repo-mode, report/topology authority, CI); please confirm it reflects everything you want in the GA notes.

## Release mechanics

Merging this PR does **not** publish. Publication is tag-triggered: after merge, `git tag v2.0.1 && git push origin v2.0.1` runs `release.yml` (npm ci → npm test → release:check → `npm publish --provenance`). The clean CI checkout packs ~5.6 MB (no `mcp/node_modules`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository mode enhancements for improved local diff-review capabilities.
  * Acceptance of synthetic repo target identifiers during sessions.

* **Improvements**
  * Refined structured report composition and topology authority handling; report tooling updated.
  * Strengthened frontier and scheduler coherence.
  * CI/release pipeline hardened with clean-release and provenance audits.

* **Chores**
  * Version bumped to 2.0.1 across packages and published as v2 on npm.

* **Documentation**
  * Added v2.0.1 release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->