### PR TITLE
Fix critical audit findings: command injection, unpinned dep, guard bypass

### DIFF
--- a/.claude/hooks/session-read-guard.sh
+++ b/.claude/hooks/session-read-guard.sh
@@ -222,7 +222,12 @@ def check_bash_command(command):
     try:
         tokens = shlex.split(command, posix=True)
     except ValueError:
-        return
+        print(
+            "BLOCKED: Command cannot be safely parsed. "
+            "Refusing to allow potentially unsafe shell operation.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     for index, token in enumerate(tokens):
         command_name = pathlib.PurePosixPath(token).name
         if command_name not in READ_COMMANDS:

--- a/.claude/hooks/session-write-guard.sh
+++ b/.claude/hooks/session-write-guard.sh
@@ -205,7 +205,10 @@ def check_mutating_path_commands(command):
     try:
         tokens = shlex.split(command, posix=True)
     except ValueError:
-        return
+        block(
+            "BLOCKED: Command cannot be safely parsed. "
+            "Refusing to allow potentially unsafe shell operation."
+        )
 
     mutators = {"rm", "unlink", "mv", "cp", "chmod", "chown"}
     for index, token in enumerate(tokens):

--- a/adapters/codex/hacker-bob/.mcp.json
+++ b/adapters/codex/hacker-bob/.mcp.json
@@ -10,7 +10,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@brutalist/mcp@latest"
+        "@brutalist/mcp@1.14.7"
       ]
     }
   }

--- a/adapters/codex/index.js
+++ b/adapters/codex/index.js
@@ -8,6 +8,7 @@ const {
   updateCodexSkillFiles,
 } = require("../../scripts/lib/codex-role-renderer.js");
 const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
+const { BRUTALIST_MCP_SERVER } = require("../../scripts/merge-claude-config.js");
 
 const id = "codex";
 const PLUGIN_NAME = "hacker-bob";
@@ -163,15 +164,6 @@ function managedDirs() {
     ".agents",
   ];
 }
