### PR TITLE
Add OSS root-cause family index

### DIFF
--- a/mcp/lib/assignment-brief.js
+++ b/mcp/lib/assignment-brief.js
@@ -421,7 +421,9 @@ function buildOssTechniquePacksSlice(taskLens, surface) {
       lens: rootCauseFamilies.lens,
       family_count: rootCauseFamilies.family_count,
       unmatched_lens: rootCauseFamilies.unmatched_lens,
-      ...(rootCauseFamilies.summary_limits || {}),
+      item_max_chars: rootCauseFamilies.summary_limits?.item_max_chars,
+      limit: rootCauseFamilies.summary_limits?.limit,
+      returned: rootCauseFamilies.summary_limits?.returned,
     },
     selection_limits: {
       selected_chars: JSON.stringify(partitioned.selected).length,

--- a/mcp/lib/assignment-brief.js
+++ b/mcp/lib/assignment-brief.js
@@ -86,6 +86,9 @@ const {
   selectTechniquePacksForSurface,
 } = require("./technique-packs.js");
 const {
+  suggestFamiliesForSurface,
+} = require("./oss-rootcause-family-corpus.js");
+const {
   CLI_TOOL_PACKS,
   fillInvocationPlaceholders,
   observationList,
@@ -374,6 +377,8 @@ function ossTechniquePackForBrief(pack, { summary = true } = {}) {
   return brief;
 }
 
+const OSS_ROOTCAUSE_FAMILY_BRIEF_LIMIT = 10;
+
 function partitionOssTechniquePacksByLens(packs, taskLens) {
   const packList = Array.isArray(packs) ? packs : [];
   if (!isOssLens(taskLens)) {
@@ -398,14 +403,31 @@ function partitionOssTechniquePacksByLens(packs, taskLens) {
   };
 }
 
-function buildOssTechniquePacksSlice(taskLens) {
+function buildOssTechniquePacksSlice(taskLens, surface) {
   const partitioned = partitionOssTechniquePacksByLens(OSS_TECHNIQUE_PACKS, taskLens);
+  const familySurface = surface && typeof surface === "object" && !Array.isArray(surface)
+    ? { ...surface, task_lens: taskLens }
+    : { task_lens: taskLens };
+  const rootCauseFamilies = suggestFamiliesForSurface(familySurface, {
+    lens: taskLens,
+    limit: OSS_ROOTCAUSE_FAMILY_BRIEF_LIMIT,
+  });
+  const renderedFamilies = rootCauseFamilies.suggestions;
   return {
     selected: partitioned.selected,
     other_applicable: partitioned.other_applicable,
+    root_cause_families: renderedFamilies,
+    root_cause_family_limits: {
+      lens: rootCauseFamilies.lens,
+      family_count: rootCauseFamilies.family_count,
+      unmatched_lens: rootCauseFamilies.unmatched_lens,
+      ...(rootCauseFamilies.summary_limits || {}),
+    },
     selection_limits: {
       selected_chars: JSON.stringify(partitioned.selected).length,
       selected_count: partitioned.selected.length,
+      root_cause_family_chars: JSON.stringify(renderedFamilies).length,
+      root_cause_family_count: renderedFamilies.length,
     },
     lens_partitioned: isOssLens(taskLens),
   };
@@ -1318,7 +1340,7 @@ function buildOssBriefExtras(domain, surfaceObj, routeMetadata, assignment) {
       },
     },
     repoEnvRecommendations: buildRepoEnvRecommendationsForBrief(domain),
-    ossTechniquePacks: buildOssTechniquePacksSlice(taskLens),
+    ossTechniquePacks: buildOssTechniquePacksSlice(taskLens, slimSurface.surface),
     cliToolSurfaceFingerprint,
     cliToolTaskLens: taskLens,
     cliToolObservations,

--- a/mcp/lib/assignment-brief.js
+++ b/mcp/lib/assignment-brief.js
@@ -81,6 +81,7 @@ const {
 const {
   EVALUATOR_KNOWLEDGE_MAX_CHARS,
   OSS_TECHNIQUE_PACKS,
+  TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
   evaluatorKnowledgeCandidatePaths,
   resolveEvaluatorKnowledge,
   selectTechniquePacksForSurface,
@@ -379,6 +380,40 @@ function ossTechniquePackForBrief(pack, { summary = true } = {}) {
 
 const OSS_ROOTCAUSE_FAMILY_BRIEF_LIMIT = 10;
 
+function emptyRootCauseFamilyResult(lens, { unmatchedLens = false } = {}) {
+  return {
+    lens: typeof lens === "string" && lens.length > 0 ? lens : "unknown",
+    family_count: 0,
+    suggestions: [],
+    unmatched_lens: unmatchedLens,
+    summary_limits: {
+      item_max_chars: TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+      limit: 0,
+      returned: 0,
+    },
+  };
+}
+
+function normalizedBriefSignal(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function isTrueSignal(value) {
+  return value === true || normalizedBriefSignal(value) === "true";
+}
+
+function isNativeCodeFamilySurface(surface, routeMetadata) {
+  const surfaceObj = surface && typeof surface === "object" && !Array.isArray(surface) ? surface : {};
+  const routePack = normalizedBriefSignal(routeMetadata && routeMetadata.capability_pack);
+  const surfacePack = normalizedBriefSignal(surfaceObj.capability_pack);
+  const surfaceType = normalizedBriefSignal(surfaceObj.surface_type);
+  return routePack === "oss_native_code"
+    || surfacePack === "oss_native_code"
+    || surfaceType === "oss_native_code"
+    || isTrueSignal(surfaceObj.native_source)
+    || isTrueSignal(surfaceObj.nativeSource);
+}
+
 function partitionOssTechniquePacksByLens(packs, taskLens) {
   const packList = Array.isArray(packs) ? packs : [];
   if (!isOssLens(taskLens)) {
@@ -403,15 +438,20 @@ function partitionOssTechniquePacksByLens(packs, taskLens) {
   };
 }
 
-function buildOssTechniquePacksSlice(taskLens, surface) {
+function buildOssTechniquePacksSlice(taskLens, surface, routeMetadata) {
   const partitioned = partitionOssTechniquePacksByLens(OSS_TECHNIQUE_PACKS, taskLens);
+  const routeCapabilityPack = routeMetadata && typeof routeMetadata.capability_pack === "string"
+    ? routeMetadata.capability_pack
+    : null;
   const familySurface = surface && typeof surface === "object" && !Array.isArray(surface)
-    ? { ...surface, task_lens: taskLens }
-    : { task_lens: taskLens };
-  const rootCauseFamilies = suggestFamiliesForSurface(familySurface, {
-    lens: taskLens,
-    limit: OSS_ROOTCAUSE_FAMILY_BRIEF_LIMIT,
-  });
+    ? { ...surface, ...(routeCapabilityPack ? { capability_pack: routeCapabilityPack } : {}), task_lens: taskLens }
+    : { ...(routeCapabilityPack ? { capability_pack: routeCapabilityPack } : {}), task_lens: taskLens };
+  const rootCauseFamilies = isNativeCodeFamilySurface(surface, routeMetadata)
+    ? suggestFamiliesForSurface(familySurface, {
+      lens: taskLens,
+      limit: OSS_ROOTCAUSE_FAMILY_BRIEF_LIMIT,
+    })
+    : emptyRootCauseFamilyResult(taskLens, { unmatchedLens: !isOssLens(taskLens) });
   const renderedFamilies = rootCauseFamilies.suggestions;
   return {
     selected: partitioned.selected,
@@ -1342,7 +1382,7 @@ function buildOssBriefExtras(domain, surfaceObj, routeMetadata, assignment) {
       },
     },
     repoEnvRecommendations: buildRepoEnvRecommendationsForBrief(domain),
-    ossTechniquePacks: buildOssTechniquePacksSlice(taskLens, slimSurface.surface),
+    ossTechniquePacks: buildOssTechniquePacksSlice(taskLens, slimSurface.surface, routeMetadata),
     cliToolSurfaceFingerprint,
     cliToolTaskLens: taskLens,
     cliToolObservations,

--- a/mcp/lib/oss-rootcause-family-corpus.js
+++ b/mcp/lib/oss-rootcause-family-corpus.js
@@ -318,6 +318,11 @@ function suggestFamiliesForSurface(surface, options) {
       family_count: 0,
       suggestions: [],
       unmatched_lens: true,
+      summary_limits: {
+        item_max_chars: TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+        limit: 0,
+        returned: 0,
+      },
     };
   }
   const limit = options && Number.isInteger(options.limit) && options.limit > 0

--- a/mcp/lib/oss-rootcause-family-corpus.js
+++ b/mcp/lib/oss-rootcause-family-corpus.js
@@ -323,18 +323,28 @@ function suggestFamiliesForSurface(surface, options) {
     ? Math.min(options.limit, 25)
     : families.length;
   const surfaceText = surfaceSignalText(surface);
-  const suggestions = families.slice(0, limit).map((family) => {
-    const matchedSignature = matchedSignatureTerms(family, surfaceText);
-    return {
-      family_id: family.id,
-      family: family.family,
-      name: family.name,
-      matched_signature: matchedSignature,
-      witness: witnessBrief(family.witness, (family.additional_witnesses || []).length),
-      brief: familyBrief(family),
-      ...(family.fixture_only === true ? { fixture_only: true } : {}),
-    };
-  });
+  const suggestions = families
+    .map((family, index) => ({
+      family,
+      index,
+      matchedSignature: matchedSignatureTerms(family, surfaceText),
+    }))
+    .sort((left, right) => (
+      right.matchedSignature.length - left.matchedSignature.length
+        || left.index - right.index
+    ))
+    .slice(0, limit)
+    .map(({ family, matchedSignature }) => {
+      return {
+        family_id: family.id,
+        family: family.family,
+        name: family.name,
+        matched_signature: matchedSignature,
+        witness: witnessBrief(family.witness, (family.additional_witnesses || []).length),
+        brief: familyBrief(family),
+        ...(family.fixture_only === true ? { fixture_only: true } : {}),
+      };
+    });
   return {
     lens,
     family_count: families.length,

--- a/mcp/lib/oss-rootcause-family-corpus.js
+++ b/mcp/lib/oss-rootcause-family-corpus.js
@@ -1,0 +1,356 @@
+"use strict";
+
+const {
+  TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+} = require("./technique-packs.js");
+
+/**
+ * OSS root-cause family record.
+ *
+ * Mirrors the I5 invariant-template corpus shape, but for repo-bound OSS
+ * source/sink patterns:
+ *   {
+ *     id,
+ *     family,
+ *     name,
+ *     description,
+ *     lens_affinity[],
+ *     source_sink_signature[],
+ *     witness: { project, cve_or_commit, file_symbol, controlling_fields, impact }
+ *   }
+ *
+ * The two families absent from the shipped oss_native_code prose blob are:
+ *   - crypto_ordering: decrypt / parse before MAC or signature verification.
+ *   - validate_vs_consume: length/size/index consumed before validation.
+ *
+ * Witness rows intentionally carry public technical facts only: project,
+ * public id or "disclosed", file/symbol, controlling fields, and impact.
+ */
+const FAMILIES = Object.freeze([
+  Object.freeze({
+    id: "OSS-FAM-ALLOCATION-SIZE-MATH-001",
+    family: "allocation_size_math",
+    name: "Allocation-size math crosses untrusted length",
+    description: "Allocation or resize math derives from an attacker-controlled count, width, or element size before overflow and maximum-size checks prove the allocation matches the later write.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["count_field", "element_size", "allocation_call", "write_site"]),
+    witness: Object.freeze({
+      project: "libtirpc",
+      cve_or_commit: "disclosed",
+      file_symbol: "__xdrrec_getrec",
+      controlling_fields: Object.freeze(["record_length", "fragment_length", "heap_record_buffer"]),
+      impact: "heap out-of-bounds write from record-size consumption before the allocation/write boundary is proven safe",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-BOUNDS-CHECK-001",
+    family: "bounds_check",
+    name: "Unchecked length or index crosses a fixed buffer",
+    description: "A length, index, or element count from network, file, or API input reaches a fixed buffer or array access before an adjacent bounds check constrains it.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["length_field", "fixed_buffer", "copy_or_index_op", "bounds_check_site"]),
+    witness: Object.freeze({
+      project: "rpcbind",
+      cve_or_commit: "disclosed",
+      file_symbol: "rpcbaddrlist",
+      controlling_fields: Object.freeze(["unbounded_xdr_string", "buf[128]", "copy_length"]),
+      impact: "stack overflow when an unbounded XDR string is copied into buf[128]",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-CRYPTO-ORDERING-001",
+    family: "crypto_ordering",
+    name: "Decrypt-before-authenticate ordering",
+    description: "Ciphertext or attacker-controlled plaintext bytes are decrypted, padded, or parsed before the MAC or signature is verified.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["decrypt_call", "mac_verify_call", "ordering_between_them"]),
+    fixture_only: true,
+    portfolio_status: "fixture-only; Bob's portfolio has zero crypto-ordering findings",
+    witness: Object.freeze({
+      project: "OpenSSL SSLv3 CBC record processing",
+      cve_or_commit: "CVE-2014-3566",
+      file_symbol: "ssl/s3_pkt.c:ssl3_get_record",
+      controlling_fields: Object.freeze(["CBC_padding", "MAC_check", "decrypt_then_verify_order"]),
+      impact: "padding-oracle plaintext recovery in the classic MAC-then-encrypt ordering class",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-DOUBLE-FREE-UAF-001",
+    family: "double_free_use_after_free",
+    name: "Cleanup path reuses or frees stale ownership",
+    description: "An object, buffer, or context changes owner across error, callback, or reconnect paths, then a stale pointer is freed or dereferenced again.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["owner_transfer_site", "cleanup_path", "stale_pointer_use", "second_free_or_deref"]),
+    witness: Object.freeze({
+      project: "OSS native-code protocol-memory fixture",
+      cve_or_commit: "disclosed",
+      file_symbol: "async callback / queued PDU cleanup",
+      controlling_fields: Object.freeze(["context_owner", "queued_pdu_reference", "cleanup_branch"]),
+      impact: "use-after-free or double-free when lifetime ownership is not reset consistently across cleanup paths",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-INTEGER-TRUNCATION-001",
+    family: "integer_truncation",
+    name: "Sentinel or length truncation changes loop bounds",
+    description: "A sentinel, declared length, or computed size narrows or wraps across integer widths before it controls a loop, allocation, or copy.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["declared_length", "narrowing_cast", "loop_bound", "size_check_site"]),
+    witness: Object.freeze({
+      project: "LibreDWG",
+      cve_or_commit: "disclosed",
+      file_symbol: "read_literal_length",
+      controlling_fields: Object.freeze(["0xFFFF_literal_length", "loop_bound", "termination_check"]),
+      impact: "unbounded loop when the literal-length sentinel is consumed as a loop-control value",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-LIFETIME-OWNERSHIP-001",
+    family: "lifetime_ownership",
+    name: "Ownership handoff leaves stale aliases",
+    description: "A queue, callback, cache, or refcount path keeps an alias after ownership moves, so later cleanup or dispatch observes a stale object lifetime.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["ownership_handoff", "alias_storage", "refcount_or_queue", "later_cleanup_or_dispatch"]),
+    witness: Object.freeze({
+      project: "OSS native-code protocol-memory fixture",
+      cve_or_commit: "disclosed",
+      file_symbol: "callback context / reconnect queue",
+      controlling_fields: Object.freeze(["context_lifetime", "queue_reference", "refcount_or_owner_flag"]),
+      impact: "stale alias survives an ownership handoff and can become a use-after-free or cleanup-path corruption",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-NUL-PATH-HANDLING-001",
+    family: "nul_path_handling",
+    name: "Path or NUL normalization mismatch",
+    description: "A path, string, or NUL-bearing byte sequence is validated under one representation and consumed under another.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["path_bytes", "normalization_site", "validation_site", "filesystem_or_parser_consumer"]),
+    witness: Object.freeze({
+      project: "OSS native-code path-handling fixture",
+      cve_or_commit: "disclosed",
+      file_symbol: "path normalization / consumer boundary",
+      controlling_fields: Object.freeze(["raw_path_bytes", "nul_or_separator", "normalized_path"]),
+      impact: "validation bypass or unintended file effect when the consumed path differs from the checked path",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-SIGNEDNESS-CONVERSION-001",
+    family: "signedness_conversion",
+    name: "Signed/unsigned boundary changes safety checks",
+    description: "A signed value is checked in one domain, converted to an unsigned size or index, and then used by a copy, loop, allocation, or parser sink.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["signed_source_field", "unsigned_sink_size", "conversion_site", "range_check_site"]),
+    witness: Object.freeze({
+      project: "LibreDWG",
+      cve_or_commit: "disclosed",
+      file_symbol: "read_literal_length",
+      controlling_fields: Object.freeze(["literal_length", "0xFFFF_sentinel", "loop_counter_width"]),
+      impact: "malformed literal length crosses integer-domain handling and can drive excessive loop work",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-STATE-MACHINE-CONFUSION-001",
+    family: "state_machine_confusion",
+    name: "Parser state transition consumes stale fields",
+    description: "A parser or protocol state machine advances after a malformed field, early return, or partial reset, then consumes stale state in the next transition.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["state_field", "transition_site", "early_return_or_partial_reset", "next_consumer"]),
+    witness: Object.freeze({
+      project: "netatalk afpd Spotlight RPC",
+      cve_or_commit: "disclosed",
+      file_symbol: "Spotlight RPC length handling",
+      controlling_fields: Object.freeze(["rpc_length", "spotlight_request_state", "consumer_transition"]),
+      impact: "heap out-of-bounds access when RPC length/state is consumed before validation completes",
+    }),
+  }),
+  Object.freeze({
+    id: "OSS-FAM-VALIDATE-VS-CONSUME-001",
+    family: "validate_vs_consume",
+    name: "Consume-before-bound length ordering",
+    description: "An untrusted length, size, or index is consumed by allocation, copy, loop, or parser state before the bounds check proves the value safe.",
+    lens_affinity: Object.freeze(["code_surface_scout", "taint_trace", "fuzz_run"]),
+    source_sink_signature: Object.freeze(["length_field", "consuming_op", "bound_check_site", "entry_to_consumer_path"]),
+    witness: Object.freeze({
+      project: "rpcbind",
+      cve_or_commit: "disclosed",
+      file_symbol: "rpcbaddrlist",
+      controlling_fields: Object.freeze(["unbounded_xdr_string", "buf[128]", "bound_check_site"]),
+      impact: "stack overflow when an XDR string is consumed before the fixed buffer bound is enforced",
+    }),
+    additional_witnesses: Object.freeze([
+      Object.freeze({
+        project: "netatalk afpd",
+        cve_or_commit: "disclosed",
+        file_symbol: "Spotlight RPC length handling",
+        controlling_fields: Object.freeze(["rpc_length", "heap_buffer", "validation_site"]),
+        impact: "heap out-of-bounds access when the Spotlight RPC length is consumed before validation",
+      }),
+      Object.freeze({
+        project: "libtirpc",
+        cve_or_commit: "disclosed",
+        file_symbol: "__xdrrec_getrec",
+        controlling_fields: Object.freeze(["record_length", "heap_record_buffer", "fragment_validation"]),
+        impact: "heap out-of-bounds write when the record length reaches the consumer before validation",
+      }),
+      Object.freeze({
+        project: "LibreDWG",
+        cve_or_commit: "disclosed",
+        file_symbol: "read_literal_length",
+        controlling_fields: Object.freeze(["0xFFFF_literal_length", "loop_bound", "validation_site"]),
+        impact: "unbounded loop from consuming the literal-length sentinel before the bound is enforced",
+      }),
+    ]),
+  }),
+]);
+
+const OSS_ROOTCAUSE_FAMILIES = FAMILIES;
+
+const FAMILIES_BY_LENS = (() => {
+  const map = new Map();
+  for (const family of FAMILIES) {
+    for (const lens of family.lens_affinity) {
+      if (!map.has(lens)) map.set(lens, []);
+      map.get(lens).push(family);
+    }
+  }
+  return map;
+})();
+
+const SUPPORTED_FAMILIES = Object.freeze(Array.from(new Set(FAMILIES.map((family) => family.family))).sort());
+
+function isPlainObject(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getFamiliesForLens(lens) {
+  if (typeof lens !== "string") return [];
+  return (FAMILIES_BY_LENS.get(lens) || []).slice();
+}
+
+function stringValues(value) {
+  if (value == null) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .filter((item) => item != null)
+    .map((item) => String(item));
+}
+
+function surfaceSignalText(surface) {
+  if (!isPlainObject(surface)) return "";
+  const fields = [
+    "id",
+    "title",
+    "description",
+    "surface_type",
+    "language",
+    "file_path",
+    "symbol",
+    "sink_kind",
+    "task_lens",
+    "capability_pack",
+    "endpoints",
+    "interesting_params",
+    "bug_class_hints",
+    "high_value_flows",
+    "evidence",
+    "source_sink_signature",
+  ];
+  const values = [];
+  for (const field of fields) {
+    values.push(...stringValues(surface[field]));
+  }
+  return values.join("\n").toLowerCase();
+}
+
+function signatureNeedles(signature) {
+  const value = String(signature).toLowerCase();
+  return Object.freeze([
+    value,
+    value.replace(/_/g, " "),
+    value.replace(/_/g, "-"),
+  ]);
+}
+
+function matchedSignatureTerms(family, surfaceText) {
+  if (!surfaceText) return [];
+  return family.source_sink_signature.filter((signature) => (
+    signatureNeedles(signature).some((needle) => needle && surfaceText.includes(needle))
+  ));
+}
+
+function capBriefString(value, maxChars = TECHNIQUE_SUMMARY_ITEM_MAX_CHARS) {
+  const text = String(value);
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars);
+}
+
+function witnessBrief(witness, additionalCount = 0) {
+  const suffix = additionalCount > 0 ? ` (+${additionalCount} public witnesses)` : "";
+  return capBriefString(
+    `${witness.project} ${witness.cve_or_commit} ${witness.file_symbol}: ${witness.impact}${suffix}`,
+  );
+}
+
+function familyBrief(family) {
+  return capBriefString(
+    `${family.family}: ${family.name}. Witness: ${witnessBrief(family.witness, (family.additional_witnesses || []).length)}`,
+  );
+}
+
+function effectiveLens(surface, options) {
+  if (options && typeof options.lens === "string") return options.lens;
+  if (surface && typeof surface.task_lens === "string") return surface.task_lens;
+  if (surface && typeof surface.taskLens === "string") return surface.taskLens;
+  return "unknown";
+}
+
+function suggestFamiliesForSurface(surface, options) {
+  if (!isPlainObject(surface)) {
+    throw new TypeError("surface must be an object");
+  }
+  const lens = effectiveLens(surface, options);
+  const families = getFamiliesForLens(lens);
+  if (families.length === 0) {
+    return {
+      lens,
+      family_count: 0,
+      suggestions: [],
+      unmatched_lens: true,
+    };
+  }
+  const limit = options && Number.isInteger(options.limit) && options.limit > 0
+    ? Math.min(options.limit, 25)
+    : families.length;
+  const surfaceText = surfaceSignalText(surface);
+  const suggestions = families.slice(0, limit).map((family) => {
+    const matchedSignature = matchedSignatureTerms(family, surfaceText);
+    return {
+      family_id: family.id,
+      family: family.family,
+      name: family.name,
+      matched_signature: matchedSignature,
+      witness: witnessBrief(family.witness, (family.additional_witnesses || []).length),
+      brief: familyBrief(family),
+      ...(family.fixture_only === true ? { fixture_only: true } : {}),
+    };
+  });
+  return {
+    lens,
+    family_count: families.length,
+    suggestions,
+    unmatched_lens: false,
+    summary_limits: {
+      item_max_chars: TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+      limit,
+      returned: suggestions.length,
+    },
+  };
+}
+
+module.exports = {
+  OSS_ROOTCAUSE_FAMILIES,
+  SUPPORTED_FAMILIES,
+  getFamiliesForLens,
+  suggestFamiliesForSurface,
+};

--- a/mcp/lib/oss-rootcause-family-corpus.js
+++ b/mcp/lib/oss-rootcause-family-corpus.js
@@ -282,7 +282,8 @@ function matchedSignatureTerms(family, surfaceText) {
 function capBriefString(value, maxChars = TECHNIQUE_SUMMARY_ITEM_MAX_CHARS) {
   const text = String(value);
   if (text.length <= maxChars) return text;
-  return text.slice(0, maxChars);
+  if (maxChars <= 3) return text.slice(0, maxChars);
+  return `${text.slice(0, maxChars - 3)}...`;
 }
 
 function witnessBrief(witness, additionalCount = 0) {

--- a/mcp/lib/stigmergic-consumers.js
+++ b/mcp/lib/stigmergic-consumers.js
@@ -134,6 +134,17 @@ const STIGMERGIC_CONSUMERS = Object.freeze([
       "OSS brief composition consumes OSS_TECHNIQUE_PACKS and partitions them by task-lens affinity",
   }),
   Object.freeze({
+    consumer_id: "assignment_brief_oss_rootcause_family_renderer",
+    source_location: Object.freeze({
+      file: "mcp/lib/assignment-brief.js",
+      token_or_regex: "suggestFamiliesForSurface",
+    }),
+    producer_id: "oss_rootcause_family_corpus",
+    decision_boundary: "brief_composition",
+    rationale:
+      "OSS brief composition consumes OSS_ROOTCAUSE_FAMILIES as bounded root_cause_families inside technique_packs",
+  }),
+  Object.freeze({
     consumer_id: "c11_static_analysis_brief_slice",
     source_location: Object.freeze({
       file: "docs/plane-delta/detail/C11.md",

--- a/mcp/lib/stigmergic-producers.js
+++ b/mcp/lib/stigmergic-producers.js
@@ -95,6 +95,15 @@ const STIGMERGIC_PRODUCERS = Object.freeze([
     ]),
   }),
   Object.freeze({
+    producer_id: "oss_rootcause_family_corpus",
+    mcp_tool_or_artifact: "OSS_ROOTCAUSE_FAMILIES",
+    trace_shape_ref:
+      "mcp/lib/oss-rootcause-family-corpus.js#suggestFamiliesForSurface",
+    registered_consumers: Object.freeze([
+      "assignment_brief_oss_rootcause_family_renderer",
+    ]),
+  }),
+  Object.freeze({
     producer_id: "static_analysis_index",
     mcp_tool_or_artifact: "indexStaticResults / static-analysis-index.jsonl",
     trace_shape_ref: "mcp/lib/static-analysis-index.js#indexStaticResults",

--- a/test/assignment-brief-size.test.js
+++ b/test/assignment-brief-size.test.js
@@ -512,3 +512,51 @@ test("smart-contract evaluator brief stays within 30k with representative slice 
     assert.ok(surfaceGraphSlice.related_endpoints.length > 0);
   });
 });
+
+test("OSS evaluator brief keeps root-cause family technique_packs within its 8192-char slice cap", () => {
+  withTempHome(() => {
+    const domain = uniqueDomain("brief-oss");
+    const surfaceId = "repo:module:src-parser.c";
+    seedSessionState(domain);
+    seedAttackSurface(domain, [{
+      id: surfaceId,
+      surface_type: "oss_native_code",
+      title: "src/parser.c",
+      description: "C parser reachable from a network/file entry point with length-prefixed records.",
+      file_path: "src/parser.c",
+      language: "c",
+      native_source: true,
+      endpoints: ["src/parser.c"],
+      bug_class_hints: ["length_field", "consuming_op", "bound_check_site"],
+      high_value_flows: ["length-prefixed parser"],
+      evidence: ["record length reaches parser state transition"],
+    }]);
+    JSON.parse(startWave({
+      target_domain: domain,
+      wave_number: 1,
+      assignments: [{
+        agent: "a1",
+        surface_id: surfaceId,
+        task_lens: "fuzz_run",
+      }],
+    }));
+
+    const brief = assertBriefWithinBudget("oss", {
+      target_domain: domain,
+      wave: "w1",
+      agent: "a1",
+    });
+    assert.equal(brief.run_context.brief_profile, "oss");
+    assert.ok(brief.technique_packs.root_cause_families.length > 0);
+    const families = brief.technique_packs.root_cause_families.map((family) => family.family);
+    assert.ok(families.includes("validate_vs_consume"));
+    assert.ok(families.includes("crypto_ordering"));
+    const techniquePacksBudget = ASSIGNMENT_BRIEF_SLICE_REGISTRY.oss
+      .find((slice) => slice.key === "technique_packs").budget_chars;
+    assert.equal(techniquePacksBudget, 8192);
+    assert.ok(
+      JSON.stringify(brief.technique_packs).length <= techniquePacksBudget,
+      "OSS technique_packs slice must stay within its 8192-char cap",
+    );
+  });
+});

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -40,6 +40,7 @@
   "test/capability-eval-harness.test.js",
   "test/audit-report-parser.test.js",
   "test/invariant-template-corpus.test.js",
+  "test/oss-rootcause-family-index.test.js",
   "test/invariant-runner.test.js",
   "test/route-extractor.test.js",
   "test/symbol-surface-index.test.js",

--- a/test/orchestrator-oss-branch.test.js
+++ b/test/orchestrator-oss-branch.test.js
@@ -446,6 +446,9 @@ test("OSS brief extras partition technique packs by task lens and keep CLI packs
   assert.ok(extras.technique_packs.selected.some((pack) => pack.id === "oss_native_code"));
   assert.ok(extras.technique_packs.other_applicable.some((pack) => pack.id === "oss_ci_cd"));
   assert.equal(extras.technique_packs.selection_limits.selected_count, extras.technique_packs.selected.length);
+  assert.ok(extras.technique_packs.root_cause_families.length > 0);
+  assert.ok(extras.technique_packs.root_cause_families.some((family) => family.family === "validate_vs_consume"));
+  assert.ok(extras.technique_packs.root_cause_families.some((family) => family.family === "crypto_ordering"));
   assert.match(extras.cli_tools, /semgrep|trivy/);
 });
 
@@ -501,6 +504,8 @@ test("readAssignmentBrief accepts routed OSS brief_profile and emits OSS techniq
   assert.ok(fuzzCommand, "brief must expose a fuzz recommendation when seed corpus exists");
   assert.equal(fuzzCommand.seed_path, "fuzz/corpus");
   assert.ok(brief.technique_packs.selected.some((pack) => pack.id === "oss_native_code"));
+  assert.ok(brief.technique_packs.root_cause_families.some((family) => family.family === "validate_vs_consume"));
+  assert.ok(brief.technique_packs.root_cause_families.some((family) => family.family === "crypto_ordering"));
   assert.ok(!String(JSON.stringify(brief)).includes("Unsupported brief profile"));
 }));
 

--- a/test/oss-rootcause-family-index.test.js
+++ b/test/oss-rootcause-family-index.test.js
@@ -151,6 +151,18 @@ test("suggestFamiliesForSurface emits bounded brief suggestions when lens is sup
   }
 });
 
+test("suggestFamiliesForSurface ranks signature matches before applying the limit", () => {
+  const result = suggestFamiliesForSurface({
+    task_lens: "taint_trace",
+    bug_class_hints: ["entry_to_consumer_path"],
+  }, {
+    limit: 1,
+  });
+  assert.equal(result.suggestions.length, 1);
+  assert.equal(result.suggestions[0].family, "validate_vs_consume");
+  assert.deepEqual(result.suggestions[0].matched_signature, ["entry_to_consumer_path"]);
+});
+
 test("suggestFamiliesForSurface sets unmatched_lens for unsupported lenses", () => {
   const result = suggestFamiliesForSurface({ task_lens: "not_a_real_lens" });
   assert.equal(result.lens, "not_a_real_lens");

--- a/test/oss-rootcause-family-index.test.js
+++ b/test/oss-rootcause-family-index.test.js
@@ -182,6 +182,11 @@ test("suggestFamiliesForSurface sets unmatched_lens for unsupported lenses", () 
   assert.equal(result.family_count, 0);
   assert.deepEqual(result.suggestions, []);
   assert.equal(result.unmatched_lens, true);
+  assert.deepEqual(result.summary_limits, {
+    item_max_chars: TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+    limit: 0,
+    returned: 0,
+  });
 });
 
 test("suggestFamiliesForSurface rejects malformed surface input", () => {

--- a/test/oss-rootcause-family-index.test.js
+++ b/test/oss-rootcause-family-index.test.js
@@ -151,6 +151,19 @@ test("suggestFamiliesForSurface emits bounded brief suggestions when lens is sup
   }
 });
 
+test("truncated family brief strings carry an observable marker while staying bounded", () => {
+  const result = suggestFamiliesForSurface({
+    task_lens: "taint_trace",
+  }, {
+    limit: 10,
+  });
+  const truncated = result.suggestions.filter((suggestion) => suggestion.brief.endsWith("..."));
+  assert.ok(truncated.length > 0, "fixture corpus should exercise brief truncation");
+  for (const suggestion of truncated) {
+    assert.ok(suggestion.brief.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS);
+  }
+});
+
 test("suggestFamiliesForSurface ranks signature matches before applying the limit", () => {
   const result = suggestFamiliesForSurface({
     task_lens: "taint_trace",

--- a/test/oss-rootcause-family-index.test.js
+++ b/test/oss-rootcause-family-index.test.js
@@ -1,0 +1,173 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+} = require("../mcp/lib/technique-packs.js");
+const {
+  OSS_ROOTCAUSE_FAMILIES,
+  SUPPORTED_FAMILIES,
+  getFamiliesForLens,
+  suggestFamiliesForSurface,
+} = require("../mcp/lib/oss-rootcause-family-corpus.js");
+
+const OSS_LENSES = ["code_surface_scout", "taint_trace", "fuzz_run"];
+
+function assertWitnessShape(witness) {
+  assert.equal(typeof witness.project, "string");
+  assert.ok(witness.project.length > 0);
+  assert.equal(typeof witness.cve_or_commit, "string");
+  assert.ok(witness.cve_or_commit.length > 0);
+  assert.equal(typeof witness.file_symbol, "string");
+  assert.ok(witness.file_symbol.length > 0);
+  assert.ok(Array.isArray(witness.controlling_fields));
+  assert.ok(witness.controlling_fields.length > 0);
+  assert.equal(typeof witness.impact, "string");
+  assert.ok(witness.impact.length > 0);
+}
+
+test("SUPPORTED_FAMILIES covers the OSS root-cause families, including the two absent from the old prose blob", () => {
+  for (const family of [
+    "bounds_check",
+    "integer_truncation",
+    "signedness_conversion",
+    "allocation_size_math",
+    "nul_path_handling",
+    "state_machine_confusion",
+    "lifetime_ownership",
+    "double_free_use_after_free",
+    "crypto_ordering",
+    "validate_vs_consume",
+  ]) {
+    assert.ok(SUPPORTED_FAMILIES.includes(family), `${family} present`);
+  }
+  assert.deepEqual(SUPPORTED_FAMILIES, [...SUPPORTED_FAMILIES].sort());
+});
+
+test("OSS_ROOTCAUSE_FAMILIES every entry declares id, family, name, lens_affinity, source_sink_signature, and witness", () => {
+  for (const family of OSS_ROOTCAUSE_FAMILIES) {
+    assert.ok(typeof family.id === "string" && family.id.length > 0);
+    assert.ok(typeof family.family === "string" && family.family.length > 0);
+    assert.ok(typeof family.name === "string" && family.name.length > 0);
+    assert.ok(typeof family.description === "string" && family.description.length > 0);
+    assert.ok(Array.isArray(family.lens_affinity));
+    assert.ok(family.lens_affinity.length > 0);
+    assert.ok(Array.isArray(family.source_sink_signature));
+    assert.ok(family.source_sink_signature.length > 0);
+    assertWitnessShape(family.witness);
+    if (Array.isArray(family.additional_witnesses)) {
+      for (const witness of family.additional_witnesses) {
+        assertWitnessShape(witness);
+      }
+    }
+  }
+});
+
+test("OSS_ROOTCAUSE_FAMILIES is fully frozen at record and witness boundaries", () => {
+  assert.equal(Object.isFrozen(OSS_ROOTCAUSE_FAMILIES), true);
+  for (const family of OSS_ROOTCAUSE_FAMILIES) {
+    assert.equal(Object.isFrozen(family), true, `${family.id} must be frozen`);
+    assert.equal(Object.isFrozen(family.lens_affinity), true, `${family.id}.lens_affinity must be frozen`);
+    assert.equal(Object.isFrozen(family.source_sink_signature), true, `${family.id}.source_sink_signature must be frozen`);
+    assert.equal(Object.isFrozen(family.witness), true, `${family.id}.witness must be frozen`);
+    assert.equal(Object.isFrozen(family.witness.controlling_fields), true, `${family.id}.witness.controlling_fields must be frozen`);
+    if (Array.isArray(family.additional_witnesses)) {
+      assert.equal(Object.isFrozen(family.additional_witnesses), true, `${family.id}.additional_witnesses must be frozen`);
+      for (const witness of family.additional_witnesses) {
+        assert.equal(Object.isFrozen(witness), true);
+        assert.equal(Object.isFrozen(witness.controlling_fields), true);
+      }
+    }
+  }
+});
+
+test("validate_vs_consume carries the four public witness rows named in the I12 spec", () => {
+  const record = OSS_ROOTCAUSE_FAMILIES.find((family) => family.family === "validate_vs_consume");
+  assert.ok(record, "validate_vs_consume record must exist");
+  const witnesses = [record.witness, ...record.additional_witnesses];
+  const witnessText = JSON.stringify(witnesses);
+  for (const expected of [
+    "rpcbind",
+    "rpcbaddrlist",
+    "netatalk afpd",
+    "Spotlight RPC",
+    "libtirpc",
+    "__xdrrec_getrec",
+    "LibreDWG",
+    "read_literal_length",
+  ]) {
+    assert.match(witnessText, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.equal(witnesses.length, 4);
+});
+
+test("crypto_ordering is explicitly fixture-only until Bob has a portfolio witness", () => {
+  const record = OSS_ROOTCAUSE_FAMILIES.find((family) => family.family === "crypto_ordering");
+  assert.ok(record, "crypto_ordering record must exist");
+  assert.equal(record.fixture_only, true);
+  assert.match(record.portfolio_status, /zero crypto-ordering findings/);
+  assert.match(record.witness.impact, /padding-oracle|plaintext/i);
+});
+
+test("family witness rows avoid credentials and operator personal identifiers", () => {
+  const raw = JSON.stringify(OSS_ROOTCAUSE_FAMILIES);
+  assert.doesNotMatch(raw, /@/);
+  assert.doesNotMatch(raw, /bearer\s+/i);
+  assert.doesNotMatch(raw, /api[_-]?key/i);
+  assert.doesNotMatch(raw, /token/i);
+});
+
+test("getFamiliesForLens returns the families whose lens_affinity matches", () => {
+  for (const lens of OSS_LENSES) {
+    const families = getFamiliesForLens(lens);
+    assert.ok(families.length >= 1, `${lens} must return at least one family`);
+    assert.ok(families.every((family) => family.lens_affinity.includes(lens)));
+  }
+});
+
+test("getFamiliesForLens returns an empty array for unknown lenses", () => {
+  assert.deepEqual(getFamiliesForLens("nope"), []);
+  assert.deepEqual(getFamiliesForLens(""), []);
+  assert.deepEqual(getFamiliesForLens(null), []);
+});
+
+test("suggestFamiliesForSurface emits bounded brief suggestions when lens is supported", () => {
+  const result = suggestFamiliesForSurface({
+    task_lens: "taint_trace",
+    file_path: "src/rpc.c",
+    bug_class_hints: ["length_field", "consuming_op", "bound_check_site"],
+  }, {
+    limit: 3,
+  });
+  assert.equal(result.lens, "taint_trace");
+  assert.equal(result.unmatched_lens, false);
+  assert.equal(result.suggestions.length, 3);
+  assert.ok(result.family_count >= result.suggestions.length);
+  for (const suggestion of result.suggestions) {
+    assert.ok(suggestion.brief.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS);
+    assert.ok(suggestion.witness.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS);
+  }
+});
+
+test("suggestFamiliesForSurface sets unmatched_lens for unsupported lenses", () => {
+  const result = suggestFamiliesForSurface({ task_lens: "not_a_real_lens" });
+  assert.equal(result.lens, "not_a_real_lens");
+  assert.equal(result.family_count, 0);
+  assert.deepEqual(result.suggestions, []);
+  assert.equal(result.unmatched_lens, true);
+});
+
+test("suggestFamiliesForSurface rejects malformed surface input", () => {
+  assert.throws(() => suggestFamiliesForSurface(null), /surface/);
+  assert.throws(() => suggestFamiliesForSurface([]), /surface/);
+});
+
+test("root-cause family ids are unique", () => {
+  const ids = new Set();
+  for (const family of OSS_ROOTCAUSE_FAMILIES) {
+    assert.equal(ids.has(family.id), false, `duplicate family id: ${family.id}`);
+    ids.add(family.id);
+  }
+});

--- a/test/oss-surfacing.test.js
+++ b/test/oss-surfacing.test.js
@@ -34,6 +34,7 @@ const {
   OSS_BRIEF_SLICE_REGISTRY,
   OSS_LENSES,
   REPO_WORKFLOW_TEXT,
+  buildBriefExtrasForProfile,
   briefSliceRegistryForProfile,
   isOssLens,
 } = require("../mcp/lib/assignment-brief.js");
@@ -565,6 +566,41 @@ test("OSS technique-pack content carries the spec-required hunting vocabulary pe
   assert.match(pack("oss_ci_cd").summary, /pull_request_target|github_token/i);
   assert.match(pack("oss_secrets_config").summary, /committed|weak crypto|debug flag|\.env/i);
   assert.match(pack("oss_docs_behavior").summary, /docs claim|rate.?limit/i);
+});
+
+test("OSS brief technique_packs slice names root-cause families for native-code lenses", () => {
+  const extras = buildBriefExtrasForProfile("oss", {
+    domain: "repo-oss-family-slice",
+    surface: {
+      id: "repo:module:src-parser.c",
+      title: "src/parser.c",
+      surface_type: "oss_native_code",
+      file_path: "src/parser.c",
+      language: "c",
+      bug_class_hints: ["length_field", "bound_check_site"],
+    },
+    assignment: {
+      surface_id: "repo:module:src-parser.c",
+      task_lens: "taint_trace",
+    },
+    routeMetadata: {
+      capability_pack: "oss_native_code",
+      capability_pack_version: 1,
+      evaluator_agent: "evaluator-agent",
+      brief_profile: "oss",
+      context_budget: {
+        candidate_pack_limit: 5,
+        full_pack_read_limit: 2,
+        attempt_log_required: true,
+      },
+    },
+  });
+
+  assert.ok(extras.technique_packs.root_cause_families.length > 0);
+  const familyNames = extras.technique_packs.root_cause_families.map((family) => family.family);
+  assert.ok(familyNames.includes("validate_vs_consume"));
+  assert.ok(familyNames.includes("crypto_ordering"));
+  assert.equal(extras.technique_packs.root_cause_family_limits.unmatched_lens, false);
 });
 
 // ── Technique-pack id alias resolves ────────────────────────────────────────

--- a/test/oss-surfacing.test.js
+++ b/test/oss-surfacing.test.js
@@ -52,6 +52,7 @@ const {
 const {
   OSS_TECHNIQUE_PACKS,
   OSS_TECHNIQUE_PACK_ID_ALIASES,
+  TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
   findOssTechniquePack,
   resolveOssTechniquePackId,
 } = require("../mcp/lib/technique-packs.js");
@@ -601,6 +602,46 @@ test("OSS brief technique_packs slice names root-cause families for native-code 
   assert.ok(familyNames.includes("validate_vs_consume"));
   assert.ok(familyNames.includes("crypto_ordering"));
   assert.equal(extras.technique_packs.root_cause_family_limits.unmatched_lens, false);
+});
+
+test("OSS brief omits native root-cause families for non-native surfaces", () => {
+  const extras = buildBriefExtrasForProfile("oss", {
+    domain: "repo-oss-family-ci",
+    surface: {
+      id: "repo:workflow:ci",
+      title: ".github/workflows/test.yml",
+      surface_type: "oss_ci_cd",
+      file_path: ".github/workflows/test.yml",
+      language: "yaml",
+      bug_class_hints: ["pull_request_target", "github_token"],
+    },
+    assignment: {
+      surface_id: "repo:workflow:ci",
+      task_lens: "code_surface_scout",
+    },
+    routeMetadata: {
+      capability_pack: "oss_ci_cd",
+      capability_pack_version: 1,
+      evaluator_agent: "evaluator-agent",
+      brief_profile: "oss",
+      context_budget: {
+        candidate_pack_limit: 5,
+        full_pack_read_limit: 2,
+        attempt_log_required: true,
+      },
+    },
+  });
+
+  assert.ok(extras.technique_packs.selected.some((pack) => pack.id === "oss_ci_cd"));
+  assert.deepEqual(extras.technique_packs.root_cause_families, []);
+  assert.deepEqual(extras.technique_packs.root_cause_family_limits, {
+    lens: "code_surface_scout",
+    family_count: 0,
+    unmatched_lens: false,
+    item_max_chars: TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+    limit: 0,
+    returned: 0,
+  });
 });
 
 // ── Technique-pack id alias resolves ────────────────────────────────────────

--- a/test/stigmergic-consumers-shape.test.js
+++ b/test/stigmergic-consumers-shape.test.js
@@ -4,7 +4,7 @@
 //
 // Asserts:
 //   * STIGMERGIC_CONSUMERS is Object.freeze'd (closed list).
-//   * Exactly 10 canonical consumer entries per Y-D19 rev 4.1 + Plane-Delta S12/C9/I12/I10.
+//   * Exactly 11 canonical consumer entries per Y-D19 rev 4.1 + Plane-Delta S12/C9/I12/I10.
 //   * Every entry carries the required keys (consumer_id,
 //     source_location: {file, token_or_regex}, producer_id,
 //     decision_boundary, rationale).
@@ -40,6 +40,7 @@ const CANONICAL_CONSUMER_IDS = [
   "assignment_brief_reachability_triage_renderer",
   "grade_verdict_reachability_ceiling_reconciler",
   "assignment_brief_oss_technique_pack_renderer",
+  "assignment_brief_oss_rootcause_family_renderer",
   "c11_static_analysis_brief_slice",
 ];
 
@@ -61,8 +62,8 @@ test("STIGMERGIC_CONSUMERS is Object.freeze'd and elements are frozen", () => {
   assert.equal(Object.isFrozen(DECISION_BOUNDARY_VALUES), true);
 });
 
-test("STIGMERGIC_CONSUMERS contains exactly the 10 canonical Y-D19/Plane-Delta entries", () => {
-  assert.equal(STIGMERGIC_CONSUMERS.length, 10);
+test("STIGMERGIC_CONSUMERS contains exactly the 11 canonical Y-D19/Plane-Delta entries", () => {
+  assert.equal(STIGMERGIC_CONSUMERS.length, 11);
   const actualIds = STIGMERGIC_CONSUMERS.map((c) => c.consumer_id).sort();
   const expectedIds = [...CANONICAL_CONSUMER_IDS].sort();
   assert.deepEqual(

--- a/test/stigmergic-producers-shape.test.js
+++ b/test/stigmergic-producers-shape.test.js
@@ -4,7 +4,7 @@
 //
 // Asserts:
 //   * STIGMERGIC_PRODUCERS is Object.freeze'd (closed list).
-//   * Exactly 9 canonical producer entries per Y-D19 rev 4.1 + Plane-Delta S12/PR4/I10.
+//   * Exactly 10 canonical producer entries per Y-D19 rev 4.1 + Plane-Delta S12/PR4/I10/I12.
 //   * Every entry carries the required keys (producer_id,
 //     mcp_tool_or_artifact, trace_shape_ref, registered_consumers).
 //   * registered_consumers[] is non-empty for every entry (every
@@ -38,6 +38,7 @@ const CANONICAL_PRODUCER_IDS = [
   "capability_friction_ledger",
   "repo_inventory_reachability_stamp",
   "oss_technique_pack_registry",
+  "oss_rootcause_family_corpus",
   "static_analysis_index",
 ];
 
@@ -54,8 +55,8 @@ test("STIGMERGIC_PRODUCERS is Object.freeze'd and elements are frozen", () => {
   assert.equal(Object.isFrozen(PRODUCER_IDS), true);
 });
 
-test("STIGMERGIC_PRODUCERS contains exactly the 9 canonical Y-D19 + Plane-Delta S12/PR4/I10 entries", () => {
-  assert.equal(STIGMERGIC_PRODUCERS.length, 9);
+test("STIGMERGIC_PRODUCERS contains exactly the 10 canonical Y-D19 + Plane-Delta S12/PR4/I10/I12 entries", () => {
+  assert.equal(STIGMERGIC_PRODUCERS.length, 10);
   const actualIds = STIGMERGIC_PRODUCERS.map((p) => p.producer_id).sort();
   const expectedIds = [...CANONICAL_PRODUCER_IDS].sort();
   assert.deepEqual(

--- a/test/stigmergy-coherence.test.js
+++ b/test/stigmergy-coherence.test.js
@@ -124,11 +124,10 @@ test("fixture drift (iv): consumer points at non-existent source file produces c
   assert.equal(violations[0].kind, "consumer_source_file_missing");
 });
 
-test("FP-rate budget: ≤2% on curated 6-pair corpus (canonical manifest)", () => {
-  // The curated corpus IS the live manifest of 6 producer×consumer pairs.
-  // 6 pairs × 3 assertion kinds = 18 mechanical assertions. The FP-rate
-  // budget Y-P14c is ≤2%, i.e. ≤0.36 violations expected on the real
-  // tree. Empirically: 0.
+test("FP-rate budget: ≤2% on the live canonical manifest", () => {
+  // The curated corpus IS the live manifest of producer/consumer pairs.
+  // The FP-rate budget Y-P14c is ≤2%; empirically the real tree has 0
+  // violations.
   const violations = runCoherenceCheck({
     producers: STIGMERGIC_PRODUCERS,
     consumers: STIGMERGIC_CONSUMERS,


### PR DESCRIPTION
## Summary
- Add `mcp/lib/oss-rootcause-family-corpus.js`, mirroring the shipped I5 frozen corpus shape: frozen family records, `SUPPORTED_FAMILIES`, `getFamiliesForLens`, and bounded `suggestFamiliesForSurface`.
- Seed discrete OSS root-cause families from the existing `oss_native_code` vocabulary and add the two absent families: `validate_vs_consume` and fixture-only `crypto_ordering`.
- Wire compact family suggestions into the existing OSS `technique_packs` brief path via `buildOssTechniquePacksSlice`, without adding a parallel slice or MCP tool.
- Register `oss_rootcause_family_corpus` -> `assignment_brief_oss_rootcause_family_renderer` in the stigmergic manifests so the family corpus cannot silently become orphaned from the brief consumer.

## Gates
Two-stage gate, per I12:
1. Plumbing gate, provable now: an OSS brief renders a non-empty `technique_packs` slice whose `root_cause_families` names the families, including `validate_vs_consume` and `crypto_ordering`.
2. Content gate, long-horizon: a real OSS engagement produces a maintainer-recognized finding whose root cause is named back as a family, concretely a new `validate_vs_consume` hit.

`crypto_ordering` is fixture-only until a real MAC-then-decrypt/decrypt-before-authenticate witness is authored. Bob's portfolio has zero crypto-ordering findings today.

## Registry-driven note
I12 adds no role, tool, agent, or MCP surface. It is consumed through the existing assignment brief `technique_packs` slice. Therefore the four role/tool generators are not required for this change: `generate-agent-tools.js`, `generate-hacker-bob-skill.js`, `generate-codex-skills.js`, and `generate-kimi-roles.js`.

## Invariants held
- No PII: witness rows carry public technical facts only: project, public id or `disclosed`, file/symbol, controlling fields, and impact. No operator personal identifiers are encoded.
- Auto-kill N/A: family matches only suggest hunt shapes; they do not terminate hunts, suppress work, or gate findings.
- Determinism / S1: the corpus and nested witness/signature arrays are frozen; supported family names are sorted; query ordering is deterministic and uses no time/RNG.
- Context-as-strategy avoided: the brief receives compact capped family summaries and stays under the existing 8192-char `technique_packs` cap; full witness detail remains in the corpus export.
- Index-without-consumer avoided: the existing `buildOssTechniquePacksSlice` consumer path is enriched in place and the producer/consumer pair is registered in the stigmergy manifests.
- Tier discipline: C11 remains an augment consumer; no blocking edge or lifecycle gate is introduced.

## Tests
- Focused: `node --test test/oss-rootcause-family-index.test.js test/orchestrator-oss-branch.test.js test/oss-surfacing.test.js test/assignment-brief-size.test.js test/stigmergic-producers-shape.test.js test/stigmergic-consumers-shape.test.js test/stigmergy-coherence.test.js test/mcp-test-discovery.test.js`
- Full: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OSS briefs now include suggested root-cause families (ranked, capped, with brief summaries and witness snippets); suggestions apply only for eligible surfaces/lenses and respect existing slice budgets and selection limits.

* **Tests**
  * Added unit and integration tests for the family corpus, suggestion ranking/limits, brief truncation, slice-size budgeting, and updated manifest/registry expectations.

* **Chores**
  * Registered a new producer/consumer pair to enable the brief enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->