### PR TITLE
test: fix withTempHome async-teardown race (runAuthDifferential flake)

### DIFF
--- a/test/frontier-observation-ledger.test.js
+++ b/test/frontier-observation-ledger.test.js
@@ -34,12 +34,25 @@ function withTempHome(fn) {
   const previousHome = process.env.HOME;
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-observation-ledger-"));
   process.env.HOME = home;
-  try {
-    return fn(home);
-  } finally {
+  const restore = () => {
     process.env.HOME = previousHome;
     fs.rmSync(home, { recursive: true, force: true });
+  };
+  let result;
+  try {
+    result = fn(home);
+  } catch (err) {
+    restore();
+    throw err;
   }
+  if (result && typeof result.then === "function") {
+    return result.then(
+      (value) => { restore(); return value; },
+      (err) => { restore(); throw err; },
+    );
+  }
+  restore();
+  return result;
 }
 
 function ensureSessionDir(domain) {


### PR DESCRIPTION
## Problem

The `withTempHome` helper in `test/frontier-observation-ledger.test.js` is **synchronous** (`return fn(home)` in a `try/finally`), but the *"runAuthDifferential dual-writes legacy results AND observation.recorded events"* test passes it an `async () => {...}` callback.

A sync helper returns the callback's Promise immediately, so the `finally` runs cleanup — restore `process.env.HOME` + `fs.rmSync(home)` — **before** the awaited body executes. `runAuthDifferential` then reads/writes the *real* `~/hacker-bob-sessions` instead of the temp HOME. When a stale, pre-`bob_`-rename artifact sits there, the test reads a `bounty_run_auth_differential` tool name and fails; in a fresh HOME it passes.

This intermittent failure has shadowed every full-suite run in the recent CVSS/CWE (#95) and concurrency (#98) work.

## Fix

Make the helper **thenable-aware** (the same shape the other test files' helpers already use): capture cleanup in a `restore()` closure and only run it after the callback's Promise settles. Synchronous callbacks still clean up immediately, so it's fully backward-compatible.

## Verification

- **Pre-fix, real (polluted) HOME:** `runAuthDifferential` ✖ fails.
- **Fixed, same HOME:** ✔ passes across repeated runs.
- Full `node scripts/run-mcp-tests.js`: **2379 pass / 0 fail** (was 1 flaky fail / 0 deterministic).

Scope note: a sweep found 11 other test files that *call* `withTempHome(async …)`, but all 11 already define an `async`/thenable-aware helper — this was the only genuinely sync-buggy one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup mechanism to ensure temporary resources and environment settings are reliably reset in all test execution scenarios, enhancing test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->