-
-// External adversarial-roast MCP server consumed by the brutalist-verifier
-// role. Optional — registered alongside hacker-bob but not required at
-// runtime. See prompts/roles/brutalist-verifier.md for the graceful-fallback
-// contract.
-const BRUTALIST_MCP_SERVER = Object.freeze({
-  command: "npx",
-  args: ["-y", "@brutalist/mcp@latest"],
-});
 
 function mergeConfig({ serverPath }) {
   return {

--- a/adapters/generic-mcp/index.js
+++ b/adapters/generic-mcp/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
+const { BRUTALIST_MCP_SERVER } = require("../../scripts/merge-claude-config.js");
 
 const id = "generic-mcp";
 const PROMPT_SOURCE_DIR = path.join("adapters", "generic-mcp", "prompts");
@@ -36,15 +37,6 @@ function dirExists(dirPath) {
     return false;
   }
 }
-
-// External adversarial-roast MCP server consumed by the brutalist-verifier
-// role. Optional — registered alongside hacker-bob but not required at
-// runtime. See prompts/roles/brutalist-verifier.md for the graceful-fallback
-// contract.
-const BRUTALIST_MCP_SERVER = Object.freeze({
-  command: "npx",
-  args: ["-y", "@brutalist/mcp@latest"],
-});
 
 function mergeConfig({ serverPath }) {
   return {

--- a/adapters/index.js
+++ b/adapters/index.js
@@ -2,7 +2,9 @@
 
 const fs = require("fs");
 const path = require("path");
-const { spawnSync } = require("child_process");
+// Shared, allowlist-guarded PATH probe — the single sink for `command -v`.
+// Aliased to defaultCommandExists to preserve the detectAdapterId override hook.
+const { commandExists: defaultCommandExists } = require("../scripts/lib/command-exists.js");
 
 const claude = require("./claude/index.js");
 const codex = require("./codex/index.js");
@@ -47,14 +49,6 @@ function adapterIdsForSelection(selection, options = {}) {
     ids.push(id);
   }
   return ids;
-}
-
-function defaultCommandExists(command) {
-  const result = spawnSync("sh", ["-c", `command -v ${command}`], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  return result.status === 0;
 }
 
 function safeIsDir(fsModule, candidate) {

--- a/adapters/kimi/index.js
+++ b/adapters/kimi/index.js
@@ -8,14 +8,10 @@ const {
   updateKimiSkillFiles,
 } = require("../../scripts/lib/kimi-role-renderer.js");
 const { createSafeInstallFs } = require("../../scripts/lib/install-fs.js");
+const { BRUTALIST_MCP_SERVER } = require("../../scripts/merge-claude-config.js");
 
 const id = "kimi";
 const DEFAULT_ROOT = path.join(__dirname, "..", "..");
-
-const BRUTALIST_MCP_SERVER = Object.freeze({
-  command: "npx",
-  args: ["-y", "@brutalist/mcp@latest"],
-});
 
 const { BOB_SKILLS, LEGACY_BOB_SKILLS } = config;
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -284,6 +284,7 @@ function sourceCommitSha(sourceRoot) {
 }
 
 function commandExists(command) {
+  if (!/^[a-z0-9_-]+$/i.test(command)) return false;
   const result = spawnSync("sh", ["-c", `command -v ${command}`], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -12,6 +12,7 @@ const {
   getAdapter,
 } = require("../adapters/index.js");
 const { clearUpdateCache } = require("../mcp/lib/update-check.js");
+const { commandExists } = require("./lib/command-exists.js");
 
 const BOB_RESOURCE_DIR = ".hacker-bob";
 const NEUTRAL_INSTALL_SCHEMA_VERSION = 2;
@@ -281,15 +282,6 @@ function sourceCommitSha(sourceRoot) {
   if (result.status !== 0) return null;
   const sha = result.stdout.trim();
   return sha || null;
-}
-
-function commandExists(command) {
-  if (!/^[a-z0-9_-]+$/i.test(command)) return false;
-  const result = spawnSync("sh", ["-c", `command -v ${command}`], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  return result.status === 0;
 }
 
 function commandOrGoBinExists(command) {

--- a/scripts/lib/command-exists.js
+++ b/scripts/lib/command-exists.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const { spawnSync } = require("child_process");
+
+// Single source of truth for "is this command on PATH?" used by the installer,
+// the doctor/lifecycle checks, and the adapter probes. It interpolates its
+// argument into a shell string (`command -v <name>`), so the argument is
+// validated against a strict allowlist FIRST — otherwise a value containing a
+// shell metacharacter (`;`, `|`, `$()`, backticks, whitespace, redirects, …)
+// would break out of the `command -v` word and execute arbitrary code.
+//
+// Executable names are [A-Za-z0-9._-]: letters, digits, dot (e.g. `jwt_tool.py`,
+// `python3.11`), underscore, and hyphen. None of those are shell metacharacters
+// in an unquoted word, so a value that matches the allowlist is passed to
+// `command -v` as exactly one harmless token. Anything else is rejected before
+// the shell ever runs, fail-closed (returns false). Centralizing the check here
+// is the point: previously this sink was duplicated (scripts/install.js and
+// adapters/index.js), so guarding one copy left the other exposed.
+const SAFE_COMMAND_NAME = /^[a-z0-9._-]+$/i;
+
+function isSafeCommandName(command) {
+  return typeof command === "string" && SAFE_COMMAND_NAME.test(command);
+}
+
+function commandExists(command) {
+  if (!isSafeCommandName(command)) return false;
+  const result = spawnSync("sh", ["-c", `command -v ${command}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0;
+}
+
+module.exports = { commandExists, isSafeCommandName, SAFE_COMMAND_NAME };

--- a/scripts/merge-claude-config.js
+++ b/scripts/merge-claude-config.js
@@ -395,7 +395,7 @@ function mergeSettings(existing, bobSettings) {
 // contract.
 const BRUTALIST_MCP_SERVER = Object.freeze({
   command: "npx",
-  args: ["-y", "@brutalist/mcp@latest"],
+  args: ["-y", "@brutalist/mcp@1.14.7"],
 });
 
 function mergeMcp(existing, serverPath) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -11,6 +11,7 @@ const { promisify } = require("node:util");
 const ROOT = path.join(__dirname, "..");
 const CLI = path.join(ROOT, "bin", "hacker-bob.js");
 const PACKAGE_VERSION = require("../package.json").version;
+const { BRUTALIST_MCP_SERVER } = require("../scripts/merge-claude-config.js");
 const execFileAsync = promisify(execFile);
 
 test("CLI help explains per-project installs and global CLI behavior", () => {
@@ -66,7 +67,7 @@ test("CLI installs into a workspace", () => {
     assert.ok(!mcp.mcpServers.bountyagent, "v2.0+ installs must not emit the legacy bountyagent server key");
     assert.ok(mcp.mcpServers.brutalist, "Claude install must register the optional brutalist MCP server");
     assert.equal(mcp.mcpServers.brutalist.command, "npx");
-    assert.deepEqual(mcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@latest"]);
+    assert.deepEqual(mcp.mcpServers.brutalist.args, BRUTALIST_MCP_SERVER.args);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(tempHome, { recursive: true, force: true });
@@ -94,7 +95,7 @@ test("CLI installs and doctors the Codex adapter without Claude files", () => {
     const codexMcp = JSON.parse(fs.readFileSync(path.join(workspace, ".codex", "plugins", "hacker-bob", ".mcp.json"), "utf8"));
     assert.ok(codexMcp.mcpServers["hacker-bob"], "Codex plugin .mcp.json must keep hacker-bob");
     assert.ok(codexMcp.mcpServers.brutalist, "Codex plugin .mcp.json must register the optional brutalist MCP server post-install");
-    assert.deepEqual(codexMcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@latest"]);
+    assert.deepEqual(codexMcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@1.14.7"]);
     assert.ok(fs.existsSync(path.join(tempHome, ".codex", "skills", "bob-evaluate", "SKILL.md")));
     assert.ok(fs.existsSync(path.join(tempHome, ".codex", "skills", "bob-status", "SKILL.md")));
     assert.ok(fs.existsSync(path.join(tempHome, ".codex", "skills", "bob-debug", "SKILL.md")));
@@ -351,7 +352,7 @@ test("CLI generic MCP adapter install and uninstall preserve unrelated MCP confi
     assert.ok(installedMcp.mcpServers["hacker-bob"]);
     assert.ok(!installedMcp.mcpServers.bountyagent);
     assert.ok(installedMcp.mcpServers.brutalist, "generic-mcp install must register the optional brutalist MCP server");
-    assert.deepEqual(installedMcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@latest"]);
+    assert.deepEqual(installedMcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@1.14.7"]);
 
     const output = execFileSync(process.execPath, [CLI, "uninstall", workspace, "--adapter", "generic-mcp", "--yes", "--json"], {
       cwd: ROOT,

--- a/test/command-exists.test.js
+++ b/test/command-exists.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+// Shared, allowlist-guarded PATH probe (scripts/lib/command-exists.js). This is
+// the single sink for `command -v <name>`, consumed by scripts/install.js (and,
+// transitively, scripts/lifecycle.js) and adapters/index.js. Two properties must
+// hold simultaneously:
+//   1. INJECTION-SAFE — a value carrying any shell metacharacter is rejected
+//      before the shell runs (fail-closed), so it can never break out of the
+//      `command -v` word and execute arbitrary code.
+//   2. NO false negatives on real executable names — including DOTTED names like
+//      `jwt_tool.py` / `python3.11`. (Regression guard: the original fix used
+//      /^[a-z0-9_-]+$/i, which excluded `.` and silently broke the
+//      commandExists("jwt_tool.py") fallback in jwtToolExists()/jwtToolAvailable().)
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  commandExists,
+  isSafeCommandName,
+} = require("../scripts/lib/command-exists.js");
+
+const INJECTION_PAYLOADS = [
+  "foo; rm -rf /",
+  "$(touch /tmp/x)",
+  "`id`",
+  "a|b",
+  "a&&b",
+  "a||b",
+  "a&b",
+  "a b",
+  "a>b",
+  "a<b",
+  "a/b",
+  "a'b",
+  'a"b',
+  "a\\b",
+  "a\nb",
+  "a*b",
+  "a(b)",
+  "a{b}",
+  "a=b",
+  "a~b",
+  "$PATH",
+  "../bin/sh",
+];
+
+const VALID_NAMES = [
+  "node",
+  "jwt_tool",
+  "jwt_tool.py", // the dotted name the original fix regressed
+  "python3",
+  "python3.11",
+  "sub-finder",
+  "Amass",
+  "x",
+];
+
+test("isSafeCommandName accepts dotted/letter/digit/_/- names and rejects everything else", () => {
+  for (const name of VALID_NAMES) {
+    assert.equal(isSafeCommandName(name), true, `${JSON.stringify(name)} must be accepted`);
+  }
+  for (const payload of INJECTION_PAYLOADS) {
+    assert.equal(isSafeCommandName(payload), false, `${JSON.stringify(payload)} must be rejected`);
+  }
+  // Non-strings and empty strings are rejected, not coerced.
+  for (const bad of [null, undefined, 42, {}, [], "", " "]) {
+    assert.equal(isSafeCommandName(bad), false, `${JSON.stringify(bad)} must be rejected`);
+  }
+});
+
+test("commandExists never lets an injected command reach the shell", () => {
+  // Each payload, if interpolated unguarded into `sh -c "command -v <payload>"`,
+  // would execute the injected `touch`. The guard must reject it (return false)
+  // BEFORE the shell runs, so the sentinel is never created.
+  const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "cmd-inj-"));
+  try {
+    const sentinel = path.join(sentinelDir, "PWNED");
+    // A payload that, unguarded, would create the sentinel.
+    const payload = `x; touch ${sentinel}`;
+    assert.equal(commandExists(payload), false, "injection payload must be rejected");
+    assert.equal(fs.existsSync(sentinel), false, "the shell must never have executed the injected touch");
+
+    // Backtick + $() forms too.
+    assert.equal(commandExists(`x\`touch ${sentinel}\``), false);
+    assert.equal(commandExists(`x$(touch ${sentinel})`), false);
+    assert.equal(fs.existsSync(sentinel), false, "no command-substitution form may execute");
+  } finally {
+    fs.rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("commandExists resolves a real dotted executable name on PATH (jwt_tool.py regression guard)", () => {
+  // Create an executable literally named `jwt_tool.py`, put its dir on PATH, and
+  // confirm commandExists finds it. Pre-fix (regex without `.`) this returned
+  // false even though the command exists — the silent jwt_tool.py regression.
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "cmd-bin-"));
+  const previousPath = process.env.PATH;
+  try {
+    const exe = path.join(binDir, "jwt_tool.py");
+    fs.writeFileSync(exe, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(exe, 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${previousPath}`;
+
+    assert.equal(commandExists("jwt_tool.py"), true, "a dotted executable on PATH must be detected");
+    // A valid-but-absent name still returns false (the probe really runs).
+    assert.equal(commandExists("definitely-not-a-real-command-xyz"), false);
+  } finally {
+    process.env.PATH = previousPath;
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
+test("commandExists detects a command that is genuinely present", () => {
+  // `sh` is guaranteed present (the probe itself uses it).
+  assert.equal(commandExists("sh"), true);
+});

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -65,6 +65,7 @@
   "test/realization-e2e-smoke.test.js",
   "test/installer-legacy-upgrade.test.js",
   "test/installer-bounty-tool-rewrite.test.js",
+  "test/command-exists.test.js",
   "test/agent-run-merge-gate.test.js",
   "test/claim-clusters-priors-saturation.test.js",
   "test/cross-stack-brief-composition.test.js",

--- a/test/prompt-contracts.test.js
+++ b/test/prompt-contracts.test.js
@@ -84,6 +84,7 @@ const {
   LIFECYCLE_STATE_VALUES,
 } = require("../mcp/lib/governance-contracts.js");
 const claimsModule = require("../mcp/lib/claims.js");
+const { BRUTALIST_MCP_SERVER } = require("../scripts/merge-claude-config.js");
 
 const ROOT = path.join(__dirname, "..");
 
@@ -1703,7 +1704,7 @@ test("Codex bundled .mcp.json registers brutalist as optional alongside the host
   const mcp = JSON.parse(readFile("adapters/codex/hacker-bob/.mcp.json"));
   assert.ok(mcp.mcpServers.brutalist);
   assert.equal(mcp.mcpServers.brutalist.command, "npx");
-  assert.deepEqual(mcp.mcpServers.brutalist.args, ["-y", "@brutalist/mcp@latest"]);
+  assert.deepEqual(mcp.mcpServers.brutalist.args, BRUTALIST_MCP_SERVER.args);
 });
 
 // =============================================================================

--- a/test/test-read-guard.py
+++ b/test/test-read-guard.py
@@ -210,6 +210,12 @@ TESTS = [
      {"tool_input": {"command": f"cat {SESSION}/raw-response-body.txt"}},
      2,
      "bob_read_session_summary"),
+
+    # --- shlex.split ValueError must block, not silently allow ---
+    ("Bash with unterminated quote blocks (shlex ValueError)",
+     {"tool_input": {"command": f"cat '{SESSION}/findings.jsonl"}},
+     2,
+     "cannot be safely parsed"),
 ]
 
 

--- a/test/test-write-guard.py
+++ b/test/test-write-guard.py
@@ -223,6 +223,11 @@ TESTS = [
     ("Bash with open() in echo string (not a real write) → allow",
      {"tool_input": {"command": "echo \"open('/tmp/test.json','w')\""}},
      0),
+
+    # --- shlex.split ValueError must block, not silently allow ---
+    ("Bash with unterminated quote blocks (shlex ValueError)",
+     {"tool_input": {"command": f"rm '{SESSION}/findings.jsonl"}},
+     2),
 ]
 
 


### PR DESCRIPTION
## Summary

Fixes three critical/immediate findings from a security audit of the framework:

- **Fix command injection in `commandExists()`** — `scripts/install.js:287` interpolates its argument into a shell string. Added input validation against `/^[a-z0-9_-]+$/i` before reaching the shell.
- **Pin `@brutalist/mcp` to 1.14.7** — All adapters ran `npx -y @brutalist/mcp@latest`, fetching whatever is newest on npm on every invocation. Pinned to `1.14.7` (matching CI) and centralized the constant so all adapters import from `scripts/merge-claude-config.js` instead of defining duplicates.
- **Block on `shlex.split` `ValueError` in session guards** — Both `session-read-guard.sh` and `session-write-guard.sh` silently allowed commands when `shlex.split` raised `ValueError` on malformed input (e.g. unterminated quotes). Now both guards exit 2 (block) on parse failure.

## Test plan

- [x] Install smoke tests pass (containerized `node --test test/install-smoke.test.js`)
- [x] CLI and prompt-contracts tests pass (`node --test test/cli.test.js test/prompt-contracts.test.js`)
- [x] Hook guard tests pass (`python3 test/test-write-guard.py && python3 test/test-read-guard.py`) — 69/69 and 51/51, including new ValueError bypass test cases
- [ ] Pre-existing `doctor` command failures in container environment are unrelated (confirmed identical on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hooks now reject malformed shell commands, emitting an error and exiting with status 2 to block unsafe execution.
  * Command-probing now validates command names to prevent shell injection.

* **Chores**
  * MCP server wiring consolidated to a shared configuration and pinned to `@brutalist/mcp`@1.14.7.
  * Centralized command-exists helper added and reused across scripts.

* **Tests**
  * Added tests for malformed-command blocking, command-name validation, and pinned MCP config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->