### PR TITLE
feat(verify): web-path severity-rise guard + smart-contract carve-out (PR2)

### DIFF
--- a/.claude/agents/balanced-verifier.md
+++ b/.claude/agents/balanced-verifier.md
@@ -89,7 +89,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `balanced.json` and the human/debug mirror.
 

--- a/.claude/agents/brutalist-verifier.md
+++ b/.claude/agents/brutalist-verifier.md
@@ -107,7 +107,7 @@ Each v1 `results` entry must include:
 
 For v2, the round must cover exactly the snapshot finding IDs and every `results` entry must also include:
 - `confidence`: `high|medium|low`
-- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`
+- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`, `exploit_replay_confirmed`
 - `state_sensitive`: boolean; set true when target state, auth state, chain state, or fresh replay timing could change the result
 - `artifact_hashes`: object of bounded replay/audit artifact hashes when available, otherwise `{}`
 
@@ -117,6 +117,7 @@ Suggested v2 confidence mapping:
 - Tooling/RPC blocked: include `tooling_blocked`, usually deny/fail closed unless local policy says otherwise.
 - Roast disagreement: include `roast_disagreement`.
 - Manual inference without replay: include `manual_inference`.
+- Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `brutalist.json` and the human/debug mirror.
 

--- a/.claude/agents/final-verifier.md
+++ b/.claude/agents/final-verifier.md
@@ -53,7 +53,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `verified-final.json` and the human/debug mirror.
 

--- a/adapters/codex/skills/bob-evaluate/SKILL.md
+++ b/adapters/codex/skills/bob-evaluate/SKILL.md
@@ -1727,7 +1727,7 @@ Each v1 `results` entry must include:
 
 For v2, the round must cover exactly the snapshot finding IDs and every `results` entry must also include:
 - `confidence`: `high|medium|low`
-- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`
+- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`, `exploit_replay_confirmed`
 - `state_sensitive`: boolean; set true when target state, auth state, chain state, or fresh replay timing could change the result
 - `artifact_hashes`: object of bounded replay/audit artifact hashes when available, otherwise `{}`
 
@@ -1737,6 +1737,7 @@ Suggested v2 confidence mapping:
 - Tooling/RPC blocked: include `tooling_blocked`, usually deny/fail closed unless local policy says otherwise.
 - Roast disagreement: include `roast_disagreement`.
 - Manual inference without replay: include `manual_inference`.
+- Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `brutalist.json` and the human/debug mirror.
 
@@ -1861,7 +1862,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `balanced.json` and the human/debug mirror.
 
@@ -1975,7 +1976,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `verified-final.json` and the human/debug mirror.
 

--- a/adapters/kimi/skills/bob-evaluate/SKILL.md
+++ b/adapters/kimi/skills/bob-evaluate/SKILL.md
@@ -1710,7 +1710,7 @@ Each v1 `results` entry must include:
 
 For v2, the round must cover exactly the snapshot finding IDs and every `results` entry must also include:
 - `confidence`: `high|medium|low`
-- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`
+- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`, `exploit_replay_confirmed`
 - `state_sensitive`: boolean; set true when target state, auth state, chain state, or fresh replay timing could change the result
 - `artifact_hashes`: object of bounded replay/audit artifact hashes when available, otherwise `{}`
 
@@ -1720,6 +1720,7 @@ Suggested v2 confidence mapping:
 - Tooling/RPC blocked: include `tooling_blocked`, usually deny/fail closed unless local policy says otherwise.
 - Roast disagreement: include `roast_disagreement`.
 - Manual inference without replay: include `manual_inference`.
+- Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `brutalist.json` and the human/debug mirror.
 
@@ -1844,7 +1845,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `balanced.json` and the human/debug mirror.
 
@@ -1958,7 +1959,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `verified-final.json` and the human/debug mirror.
 

--- a/mcp/lib/claims.js
+++ b/mcp/lib/claims.js
@@ -975,4 +975,6 @@ module.exports = {
   normalizeCandidateClaim,
   normalizeEvidenceReferenceShape,
   readCandidateClaims,
+  readOffensiveRunRecords,
+  offensiveRunRowSatisfiesEvidence,
 };

--- a/mcp/lib/constants.js
+++ b/mcp/lib/constants.js
@@ -76,6 +76,7 @@ const VERIFICATION_CONFIDENCE_REASON_VALUES = [
   "roast_disagreement",
   "disambiguation_failed",
   "agreement_not_replayed",
+  "exploit_replay_confirmed",
 ];
 const VERIFICATION_REASONING_DIVERGENCE_VALUES = [
   "none",

--- a/mcp/lib/pipeline-events.js
+++ b/mcp/lib/pipeline-events.js
@@ -2,9 +2,6 @@
 
 const fs = require("fs");
 const {
-  SEVERITY_VALUES,
-} = require("./constants.js");
-const {
   assertNonEmptyString,
 } = require("./validation.js");
 const {
@@ -104,29 +101,6 @@ function normalizeCounts(counts) {
   return Object.keys(normalized).length ? normalized : null;
 }
 
-// Bounded audit list of severity clamps applied by the web severity-rise guard.
-// Each entry is {finding_id, from, to}; capped and value-bounded so the event
-// stays small and free of free-text. Used by the "severity_clamped" event so a
-// runtime clamp is distinguishable from a verifier's choice in a persisted
-// artifact, not just the ephemeral tool response. `from`/`to` MUST be valid
-// round severities — enforced on both write and read so a hand-crafted/tampered
-// events log cannot inject bogus severity-transition records into operator audit
-// views.
-function normalizeClampList(clamps) {
-  if (!Array.isArray(clamps)) return null;
-  const normalized = [];
-  for (const clamp of clamps.slice(0, 50)) {
-    if (!isPlainObject(clamp)) continue;
-    const findingId = capString(clamp.finding_id, 64);
-    const from = capString(clamp.from, 40);
-    const to = capString(clamp.to, 40);
-    if (!findingId || !from || !to) continue;
-    if (!SEVERITY_VALUES.includes(from) || !SEVERITY_VALUES.includes(to)) continue;
-    normalized.push({ finding_id: findingId, from, to });
-  }
-  return normalized.length ? normalized : null;
-}
-
 function normalizeWaveNumber(value) {
   if (Number.isInteger(value) && value > 0) return value;
   if (typeof value === "string") {
@@ -205,7 +179,6 @@ function normalizePipelineEvent(targetDomain, type, fields = {}) {
   const blockCode = capString(fields.block_code, 120);
   const source = capString(fields.source, 120);
   const counts = normalizeCounts(fields.counts);
-  const clamps = normalizeClampList(fields.clamps);
   const kind = capString(fields.kind, 64);
   const identifierHint = capString(fields.identifier_hint, 64);
   if (agent) event.agent = agent;
@@ -213,7 +186,6 @@ function normalizePipelineEvent(targetDomain, type, fields = {}) {
   if (status) event.status = status;
   if (blockCode) event.block_code = blockCode;
   if (counts) event.counts = counts;
-  if (clamps) event.clamps = clamps;
   if (source) event.source = source;
   if (kind) event.kind = kind;
   if (identifierHint) event.identifier_hint = identifierHint;
@@ -389,8 +361,6 @@ function normalizePipelineEventForRead(record, expectedDomain) {
   if (waveNumber != null) event.wave_number = waveNumber;
   const counts = normalizeCounts(record.counts);
   if (counts) event.counts = counts;
-  const clamps = normalizeClampList(record.clamps);
-  if (clamps) event.clamps = clamps;
   if (typeof record.force_merge === "boolean") event.force_merge = record.force_merge;
   const forceMergeReason = capString(record.force_merge_reason, 1000);
   if (forceMergeReason) event.force_merge_reason = forceMergeReason;

--- a/mcp/lib/pipeline-events.js
+++ b/mcp/lib/pipeline-events.js
@@ -382,6 +382,8 @@ function normalizePipelineEventForRead(record, expectedDomain) {
   if (waveNumber != null) event.wave_number = waveNumber;
   const counts = normalizeCounts(record.counts);
   if (counts) event.counts = counts;
+  const clamps = normalizeClampList(record.clamps);
+  if (clamps) event.clamps = clamps;
   if (typeof record.force_merge === "boolean") event.force_merge = record.force_merge;
   const forceMergeReason = capString(record.force_merge_reason, 1000);
   if (forceMergeReason) event.force_merge_reason = forceMergeReason;

--- a/mcp/lib/pipeline-events.js
+++ b/mcp/lib/pipeline-events.js
@@ -2,6 +2,9 @@
 
 const fs = require("fs");
 const {
+  SEVERITY_VALUES,
+} = require("./constants.js");
+const {
   assertNonEmptyString,
 } = require("./validation.js");
 const {
@@ -105,7 +108,10 @@ function normalizeCounts(counts) {
 // Each entry is {finding_id, from, to}; capped and value-bounded so the event
 // stays small and free of free-text. Used by the "severity_clamped" event so a
 // runtime clamp is distinguishable from a verifier's choice in a persisted
-// artifact, not just the ephemeral tool response.
+// artifact, not just the ephemeral tool response. `from`/`to` MUST be valid
+// round severities — enforced on both write and read so a hand-crafted/tampered
+// events log cannot inject bogus severity-transition records into operator audit
+// views.
 function normalizeClampList(clamps) {
   if (!Array.isArray(clamps)) return null;
   const normalized = [];
@@ -115,6 +121,7 @@ function normalizeClampList(clamps) {
     const from = capString(clamp.from, 40);
     const to = capString(clamp.to, 40);
     if (!findingId || !from || !to) continue;
+    if (!SEVERITY_VALUES.includes(from) || !SEVERITY_VALUES.includes(to)) continue;
     normalized.push({ finding_id: findingId, from, to });
   }
   return normalized.length ? normalized : null;

--- a/mcp/lib/pipeline-events.js
+++ b/mcp/lib/pipeline-events.js
@@ -44,6 +44,7 @@ const PIPELINE_EVENT_TYPES = Object.freeze([
   "verification_attempt_archived",
   "verification_archive_pruned",
   "verification_written",
+  "severity_clamped",
   "evidence_written",
   "proof_bundle_written",
   "grade_written",
@@ -98,6 +99,25 @@ function normalizeCounts(counts) {
     }
   }
   return Object.keys(normalized).length ? normalized : null;
+}
+
+// Bounded audit list of severity clamps applied by the web severity-rise guard.
+// Each entry is {finding_id, from, to}; capped and value-bounded so the event
+// stays small and free of free-text. Used by the "severity_clamped" event so a
+// runtime clamp is distinguishable from a verifier's choice in a persisted
+// artifact, not just the ephemeral tool response.
+function normalizeClampList(clamps) {
+  if (!Array.isArray(clamps)) return null;
+  const normalized = [];
+  for (const clamp of clamps.slice(0, 50)) {
+    if (!isPlainObject(clamp)) continue;
+    const findingId = capString(clamp.finding_id, 64);
+    const from = capString(clamp.from, 40);
+    const to = capString(clamp.to, 40);
+    if (!findingId || !from || !to) continue;
+    normalized.push({ finding_id: findingId, from, to });
+  }
+  return normalized.length ? normalized : null;
 }
 
 function normalizeWaveNumber(value) {
@@ -178,6 +198,7 @@ function normalizePipelineEvent(targetDomain, type, fields = {}) {
   const blockCode = capString(fields.block_code, 120);
   const source = capString(fields.source, 120);
   const counts = normalizeCounts(fields.counts);
+  const clamps = normalizeClampList(fields.clamps);
   const kind = capString(fields.kind, 64);
   const identifierHint = capString(fields.identifier_hint, 64);
   if (agent) event.agent = agent;
@@ -185,6 +206,7 @@ function normalizePipelineEvent(targetDomain, type, fields = {}) {
   if (status) event.status = status;
   if (blockCode) event.block_code = blockCode;
   if (counts) event.counts = counts;
+  if (clamps) event.clamps = clamps;
   if (source) event.source = source;
   if (kind) event.kind = kind;
   if (identifierHint) event.identifier_hint = identifierHint;

--- a/mcp/lib/tools/write-verification-round.js
+++ b/mcp/lib/tools/write-verification-round.js
@@ -100,6 +100,7 @@ module.exports = wrapWriteTool({
             },
             "confidence_reasons": {
               "type": "array",
+              "description": "Effective confidence reasons for this result. NOTE: `exploit_replay_confirmed` is a proof claim — on web-scoped sessions the runtime preserves it (in any of the three reason arrays) ONLY when it backs a validated, exploit-proven severity rise; otherwise it is stripped from the persisted, content-hashed round artifact so it cannot stand as a false proof signal.",
               "items": {
                 "type": "string",
                 "enum": [

--- a/mcp/lib/tools/write-verification-round.js
+++ b/mcp/lib/tools/write-verification-round.js
@@ -110,7 +110,8 @@ module.exports = wrapWriteTool({
                   "manual_inference",
                   "roast_disagreement",
                   "disambiguation_failed",
-                  "agreement_not_replayed"
+                  "agreement_not_replayed",
+                  "exploit_replay_confirmed"
                 ]
               }
             },
@@ -138,7 +139,8 @@ module.exports = wrapWriteTool({
                   "manual_inference",
                   "roast_disagreement",
                   "disambiguation_failed",
-                  "agreement_not_replayed"
+                  "agreement_not_replayed",
+                  "exploit_replay_confirmed"
                 ]
               }
             },
@@ -154,7 +156,8 @@ module.exports = wrapWriteTool({
                   "manual_inference",
                   "roast_disagreement",
                   "disambiguation_failed",
-                  "agreement_not_replayed"
+                  "agreement_not_replayed",
+                  "exploit_replay_confirmed"
                 ]
               }
             }
@@ -188,4 +191,3 @@ module.exports = wrapWriteTool({
   sensitive_output: false,
   session_artifacts_written: ["brutalist.json","balanced.json","verified-final.json","verification-manifest.json"],
 });
-

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fs = require("fs");
 const {
   SEVERITY_VALUES,
   VERIFICATION_CONFIDENCE_REASON_VALUES,
@@ -17,6 +18,7 @@ const {
   parseFindingId,
 } = require("./validation.js");
 const {
+  sessionNucleusPath,
   verificationRoundPaths,
 } = require("./paths.js");
 const {
@@ -54,6 +56,9 @@ const {
 const {
   readSessionNucleus,
 } = require("./governance-store.js");
+const {
+  readSurfaceRoutesStrict,
+} = require("./surface-router.js");
 
 function verificationLib() {
   return require("./verification.js");
@@ -76,43 +81,93 @@ function toRoundSeverity(claimSeverity) {
   return claimSeverity === "informational" ? "info" : claimSeverity;
 }
 
+function routeIsSmartContract(route) {
+  if (!route || typeof route !== "object") return false;
+  if (route.surface_type === "smart_contract") return true;
+  if (typeof route.capability_pack === "string"
+    && route.capability_pack.startsWith("smart_contract")) return true;
+  return false;
+}
+
+// Trusted surface_id -> route map from the WRITE-GUARDED surface-routes.json
+// (classifySurfaceCapability output). This is the ONLY trustworthy SC signal:
+// an agent cannot tamper the routes file, whereas the claim payload is
+// arbitrary, agent-settable content (deriving the SC exemption from
+// claim.payload would let any web claim spoof the carve-out by injecting
+// sc_evidence). Missing/unreadable routes -> null: no exemption, the web clamp
+// proceeds (pure-web sessions have no SC routes, so this never weakens them).
+function smartContractSurfaceIdsFromRoutes(domain) {
+  let document;
+  try {
+    document = readSurfaceRoutesStrict(domain).document;
+  } catch {
+    return null;
+  }
+  const scSurfaceIds = new Set();
+  for (const route of document.routes) {
+    if (route && typeof route.surface_id === "string" && routeIsSmartContract(route)) {
+      scSurfaceIds.add(route.surface_id);
+    }
+  }
+  return scSurfaceIds;
+}
+
 // Web/smart_contract is a per-FINDING technology axis, orthogonal to session
 // scope: a single web-scoped session (scope_policy.target_url set) can carry
 // smart-contract surfaces in cross-stack mode (orchestrator.md "web +
 // smart_contract_evm"). The severity clamp is a WEB-only anti-inflation guard;
 // it must NEVER touch smart-contract findings, whose balanced-verifier
-// legitimately re-judges severity UPWARD from on-chain effect. The recorder
-// stamps the finding's surface_type / sc_evidence / capability_pack onto the
-// claim payload (record-candidate-claim.js buildClaimPayloadFromFinding), which
-// is the sanctioned place consumers read finding fields off a claim. None of
-// these signals can be present on a web finding, so this carve-out never
-// weakens the clamp on a pure-web engagement.
-function claimIsSmartContractFinding(claim) {
-  const payload = claim && typeof claim.payload === "object" && claim.payload !== null
-    ? claim.payload
-    : null;
-  const finding = payload && typeof payload.finding === "object" && payload.finding !== null
-    ? payload.finding
-    : null;
-  if (!finding) return false;
-  if (finding.surface_type === "smart_contract") return true;
-  if (finding.sc_evidence != null && typeof finding.sc_evidence === "object") return true;
-  if (typeof finding.capability_pack === "string"
-    && finding.capability_pack.startsWith("smart_contract")) return true;
-  return false;
+// legitimately re-judges severity UPWARD from on-chain effect. SC-ness is
+// resolved from the claim's surface_ids against the trusted routes — never from
+// the claim payload.
+function claimIsSmartContractFinding(claim, scSurfaceIds) {
+  if (!scSurfaceIds || scSurfaceIds.size === 0) return false;
+  const surfaceIds = Array.isArray(claim.surface_ids) ? claim.surface_ids : [];
+  return surfaceIds.some((surfaceId) => scSurfaceIds.has(surfaceId));
 }
 
+// Returns the list of clamps applied: [{ finding_id, from, to }]. Empty when
+// nothing was clamped (non-web session, no rise, all proven, or all SC).
 function clampUnprovenSeverityRises(domain, results) {
   let nucleus;
   try {
     nucleus = readSessionNucleus(domain);
-  } catch {
-    return;
+  } catch (error) {
+    // Security boundary vs. availability: a session-nucleus.json that EXISTS but
+    // fails to parse is a corrupt scope record on an established session — fail
+    // closed so the guard cannot be silently disabled by tampering the nucleus.
+    // If the nucleus is simply ABSENT and the state isn't readable either, scope
+    // is indeterminate (e.g. a partially-seeded session), so pass through rather
+    // than block verification. A real web session at VERIFY always derives a
+    // target_url nucleus from its readable state, so it never lands here.
+    if (fs.existsSync(sessionNucleusPath(domain))) {
+      throw new ToolError(
+        ERROR_CODES.STATE_CONFLICT,
+        `severity-rise guard could not read session nucleus: ${error.message || String(error)}`,
+      );
+    }
+    return [];
   }
-  if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return;
+  if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return [];
 
-  const freeze = readCurrentClaimFreeze(domain);
-  if (!freeze || !Array.isArray(freeze.claims)) return;
+  let freeze;
+  try {
+    freeze = readCurrentClaimFreeze(domain);
+  } catch (error) {
+    // Defense-in-depth: a corrupt freeze is already rejected upstream of this
+    // guard (v1 via findingIdSetForVerificationContext; v2 via the snapshot
+    // freshness check assertSnapshotMatchesFreeze), so this branch is not the
+    // first reader. If it is ever reached, fail closed rather than skip the
+    // guard. A missing freeze returns null (handled below) — only a corrupt
+    // one throws.
+    throw new ToolError(
+      ERROR_CODES.STATE_CONFLICT,
+      `severity-rise guard could not read claim freeze: ${error.message || String(error)}`,
+    );
+  }
+  if (!freeze || !Array.isArray(freeze.claims)) return [];
+
+  const scSurfaceIds = smartContractSurfaceIdsFromRoutes(domain);
 
   const byFinding = new Map();
   for (const claim of freeze.claims) {
@@ -123,7 +178,7 @@ function clampUnprovenSeverityRises(domain, results) {
       .filter((ref) => ref && ref.kind === "finding" && typeof ref.finding_id === "string")
       .map((ref) => ref.finding_id);
     const exploitRunRefs = refs.filter((ref) => ref && ref.kind === "exploit_run");
-    const smartContract = claimIsSmartContractFinding(claim);
+    const smartContract = claimIsSmartContractFinding(claim, scSurfaceIds);
     for (const findingId of findingIds) {
       const current = byFinding.get(findingId)
         || { maxRank: 0, maxSeverity: null, exploitRunRefs: [], isSmartContract: false };
@@ -139,6 +194,7 @@ function clampUnprovenSeverityRises(domain, results) {
     }
   }
 
+  const clamps = [];
   let runRows = null;
   let signingKey = null;
   for (const result of results) {
@@ -163,8 +219,16 @@ function clampUnprovenSeverityRises(domain, results) {
         ));
       }
     }
-    if (!proven) result.severity = toRoundSeverity(base.maxSeverity);
+    if (!proven) {
+      const from = result.severity;
+      const to = toRoundSeverity(base.maxSeverity);
+      if (to !== from) {
+        result.severity = to;
+        clamps.push({ finding_id: result.finding_id, from, to });
+      }
+    }
   }
+  return clamps;
 }
 
 function normalizeStringEnumArray(value, fieldName, allowedValues, { required = false } = {}) {
@@ -463,7 +527,7 @@ function writeVerificationRound(args) {
     }
   }
 
-  clampUnprovenSeverityRises(domain, results);
+  const severityClamps = clampUnprovenSeverityRises(domain, results);
 
   const document = {
     version: schemaVersion,
@@ -494,6 +558,11 @@ function writeVerificationRound(args) {
     results_count: results.length,
     written_json: paths.json,
   };
+  // Audit signal: surface the clamp so an operator (and the agent that
+  // submitted the higher severity) can tell a verifier's choice from a runtime
+  // clamp. Without this the persisted severity differs silently from the
+  // submitted one.
+  if (severityClamps.length > 0) response.severity_clamps = severityClamps;
   if (schemaVersion === 2) {
     response.verification_attempt_id = v2State.verification_attempt_id;
     response.verification_snapshot_hash = v2State.verification_snapshot_hash;
@@ -515,6 +584,14 @@ function writeVerificationRound(args) {
       confirmed: results.filter((result) => result.disposition === "confirmed").length,
     },
   }, safeGovernanceContextForDomain(domain));
+  if (severityClamps.length > 0) {
+    safeAppendPipelineEventDirect(domain, "severity_clamped", {
+      status: round,
+      source: "bob_write_verification_round",
+      counts: { clamped: severityClamps.length },
+      clamps: severityClamps,
+    }, safeGovernanceContextForDomain(domain));
+  }
   if (schemaVersion === 2) verificationLib().refreshVerificationManifest(domain, { throw_on_error: true });
   return JSON.stringify(response);
   });
@@ -543,5 +620,6 @@ module.exports = {
   renderVerificationRoundMarkdown,
   requirePriorVerificationRound,
   sortVerificationResultsByFindingIds,
+  verifySeverityRank,
   writeVerificationRound,
 };

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -41,9 +41,130 @@ const {
 const {
   findingIdSetForVerificationContext,
 } = require("./verification-finding-id-adapter.js");
+const {
+  readCurrentClaimFreeze,
+} = require("./claim-freeze.js");
+const {
+  readOffensiveRunRecords,
+  offensiveRunRowSatisfiesEvidence,
+} = require("./claims.js");
+const {
+  readHandoffSigningKey,
+} = require("./handoff-signing-key.js");
+const {
+  readSessionNucleus,
+} = require("./governance-store.js");
 
 function verificationLib() {
   return require("./verification.js");
+}
+
+const VERIFY_SEVERITY_RANK = Object.freeze({
+  info: 1,
+  informational: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  critical: 5,
+});
+
+function verifySeverityRank(severity) {
+  return (typeof severity === "string" && VERIFY_SEVERITY_RANK[severity.toLowerCase()]) || 0;
+}
+
+function toRoundSeverity(claimSeverity) {
+  return claimSeverity === "informational" ? "info" : claimSeverity;
+}
+
+// Web/smart_contract is a per-FINDING technology axis, orthogonal to session
+// scope: a single web-scoped session (scope_policy.target_url set) can carry
+// smart-contract surfaces in cross-stack mode (orchestrator.md "web +
+// smart_contract_evm"). The severity clamp is a WEB-only anti-inflation guard;
+// it must NEVER touch smart-contract findings, whose balanced-verifier
+// legitimately re-judges severity UPWARD from on-chain effect. The recorder
+// stamps the finding's surface_type / sc_evidence / capability_pack onto the
+// claim payload (record-candidate-claim.js buildClaimPayloadFromFinding), which
+// is the sanctioned place consumers read finding fields off a claim. None of
+// these signals can be present on a web finding, so this carve-out never
+// weakens the clamp on a pure-web engagement.
+function claimIsSmartContractFinding(claim) {
+  const payload = claim && typeof claim.payload === "object" && claim.payload !== null
+    ? claim.payload
+    : null;
+  const finding = payload && typeof payload.finding === "object" && payload.finding !== null
+    ? payload.finding
+    : null;
+  if (!finding) return false;
+  if (finding.surface_type === "smart_contract") return true;
+  if (finding.sc_evidence != null && typeof finding.sc_evidence === "object") return true;
+  if (typeof finding.capability_pack === "string"
+    && finding.capability_pack.startsWith("smart_contract")) return true;
+  return false;
+}
+
+function clampUnprovenSeverityRises(domain, results) {
+  let nucleus;
+  try {
+    nucleus = readSessionNucleus(domain);
+  } catch {
+    return;
+  }
+  if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return;
+
+  const freeze = readCurrentClaimFreeze(domain);
+  if (!freeze || !Array.isArray(freeze.claims)) return;
+
+  const byFinding = new Map();
+  for (const claim of freeze.claims) {
+    if (!claim || typeof claim !== "object") continue;
+    const rank = verifySeverityRank(claim.severity);
+    const refs = Array.isArray(claim.evidence_refs) ? claim.evidence_refs : [];
+    const findingIds = refs
+      .filter((ref) => ref && ref.kind === "finding" && typeof ref.finding_id === "string")
+      .map((ref) => ref.finding_id);
+    const exploitRunRefs = refs.filter((ref) => ref && ref.kind === "exploit_run");
+    const smartContract = claimIsSmartContractFinding(claim);
+    for (const findingId of findingIds) {
+      const current = byFinding.get(findingId)
+        || { maxRank: 0, maxSeverity: null, exploitRunRefs: [], isSmartContract: false };
+      if (rank > current.maxRank) {
+        current.maxRank = rank;
+        current.maxSeverity = claim.severity;
+      }
+      // Any contributing smart-contract claim marks the whole finding off-limits
+      // to the clamp (conservative toward the spec invariant).
+      if (smartContract) current.isSmartContract = true;
+      for (const ref of exploitRunRefs) current.exploitRunRefs.push(ref);
+      byFinding.set(findingId, current);
+    }
+  }
+
+  let runRows = null;
+  let signingKey = null;
+  for (const result of results) {
+    if (!result || typeof result.severity !== "string") continue;
+    const base = byFinding.get(result.finding_id);
+    if (!base || base.maxRank === 0) continue;
+    // Spec invariant: never clamp smart-contract findings, even inside a
+    // web-scoped (cross-stack) session. Their upward on-chain severity re-judge
+    // is legitimate and proof-free.
+    if (base.isSmartContract) continue;
+    if (verifySeverityRank(result.severity) <= base.maxRank) continue;
+
+    const hasExploitReplaySignal = Array.isArray(result.confidence_reasons)
+      && result.confidence_reasons.includes("exploit_replay_confirmed");
+    let proven = false;
+    if (hasExploitReplaySignal && base.exploitRunRefs.length > 0) {
+      if (runRows === null) runRows = readOffensiveRunRecords(domain);
+      if (runRows.length > 0) {
+        if (signingKey === null) signingKey = readHandoffSigningKey(domain);
+        proven = base.exploitRunRefs.some((ref) => (
+          runRows.some((row) => offensiveRunRowSatisfiesEvidence(row, ref, domain, signingKey))
+        ));
+      }
+    }
+    if (!proven) result.severity = toRoundSeverity(base.maxSeverity);
+  }
 }
 
 function normalizeStringEnumArray(value, fieldName, allowedValues, { required = false } = {}) {
@@ -341,6 +462,8 @@ function writeVerificationRound(args) {
       throw new ToolError(ERROR_CODES.INVALID_ARGUMENTS, "adjudication_plan_hash is only allowed for final v2 verification");
     }
   }
+
+  clampUnprovenSeverityRises(domain, results);
 
   const document = {
     version: schemaVersion,

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -18,7 +18,7 @@ const {
   parseFindingId,
 } = require("./validation.js");
 const {
-  sessionNucleusPath,
+  surfaceRoutesPath,
   verificationRoundPaths,
 } = require("./paths.js");
 const {
@@ -54,8 +54,11 @@ const {
   readHandoffSigningKey,
 } = require("./handoff-signing-key.js");
 const {
-  readSessionNucleus,
-} = require("./governance-store.js");
+  sessionNucleusFromState,
+} = require("./governance-contracts.js");
+const {
+  readSessionStateStrict,
+} = require("./session-state-store.js");
 const {
   readSurfaceRoutesStrict,
 } = require("./surface-router.js");
@@ -100,8 +103,19 @@ function smartContractSurfaceIdsFromRoutes(domain) {
   let document;
   try {
     document = readSurfaceRoutesStrict(domain).document;
-  } catch {
-    return null;
+  } catch (error) {
+    // ABSENT routes = a pure-web (or pre-routing) session with no SC surfaces:
+    // no exemption needed. But a routes file that EXISTS yet fails to parse
+    // means we cannot identify SC findings; silently treating them as web would
+    // clamp a smart-contract finding's legitimate on-chain re-judge — the exact
+    // thing the invariant forbids — so fail CLOSED instead.
+    if (fs.existsSync(surfaceRoutesPath(domain))) {
+      throw new ToolError(
+        ERROR_CODES.STATE_CONFLICT,
+        `severity-rise guard could not read surface routes: ${error.message || String(error)}`,
+      );
+    }
+    return new Set();
   }
   const scSurfaceIds = new Set();
   for (const route of document.routes) {
@@ -134,21 +148,16 @@ function claimIsSmartContractFinding(claim, scSurfaceIds) {
 function applyUnprovenSeverityClamps(domain, results) {
   let nucleus;
   try {
-    nucleus = readSessionNucleus(domain);
-  } catch (error) {
-    // Security boundary vs. availability: a session-nucleus.json that EXISTS but
-    // fails to parse is a corrupt scope record on an established session — fail
-    // closed so the guard cannot be silently disabled by tampering the nucleus.
-    // If the nucleus is simply ABSENT and the state isn't readable either, scope
-    // is indeterminate (e.g. a partially-seeded session), so pass through rather
-    // than block verification. A real web session at VERIFY always derives a
-    // target_url nucleus from its readable state, so it never lands here.
-    if (fs.existsSync(sessionNucleusPath(domain))) {
-      throw new ToolError(
-        ERROR_CODES.STATE_CONFLICT,
-        `severity-rise guard could not read session nucleus: ${error.message || String(error)}`,
-      );
-    }
+    // Derive web-scope from the VALIDATED session state (the write tool authority
+    // validates state.json before this handler), NOT from session-nucleus.json.
+    // The nucleus file is not write-guarded, so reading it would let a corrupt
+    // or semantically-drifted nucleus (target_url removed / swapped for
+    // target_repo) silently disable the guard on a session whose state still
+    // authorizes a web target. State is the trustworthy scope authority here.
+    nucleus = sessionNucleusFromState(readSessionStateStrict(domain).state);
+  } catch {
+    // No readable/validated state: scope is indeterminate (e.g. a partially
+    // seeded session) — pass through rather than block verification.
     return [];
   }
   if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return [];
@@ -210,25 +219,30 @@ function applyUnprovenSeverityClamps(domain, results) {
     if (base.isSmartContract) continue;
     if (verifySeverityRank(result.severity) <= base.maxRank) continue;
 
-    // The exploit-backed allow-path is a FLOOR, not proof of the asserted
-    // severity: it confirms the finding has SOME real, MAC-signed exploit row in
-    // the ledger, raising the bar from "zero proof" to "a genuine exploit +
-    // verifier assertion". It does NOT yet prove the replay demonstrated THIS
-    // higher severity (the row carries no impact/severity binding). Closing that
-    // gap is a HARD REQUIREMENT of the future offensive-runner PR: it must bind
-    // each row to the demonstrated impact and anchor it to the current
-    // verification window (e.g. a verification_exploit_run ref kind), and this
-    // check must then verify that binding. Until the runner exists this branch
-    // is dormant (readOffensiveRunRecords returns []), so every web rise clamps.
+    // The exploit-backed allow-path requires proof bound to the ASSERTED
+    // severity, not merely that some exploit row exists. A matching, MAC-signed
+    // row must carry a `demonstrated_severity` (the impact tier the safe exploit
+    // actually demonstrated, MAC-covered so it can't be forged) that meets or
+    // exceeds `result.severity`. This closes the gap both reviewers flagged: a
+    // low-severity row (e.g. a reflected canary) can no longer unlock a critical
+    // rise. Because no producer writes `demonstrated_severity` yet (the offensive
+    // runner is a future PR), `verifySeverityRank(undefined)` is 0 and this never
+    // passes today — the branch is dormant and every unproven web rise clamps.
+    // The runner PR must set `demonstrated_severity` AND anchor each row to the
+    // current verification window (replay freshness) before relying on it.
     const hasExploitReplaySignal = Array.isArray(result.confidence_reasons)
       && result.confidence_reasons.includes("exploit_replay_confirmed");
+    const assertedRank = verifySeverityRank(result.severity);
     let proven = false;
     if (hasExploitReplaySignal && base.exploitRunRefs.length > 0) {
       if (runRows === null) runRows = readOffensiveRunRecords(domain);
       if (runRows.length > 0) {
         if (signingKey === null) signingKey = readHandoffSigningKey(domain);
         proven = base.exploitRunRefs.some((ref) => (
-          runRows.some((row) => offensiveRunRowSatisfiesEvidence(row, ref, domain, signingKey))
+          runRows.some((row) => (
+            offensiveRunRowSatisfiesEvidence(row, ref, domain, signingKey)
+            && verifySeverityRank(row.demonstrated_severity) >= assertedRank
+          ))
         ));
       }
     }

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -81,6 +81,14 @@ function toRoundSeverity(claimSeverity) {
   return claimSeverity === "informational" ? "info" : claimSeverity;
 }
 
+// The three v2 result fields that can carry confidence reasons. An unvalidated
+// `exploit_replay_confirmed` proof claim must be stripped from all of them.
+const REASON_ARRAY_FIELDS = Object.freeze([
+  "confidence_reasons",
+  "inherited_confidence_reasons",
+  "resolved_confidence_reasons",
+]);
+
 // MUTATES `results` in place: lowers `result.severity` for each unproven
 // severity rise, and strips a `exploit_replay_confirmed` reason that did not
 // back a validated rise. Returns the list of clamps applied:
@@ -198,8 +206,11 @@ function clampResultSeveritiesInPlace(domain, results) {
       // rise. No producer writes `demonstrated_severity` yet (the offensive
       // runner is a future PR), so `verifySeverityRank(undefined)` is 0 and this
       // never passes today: the branch is dormant and every unproven rise clamps.
-      // The runner PR must set `demonstrated_severity` AND anchor each row to the
-      // current verification window (replay freshness) before relying on it.
+      // The runner PR must (a) write `demonstrated_severity` as a valid
+      // SEVERITY_VALUES member before signing — an unrecognized value ranks 0 and
+      // silently never unlocks (fail-safe but unobservable), (b) anchor each row
+      // to the current verification window (replay freshness), and (c) bind the
+      // row to the specific finding it proves — before relying on this path.
       const assertedRank = verifySeverityRank(result.severity);
       if (hasExploitReplaySignal && base.exploitRunRefs.length > 0) {
         if (runRows === null) runRows = readOffensiveRunRecords(domain);
@@ -225,11 +236,19 @@ function clampResultSeveritiesInPlace(domain, results) {
 
     // `exploit_replay_confirmed` is a proof claim. Keep it ONLY when it backed a
     // validated severity rise; on a non-rise, an unproven (clamped) rise, or a
-    // finding with no frozen baseline, strip it so the persisted, content-hashed
-    // round artifact never carries a false exploit-proof audit signal.
-    if (hasExploitReplaySignal && !provenRise) {
-      result.confidence_reasons = result.confidence_reasons
-        .filter((reason) => reason !== "exploit_replay_confirmed");
+    // finding with no frozen baseline, strip it from ALL THREE persisted reason
+    // arrays (confidence_reasons + the inherited_/resolved_ provenance arrays,
+    // which the tool schema also permits to carry it) so the content-hashed round
+    // artifact never carries a false exploit-proof audit signal — in any field.
+    const exploitReasonAnywhere = REASON_ARRAY_FIELDS.some((field) => (
+      Array.isArray(result[field]) && result[field].includes("exploit_replay_confirmed")
+    ));
+    if (exploitReasonAnywhere && !provenRise) {
+      for (const field of REASON_ARRAY_FIELDS) {
+        if (Array.isArray(result[field])) {
+          result[field] = result[field].filter((reason) => reason !== "exploit_replay_confirmed");
+        }
+      }
     }
   }
   return clamps;

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -18,7 +18,7 @@ const {
   parseFindingId,
 } = require("./validation.js");
 const {
-  surfaceRoutesPath,
+  statePath,
   verificationRoundPaths,
 } = require("./paths.js");
 const {
@@ -59,9 +59,6 @@ const {
 const {
   readSessionStateStrict,
 } = require("./session-state-store.js");
-const {
-  readSurfaceRoutesStrict,
-} = require("./surface-router.js");
 
 function verificationLib() {
   return require("./verification.js");
@@ -84,56 +81,30 @@ function toRoundSeverity(claimSeverity) {
   return claimSeverity === "informational" ? "info" : claimSeverity;
 }
 
-function routeIsSmartContract(route) {
-  if (!route || typeof route !== "object") return false;
-  if (route.surface_type === "smart_contract") return true;
-  if (typeof route.capability_pack === "string"
-    && route.capability_pack.startsWith("smart_contract")) return true;
-  return false;
-}
-
-// Does this session route ANY smart-contract surface? Read from the trusted,
-// WRITE-GUARDED surface-routes.json (classifySurfaceCapability output) — an
-// agent cannot add or remove a route, so this session-level signal cannot be
-// spoofed. We deliberately do NOT key the carve-out off per-finding data: a
-// claim's surface_ids / payload / capability_pack are all agent-settable (the
-// no-wave bob_record_candidate_claim path does not validate surface assignment),
-// so a per-finding "is this SC?" test lets a web claim cite an SC surface_id to
-// dodge the clamp. ABSENT routes = pure-web (or pre-routing) session, no SC;
-// a routes file that EXISTS yet fails to parse fails CLOSED (we cannot rule out
-// SC surfaces, and clamping an SC re-judge would violate the invariant).
-function sessionHasSmartContractRoutes(domain) {
-  let document;
-  try {
-    document = readSurfaceRoutesStrict(domain).document;
-  } catch (error) {
-    if (fs.existsSync(surfaceRoutesPath(domain))) {
-      throw new ToolError(
-        ERROR_CODES.STATE_CONFLICT,
-        `severity-rise guard could not read surface routes: ${error.message || String(error)}`,
-      );
-    }
-    return false;
-  }
-  return document.routes.some((route) => routeIsSmartContract(route));
-}
-
-// MUTATES `results` in place: lowers `result.severity` for each unproven web
-// severity rise. Returns the list of clamps applied: [{ finding_id, from, to }],
-// empty when nothing was clamped (non-web session, cross-stack session, no rise,
-// or all proven). The in-place mutation is load-bearing — the same array is
-// serialized into the persisted round document by the caller.
+// MUTATES `results` in place: lowers `result.severity` for each unproven
+// severity rise, and strips a `exploit_replay_confirmed` reason that did not
+// back a validated rise. Returns the list of clamps applied:
+// [{ finding_id, from, to }]. The in-place mutation is load-bearing — the same
+// array is serialized into the persisted round document by the caller (hence
+// the explicit "InPlace" name).
 //
-// SCOPE: this is a PURE-WEB anti-inflation guard. The web/smart_contract axis is
-// per-finding (a web-scoped session can carry SC surfaces in cross-stack mode,
-// orchestrator.md "web + smart_contract_evm"), and the smart-contract
-// balanced-verifier legitimately re-judges severity UPWARD from on-chain effect.
-// Reliably separating web from SC findings per-claim would require a trusted
-// finding->surface assignment binding the claim layer does not provide, so the
-// guard scopes itself to sessions that route NO smart-contract surface. Pure-web
-// (the common case) is fully guarded; cross-stack sessions are left exactly as
-// they were before this guard existed — a strict, non-regressing addition.
-function applyUnprovenSeverityClamps(domain, results) {
+// SCOPE: this is an anti-inflation guard for WEB-SCOPED sessions
+// (scope_policy.target_url set), applied UNIFORMLY to every finding in such a
+// session. We deliberately do NOT carve out smart-contract findings. The
+// web/smart_contract axis is per-finding, but every per-finding and
+// per-session SC signal available before VERIFY is agent-influenced — claim
+// surface_ids / payload (agent-recorded), and even surface routes (an evaluator
+// can inject a synthetic smart-contract surface.observed via
+// bob_append_frontier_event that routing then classifies). A spoofable SC
+// exemption is strictly worse than none: it is an inflation bypass. The only
+// trusted, non-agent signal is the init-time session scope, so the guard keys
+// off that alone. Consequence: in a cross-stack web+SC session a smart-contract
+// finding is also held to its FROZEN (evaluator-recorded) severity unless
+// exploit-proven — the evaluator's assessment is the trusted baseline, and an
+// unproven verification-time raise above it is clamped, exactly as for web.
+// (Pure smart-contract engagements are repo-scoped — no target_url — and are
+// untouched by this guard.)
+function clampResultSeveritiesInPlace(domain, results) {
   let nucleus;
   try {
     // Derive web-scope from the VALIDATED session state (the write tool authority
@@ -143,22 +114,21 @@ function applyUnprovenSeverityClamps(domain, results) {
     // target_repo) silently disable the guard on a session whose state still
     // authorizes a web target. State is the trustworthy scope authority here.
     nucleus = sessionNucleusFromState(readSessionStateStrict(domain).state);
-  } catch {
-    // No readable/validated state: scope is indeterminate (e.g. a partially
-    // seeded session) — pass through rather than block verification. In
-    // production this branch is effectively unreachable: the write tool authority
-    // validates state.json before this handler runs, so a readable, validated
-    // state is a precondition of reaching it. The durable audit of any clamp
-    // lives in the persisted round document (`severity_clamps`), so a clamp can
-    // always be reconstructed from the content-hashed artifact.
+  } catch (error) {
+    // Distinguish "no state file yet" (a partially-seeded / pre-state session:
+    // pass through, nothing to guard) from a state file that EXISTS but is
+    // unreadable/corrupt (transient I/O, partial write, parse error: fail closed
+    // rather than silently skip the guard). In production neither occurs — the
+    // write tool authority validates state.json before this handler runs.
+    if (fs.existsSync(statePath(domain))) {
+      throw new ToolError(
+        ERROR_CODES.STATE_CONFLICT,
+        `severity-rise guard could not read session state: ${error.message || String(error)}`,
+      );
+    }
     return [];
   }
   if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return [];
-
-  // Cross-stack gate (see SCOPE note above): a session that routes any
-  // smart-contract surface is a mixed engagement; the pure-web clamp does not
-  // apply. Trusted, spoof-proof, session-level.
-  if (sessionHasSmartContractRoutes(domain)) return [];
 
   let freeze;
   try {
@@ -185,13 +155,16 @@ function applyUnprovenSeverityClamps(domain, results) {
     const findingIds = refs
       .filter((ref) => ref && ref.kind === "finding" && typeof ref.finding_id === "string")
       .map((ref) => ref.finding_id);
-    // NOTE: exploit_run refs are collected at CLAIM granularity and attached to
-    // every finding the claim references. For multi-finding claims this lets a
-    // row demonstrated for one finding stand for a sibling. Today claims carry a
-    // single finding ref and the allow-path is dormant; binding each exploit row
-    // to the specific finding it proves is a hard requirement of the future
-    // offensive-runner PR (same requirement as the cross-finding-replay note).
-    const exploitRunRefs = refs.filter((ref) => ref && ref.kind === "exploit_run");
+    // Bind exploit_run refs to a finding ONLY when the claim references exactly
+    // one finding. A multi-finding claim carrying an exploit row would otherwise
+    // let a row demonstrated for one finding stand as proof for a sibling
+    // (cross-finding spillover); refuse to propagate it. The remaining
+    // per-finding row->impact binding (which run proves which severity) is a hard
+    // requirement of the future offensive-runner PR; the allow-path is dormant
+    // until then.
+    const exploitRunRefs = findingIds.length === 1
+      ? refs.filter((ref) => ref && ref.kind === "exploit_run")
+      : [];
     for (const findingId of findingIds) {
       const current = byFinding.get(findingId)
         || { maxRank: 0, maxSeverity: null, exploitRunRefs: [] };
@@ -209,44 +182,54 @@ function applyUnprovenSeverityClamps(domain, results) {
   let signingKey = null;
   for (const result of results) {
     if (!result || typeof result.severity !== "string") continue;
-    const base = byFinding.get(result.finding_id);
-    if (!base || base.maxRank === 0) continue;
-    if (verifySeverityRank(result.severity) <= base.maxRank) continue;
 
-    // The exploit-backed allow-path requires proof bound to the ASSERTED
-    // severity, not merely that some exploit row exists. A matching, MAC-signed
-    // row must carry a `demonstrated_severity` (the impact tier the safe exploit
-    // actually demonstrated, MAC-covered so it can't be forged) that meets or
-    // exceeds `result.severity`. This closes the gap both reviewers flagged: a
-    // low-severity row (e.g. a reflected canary) can no longer unlock a critical
-    // rise. Because no producer writes `demonstrated_severity` yet (the offensive
-    // runner is a future PR), `verifySeverityRank(undefined)` is 0 and this never
-    // passes today — the branch is dormant and every unproven web rise clamps.
-    // The runner PR must set `demonstrated_severity` AND anchor each row to the
-    // current verification window (replay freshness) before relying on it.
     const hasExploitReplaySignal = Array.isArray(result.confidence_reasons)
       && result.confidence_reasons.includes("exploit_replay_confirmed");
-    const assertedRank = verifySeverityRank(result.severity);
-    let proven = false;
-    if (hasExploitReplaySignal && base.exploitRunRefs.length > 0) {
-      if (runRows === null) runRows = readOffensiveRunRecords(domain);
-      if (runRows.length > 0) {
-        if (signingKey === null) signingKey = readHandoffSigningKey(domain);
-        proven = base.exploitRunRefs.some((ref) => (
-          runRows.some((row) => (
-            offensiveRunRowSatisfiesEvidence(row, ref, domain, signingKey)
-            && verifySeverityRank(row.demonstrated_severity) >= assertedRank
-          ))
-        ));
+    let provenRise = false;
+
+    const base = byFinding.get(result.finding_id);
+    if (base && base.maxRank > 0 && verifySeverityRank(result.severity) > base.maxRank) {
+      // A rise above the frozen baseline. The exploit-backed allow-path requires
+      // proof bound to the ASSERTED severity, not merely that some exploit row
+      // exists. A matching, MAC-signed row must carry a `demonstrated_severity`
+      // (the impact tier the safe exploit actually demonstrated, MAC-covered so
+      // it can't be forged) that meets or exceeds `result.severity` — a
+      // low-severity row (e.g. a reflected canary) can never unlock a critical
+      // rise. No producer writes `demonstrated_severity` yet (the offensive
+      // runner is a future PR), so `verifySeverityRank(undefined)` is 0 and this
+      // never passes today: the branch is dormant and every unproven rise clamps.
+      // The runner PR must set `demonstrated_severity` AND anchor each row to the
+      // current verification window (replay freshness) before relying on it.
+      const assertedRank = verifySeverityRank(result.severity);
+      if (hasExploitReplaySignal && base.exploitRunRefs.length > 0) {
+        if (runRows === null) runRows = readOffensiveRunRecords(domain);
+        if (runRows.length > 0) {
+          if (signingKey === null) signingKey = readHandoffSigningKey(domain);
+          provenRise = base.exploitRunRefs.some((ref) => (
+            runRows.some((row) => (
+              offensiveRunRowSatisfiesEvidence(row, ref, domain, signingKey)
+              && verifySeverityRank(row.demonstrated_severity) >= assertedRank
+            ))
+          ));
+        }
+      }
+      if (!provenRise) {
+        const from = result.severity;
+        const to = toRoundSeverity(base.maxSeverity);
+        if (to !== from) {
+          result.severity = to;
+          clamps.push({ finding_id: result.finding_id, from, to });
+        }
       }
     }
-    if (!proven) {
-      const from = result.severity;
-      const to = toRoundSeverity(base.maxSeverity);
-      if (to !== from) {
-        result.severity = to;
-        clamps.push({ finding_id: result.finding_id, from, to });
-      }
+
+    // `exploit_replay_confirmed` is a proof claim. Keep it ONLY when it backed a
+    // validated severity rise; on a non-rise, an unproven (clamped) rise, or a
+    // finding with no frozen baseline, strip it so the persisted, content-hashed
+    // round artifact never carries a false exploit-proof audit signal.
+    if (hasExploitReplaySignal && !provenRise) {
+      result.confidence_reasons = result.confidence_reasons
+        .filter((reason) => reason !== "exploit_replay_confirmed");
     }
   }
   return clamps;
@@ -568,7 +551,7 @@ function writeVerificationRound(args) {
     }
   }
 
-  const severityClamps = applyUnprovenSeverityClamps(domain, results);
+  const severityClamps = clampResultSeveritiesInPlace(domain, results);
 
   const document = {
     version: schemaVersion,

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -92,59 +92,47 @@ function routeIsSmartContract(route) {
   return false;
 }
 
-// Trusted surface_id -> route map from the WRITE-GUARDED surface-routes.json
-// (classifySurfaceCapability output). This is the ONLY trustworthy SC signal:
-// an agent cannot tamper the routes file, whereas the claim payload is
-// arbitrary, agent-settable content (deriving the SC exemption from
-// claim.payload would let any web claim spoof the carve-out by injecting
-// sc_evidence). Missing/unreadable routes -> null: no exemption, the web clamp
-// proceeds (pure-web sessions have no SC routes, so this never weakens them).
-function smartContractSurfaceIdsFromRoutes(domain) {
+// Does this session route ANY smart-contract surface? Read from the trusted,
+// WRITE-GUARDED surface-routes.json (classifySurfaceCapability output) — an
+// agent cannot add or remove a route, so this session-level signal cannot be
+// spoofed. We deliberately do NOT key the carve-out off per-finding data: a
+// claim's surface_ids / payload / capability_pack are all agent-settable (the
+// no-wave bob_record_candidate_claim path does not validate surface assignment),
+// so a per-finding "is this SC?" test lets a web claim cite an SC surface_id to
+// dodge the clamp. ABSENT routes = pure-web (or pre-routing) session, no SC;
+// a routes file that EXISTS yet fails to parse fails CLOSED (we cannot rule out
+// SC surfaces, and clamping an SC re-judge would violate the invariant).
+function sessionHasSmartContractRoutes(domain) {
   let document;
   try {
     document = readSurfaceRoutesStrict(domain).document;
   } catch (error) {
-    // ABSENT routes = a pure-web (or pre-routing) session with no SC surfaces:
-    // no exemption needed. But a routes file that EXISTS yet fails to parse
-    // means we cannot identify SC findings; silently treating them as web would
-    // clamp a smart-contract finding's legitimate on-chain re-judge — the exact
-    // thing the invariant forbids — so fail CLOSED instead.
     if (fs.existsSync(surfaceRoutesPath(domain))) {
       throw new ToolError(
         ERROR_CODES.STATE_CONFLICT,
         `severity-rise guard could not read surface routes: ${error.message || String(error)}`,
       );
     }
-    return new Set();
+    return false;
   }
-  const scSurfaceIds = new Set();
-  for (const route of document.routes) {
-    if (route && typeof route.surface_id === "string" && routeIsSmartContract(route)) {
-      scSurfaceIds.add(route.surface_id);
-    }
-  }
-  return scSurfaceIds;
-}
-
-// Web/smart_contract is a per-FINDING technology axis, orthogonal to session
-// scope: a single web-scoped session (scope_policy.target_url set) can carry
-// smart-contract surfaces in cross-stack mode (orchestrator.md "web +
-// smart_contract_evm"). The severity clamp is a WEB-only anti-inflation guard;
-// it must NEVER touch smart-contract findings, whose balanced-verifier
-// legitimately re-judges severity UPWARD from on-chain effect. SC-ness is
-// resolved from the claim's surface_ids against the trusted routes — never from
-// the claim payload.
-function claimIsSmartContractFinding(claim, scSurfaceIds) {
-  if (!scSurfaceIds || scSurfaceIds.size === 0) return false;
-  const surfaceIds = Array.isArray(claim.surface_ids) ? claim.surface_ids : [];
-  return surfaceIds.some((surfaceId) => scSurfaceIds.has(surfaceId));
+  return document.routes.some((route) => routeIsSmartContract(route));
 }
 
 // MUTATES `results` in place: lowers `result.severity` for each unproven web
 // severity rise. Returns the list of clamps applied: [{ finding_id, from, to }],
-// empty when nothing was clamped (non-web session, no rise, all proven, or all
-// SC). The in-place mutation is load-bearing — the same array is serialized into
-// the persisted round document by the caller.
+// empty when nothing was clamped (non-web session, cross-stack session, no rise,
+// or all proven). The in-place mutation is load-bearing — the same array is
+// serialized into the persisted round document by the caller.
+//
+// SCOPE: this is a PURE-WEB anti-inflation guard. The web/smart_contract axis is
+// per-finding (a web-scoped session can carry SC surfaces in cross-stack mode,
+// orchestrator.md "web + smart_contract_evm"), and the smart-contract
+// balanced-verifier legitimately re-judges severity UPWARD from on-chain effect.
+// Reliably separating web from SC findings per-claim would require a trusted
+// finding->surface assignment binding the claim layer does not provide, so the
+// guard scopes itself to sessions that route NO smart-contract surface. Pure-web
+// (the common case) is fully guarded; cross-stack sessions are left exactly as
+// they were before this guard existed — a strict, non-regressing addition.
 function applyUnprovenSeverityClamps(domain, results) {
   let nucleus;
   try {
@@ -157,10 +145,20 @@ function applyUnprovenSeverityClamps(domain, results) {
     nucleus = sessionNucleusFromState(readSessionStateStrict(domain).state);
   } catch {
     // No readable/validated state: scope is indeterminate (e.g. a partially
-    // seeded session) — pass through rather than block verification.
+    // seeded session) — pass through rather than block verification. In
+    // production this branch is effectively unreachable: the write tool authority
+    // validates state.json before this handler runs, so a readable, validated
+    // state is a precondition of reaching it. The durable audit of any clamp
+    // lives in the persisted round document (`severity_clamps`), so a clamp can
+    // always be reconstructed from the content-hashed artifact.
     return [];
   }
   if (!nucleus || nucleus.scope_policy == null || nucleus.scope_policy.target_url == null) return [];
+
+  // Cross-stack gate (see SCOPE note above): a session that routes any
+  // smart-contract surface is a mixed engagement; the pure-web clamp does not
+  // apply. Trusted, spoof-proof, session-level.
+  if (sessionHasSmartContractRoutes(domain)) return [];
 
   let freeze;
   try {
@@ -179,8 +177,6 @@ function applyUnprovenSeverityClamps(domain, results) {
   }
   if (!freeze || !Array.isArray(freeze.claims)) return [];
 
-  const scSurfaceIds = smartContractSurfaceIdsFromRoutes(domain);
-
   const byFinding = new Map();
   for (const claim of freeze.claims) {
     if (!claim || typeof claim !== "object") continue;
@@ -189,18 +185,20 @@ function applyUnprovenSeverityClamps(domain, results) {
     const findingIds = refs
       .filter((ref) => ref && ref.kind === "finding" && typeof ref.finding_id === "string")
       .map((ref) => ref.finding_id);
+    // NOTE: exploit_run refs are collected at CLAIM granularity and attached to
+    // every finding the claim references. For multi-finding claims this lets a
+    // row demonstrated for one finding stand for a sibling. Today claims carry a
+    // single finding ref and the allow-path is dormant; binding each exploit row
+    // to the specific finding it proves is a hard requirement of the future
+    // offensive-runner PR (same requirement as the cross-finding-replay note).
     const exploitRunRefs = refs.filter((ref) => ref && ref.kind === "exploit_run");
-    const smartContract = claimIsSmartContractFinding(claim, scSurfaceIds);
     for (const findingId of findingIds) {
       const current = byFinding.get(findingId)
-        || { maxRank: 0, maxSeverity: null, exploitRunRefs: [], isSmartContract: false };
+        || { maxRank: 0, maxSeverity: null, exploitRunRefs: [] };
       if (rank > current.maxRank) {
         current.maxRank = rank;
         current.maxSeverity = claim.severity;
       }
-      // Any contributing smart-contract claim marks the whole finding off-limits
-      // to the clamp (conservative toward the spec invariant).
-      if (smartContract) current.isSmartContract = true;
       for (const ref of exploitRunRefs) current.exploitRunRefs.push(ref);
       byFinding.set(findingId, current);
     }
@@ -213,10 +211,6 @@ function applyUnprovenSeverityClamps(domain, results) {
     if (!result || typeof result.severity !== "string") continue;
     const base = byFinding.get(result.finding_id);
     if (!base || base.maxRank === 0) continue;
-    // Spec invariant: never clamp smart-contract findings, even inside a
-    // web-scoped (cross-stack) session. Their upward on-chain severity re-judge
-    // is legitimate and proof-free.
-    if (base.isSmartContract) continue;
     if (verifySeverityRank(result.severity) <= base.maxRank) continue;
 
     // The exploit-backed allow-path requires proof bound to the ASSERTED
@@ -418,6 +412,26 @@ function normalizeVerificationRoundDocument(document, { expectedDomain, expected
     normalized.results.sort((a, b) => a.finding_id.localeCompare(b.finding_id));
   }
 
+  // Durable clamp audit. Preserved with the exact {finding_id, from, to} shape it
+  // was written with so the v2 final_verification_hash recomputes consistently on
+  // read; from/to are enum-validated so a tampered artifact cannot inject bogus
+  // severity transitions.
+  if (document.severity_clamps != null) {
+    if (!Array.isArray(document.severity_clamps)) {
+      throw new Error("severity_clamps must be an array");
+    }
+    normalized.severity_clamps = document.severity_clamps.map((clamp, index) => {
+      if (clamp == null || typeof clamp !== "object" || Array.isArray(clamp)) {
+        throw new Error(`severity_clamps[${index}] must be an object`);
+      }
+      return {
+        finding_id: parseFindingId(clamp.finding_id),
+        from: assertEnumValue(clamp.from, SEVERITY_VALUES, `severity_clamps[${index}].from`),
+        to: assertEnumValue(clamp.to, SEVERITY_VALUES, `severity_clamps[${index}].to`),
+      };
+    });
+  }
+
   if (expectedDomain != null && normalized.target_domain !== expectedDomain) {
     throw new Error(`verification round target_domain mismatch: expected ${expectedDomain}`);
   }
@@ -563,6 +577,11 @@ function writeVerificationRound(args) {
     notes,
     results,
   };
+  // Durable, authoritative clamp audit: record every {finding_id, from, to} in
+  // the persisted (content-hashed, for v2) round document so a runtime clamp is
+  // reconstructable from the artifact itself — not only the ephemeral response
+  // or the best-effort pipeline event. Omitted when nothing was clamped.
+  if (severityClamps.length > 0) document.severity_clamps = severityClamps;
   if (schemaVersion === 2) {
     document.verification_attempt_id = v2State.verification_attempt_id;
     document.verification_snapshot_hash = v2State.verification_snapshot_hash;
@@ -612,11 +631,13 @@ function writeVerificationRound(args) {
     },
   }, safeGovernanceContextForDomain(domain));
   if (severityClamps.length > 0) {
+    // Lightweight signal only: the authoritative, per-finding clamp audit lives
+    // in the persisted round document's `severity_clamps`. counts.clamped is the
+    // exact (uncapped) count, so this event never diverges from the record.
     safeAppendPipelineEventDirect(domain, "severity_clamped", {
       status: round,
       source: "bob_write_verification_round",
       counts: { clamped: severityClamps.length },
-      clamps: severityClamps,
     }, safeGovernanceContextForDomain(domain));
   }
   if (schemaVersion === 2) verificationLib().refreshVerificationManifest(domain, { throw_on_error: true });

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -126,9 +126,12 @@ function claimIsSmartContractFinding(claim, scSurfaceIds) {
   return surfaceIds.some((surfaceId) => scSurfaceIds.has(surfaceId));
 }
 
-// Returns the list of clamps applied: [{ finding_id, from, to }]. Empty when
-// nothing was clamped (non-web session, no rise, all proven, or all SC).
-function clampUnprovenSeverityRises(domain, results) {
+// MUTATES `results` in place: lowers `result.severity` for each unproven web
+// severity rise. Returns the list of clamps applied: [{ finding_id, from, to }],
+// empty when nothing was clamped (non-web session, no rise, all proven, or all
+// SC). The in-place mutation is load-bearing — the same array is serialized into
+// the persisted round document by the caller.
+function applyUnprovenSeverityClamps(domain, results) {
   let nucleus;
   try {
     nucleus = readSessionNucleus(domain);
@@ -207,6 +210,16 @@ function clampUnprovenSeverityRises(domain, results) {
     if (base.isSmartContract) continue;
     if (verifySeverityRank(result.severity) <= base.maxRank) continue;
 
+    // The exploit-backed allow-path is a FLOOR, not proof of the asserted
+    // severity: it confirms the finding has SOME real, MAC-signed exploit row in
+    // the ledger, raising the bar from "zero proof" to "a genuine exploit +
+    // verifier assertion". It does NOT yet prove the replay demonstrated THIS
+    // higher severity (the row carries no impact/severity binding). Closing that
+    // gap is a HARD REQUIREMENT of the future offensive-runner PR: it must bind
+    // each row to the demonstrated impact and anchor it to the current
+    // verification window (e.g. a verification_exploit_run ref kind), and this
+    // check must then verify that binding. Until the runner exists this branch
+    // is dormant (readOffensiveRunRecords returns []), so every web rise clamps.
     const hasExploitReplaySignal = Array.isArray(result.confidence_reasons)
       && result.confidence_reasons.includes("exploit_replay_confirmed");
     let proven = false;
@@ -527,7 +540,7 @@ function writeVerificationRound(args) {
     }
   }
 
-  const severityClamps = clampUnprovenSeverityRises(domain, results);
+  const severityClamps = applyUnprovenSeverityClamps(domain, results);
 
   const document = {
     version: schemaVersion,

--- a/prompts/roles/balanced-verifier.md
+++ b/prompts/roles/balanced-verifier.md
@@ -77,7 +77,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, and `round_profile: "balanced"` to the write call. Each result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`. Use the same allowed confidence reasons as brutalist; preserve `state_sensitive: true` whenever fresh state, auth, or chain state could change the outcome. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `balanced.json` and the human/debug mirror.
 

--- a/prompts/roles/brutalist-verifier.md
+++ b/prompts/roles/brutalist-verifier.md
@@ -69,7 +69,7 @@ Each v1 `results` entry must include:
 
 For v2, the round must cover exactly the snapshot finding IDs and every `results` entry must also include:
 - `confidence`: `high|medium|low`
-- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`
+- `confidence_reasons`: any of `fresh_replay_passed`, `auth_expired`, `tooling_blocked`, `state_changed`, `manual_inference`, `roast_disagreement`, `disambiguation_failed`, `agreement_not_replayed`, `exploit_replay_confirmed`
 - `state_sensitive`: boolean; set true when target state, auth state, chain state, or fresh replay timing could change the result
 - `artifact_hashes`: object of bounded replay/audit artifact hashes when available, otherwise `{}`
 
@@ -79,6 +79,7 @@ Suggested v2 confidence mapping:
 - Tooling/RPC blocked: include `tooling_blocked`, usually deny/fail closed unless local policy says otherwise.
 - Roast disagreement: include `roast_disagreement`.
 - Manual inference without replay: include `manual_inference`.
+- Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `brutalist.json` and the human/debug mirror.
 

--- a/prompts/roles/final-verifier.md
+++ b/prompts/roles/final-verifier.md
@@ -41,7 +41,7 @@ Each v1 `results` entry must include:
 - `reportable`: boolean
 - `reasoning`: required non-empty string
 
-For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed.
+For v2, add top-level `verification_attempt_id`, `verification_snapshot_hash`, `round_profile: "final"`, and `adjudication_plan_hash` to the write call. Every result must also include `confidence`, `confidence_reasons`, `state_sensitive`, and `artifact_hashes`; optional `inherited_confidence_reasons` and `resolved_confidence_reasons` are allowed. Web severity rises above the frozen claim require real exploit proof; include `exploit_replay_confirmed` only when the replay is backed by the exploit-run proof contract.
 
 Do not write verifier markdown directly. The MCP tool owns `verified-final.json` and the human/debug mirror.
 

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -99,6 +99,7 @@
   "test/oss-blocked-harness.test.js",
   "test/oss-evidence-reference.test.js",
   "test/offensive-proof-contract.test.js",
+  "test/severity-rise-guard.test.js",
   "test/sarif-ingest.test.js",
   "test/static-analysis-index.test.js",
   "test/static-lead-mapping.test.js",

--- a/test/pipeline-events.test.js
+++ b/test/pipeline-events.test.js
@@ -112,38 +112,14 @@ test("normalizePipelineEvent accepts evaluator_run_avoided and coerces counts", 
   });
 });
 
-test("severity_clamped clamps survive the write and read normalizers, bounded and value-capped", () => {
+test("severity_clamped event records an authoritative clamped count", () => {
   const written = normalizePipelineEvent("example.com", "severity_clamped", {
     status: "balanced",
     source: "bob_write_verification_round",
-    counts: { clamped: 2 },
-    clamps: [
-      { finding_id: "F-1", from: "critical", to: "low" },
-      { finding_id: "F-2", from: "high", to: "medium", extra: "dropped" },
-      { finding_id: "", from: "high", to: "low" },
-      { finding_id: "F-9", from: "critical", to: "supersafe" },
-    ],
+    counts: { clamped: 3 },
   });
   assert.equal(written.type, "severity_clamped");
-  assert.deepEqual(written.clamps, [
-    { finding_id: "F-1", from: "critical", to: "low" },
-    { finding_id: "F-2", from: "high", to: "medium" },
-  ]);
-
-  // Read path enforces the same severity-enum integrity: a tampered events log
-  // with a bogus from/to severity is dropped, not surfaced to operators.
-  const readEvent = normalizePipelineEventForRead({
-    version: 1,
-    bob_version: "test",
-    ts: "2026-01-01T00:00:00.000Z",
-    target_domain: "example.com",
-    type: "severity_clamped",
-    clamps: [
-      ...written.clamps,
-      { finding_id: "F-9", from: "DROPPED", to: "low" },
-    ],
-  }, "example.com");
-  assert.deepEqual(readEvent.clamps, written.clamps);
+  assert.deepEqual(written.counts, { clamped: 3 });
 });
 
 test("readPipelineEvents does not backfill over an existing malformed event log", () => {

--- a/test/pipeline-events.test.js
+++ b/test/pipeline-events.test.js
@@ -112,6 +112,34 @@ test("normalizePipelineEvent accepts evaluator_run_avoided and coerces counts", 
   });
 });
 
+test("severity_clamped clamps survive the write and read normalizers, bounded and value-capped", () => {
+  const written = normalizePipelineEvent("example.com", "severity_clamped", {
+    status: "balanced",
+    source: "bob_write_verification_round",
+    counts: { clamped: 2 },
+    clamps: [
+      { finding_id: "F-1", from: "critical", to: "low" },
+      { finding_id: "F-2", from: "high", to: "medium", extra: "dropped" },
+      { finding_id: "", from: "high", to: "low" },
+    ],
+  });
+  assert.equal(written.type, "severity_clamped");
+  assert.deepEqual(written.clamps, [
+    { finding_id: "F-1", from: "critical", to: "low" },
+    { finding_id: "F-2", from: "high", to: "medium" },
+  ]);
+
+  const readEvent = normalizePipelineEventForRead({
+    version: 1,
+    bob_version: "test",
+    ts: "2026-01-01T00:00:00.000Z",
+    target_domain: "example.com",
+    type: "severity_clamped",
+    clamps: written.clamps,
+  }, "example.com");
+  assert.deepEqual(readEvent.clamps, written.clamps);
+});
+
 test("readPipelineEvents does not backfill over an existing malformed event log", () => {
   withTempHome(() => {
     const filePath = pipelineEventsJsonlPath("example.com");

--- a/test/pipeline-events.test.js
+++ b/test/pipeline-events.test.js
@@ -121,6 +121,7 @@ test("severity_clamped clamps survive the write and read normalizers, bounded an
       { finding_id: "F-1", from: "critical", to: "low" },
       { finding_id: "F-2", from: "high", to: "medium", extra: "dropped" },
       { finding_id: "", from: "high", to: "low" },
+      { finding_id: "F-9", from: "critical", to: "supersafe" },
     ],
   });
   assert.equal(written.type, "severity_clamped");
@@ -129,13 +130,18 @@ test("severity_clamped clamps survive the write and read normalizers, bounded an
     { finding_id: "F-2", from: "high", to: "medium" },
   ]);
 
+  // Read path enforces the same severity-enum integrity: a tampered events log
+  // with a bogus from/to severity is dropped, not surfaced to operators.
   const readEvent = normalizePipelineEventForRead({
     version: 1,
     bob_version: "test",
     ts: "2026-01-01T00:00:00.000Z",
     target_domain: "example.com",
     type: "severity_clamped",
-    clamps: written.clamps,
+    clamps: [
+      ...written.clamps,
+      { finding_id: "F-9", from: "DROPPED", to: "low" },
+    ],
   }, "example.com");
   assert.deepEqual(readEvent.clamps, written.clamps);
 });

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -127,6 +127,9 @@ function offensiveRunRow(domain, ref = exploitRef(domain), overrides = {}) {
     exit_code: ref.exit_code,
     stdout_hash: ref.stdout_hash,
     stderr_hash: ref.stderr_hash,
+    // The impact tier the safe exploit demonstrated (MAC-covered). The guard
+    // requires this to meet/exceed the asserted severity before allowing a rise.
+    demonstrated_severity: "critical",
     ...overrides,
   };
 }
@@ -420,16 +423,48 @@ test("payload-injected sc_evidence cannot spoof the carve-out without a trusted 
   );
 }));
 
-test("corrupt session nucleus fails the severity-rise guard closed", () => withTempHome(() => {
-  const domain = "severity-rise-bad-nucleus.example";
+test("scope is derived from validated state, so a drifted nucleus file cannot disable the guard", () => withTempHome(() => {
+  const domain = "severity-rise-nucleus-drift.example";
   initWebSession(domain);
   appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low" });
   freezeClaims(domain);
-  fs.writeFileSync(sessionNucleusPath(domain), "{not-json\n", "utf8");
+  // Tamper the (non-write-guarded) nucleus file to look non-web. The guard reads
+  // scope from the validated state, so the web clamp still fires.
+  fs.writeFileSync(sessionNucleusPath(domain), `${JSON.stringify({ scope_policy: { target_repo: "x/y" } })}\n`, "utf8");
+
+  assert.equal(writeV1Round(domain, verificationResult("F-1", { severity: "critical" })), "low");
+}));
+
+test("an exploit row that demonstrates a lower severity does not unlock a higher rise", () => withTempHome(() => {
+  const domain = "severity-rise-impact-binding.example";
+  initWebSession(domain);
+  const ref = exploitRef(domain);
+  // A valid, signed row — but it only demonstrated "low" impact.
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "low" });
+  appendFrozenFindingClaim(domain, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), ref],
+    exploitOutcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
+  });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+
+  writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", { severity: "critical", confidence_reasons: ["exploit_replay_confirmed"] }),
+  ]);
+  assert.equal(persistedSeverity(domain), "low", "low-impact row cannot prove a critical rise");
+}));
+
+test("malformed surface routes fails the guard closed on a web session", () => withTempHome(() => {
+  const domain = "severity-rise-bad-routes.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", surfaceIds: ["surface-1"] });
+  freezeClaims(domain);
+  fs.writeFileSync(surfaceRoutesPath(domain), "{not-json\n", "utf8");
 
   assert.throws(
     () => writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
-    (error) => error && error.code === "STATE_CONFLICT" && /session nucleus/.test(error.message),
+    (error) => error && error.code === "STATE_CONFLICT" && /surface routes/.test(error.message),
   );
 }));
 

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -375,52 +375,50 @@ test("web v2 severity rises require both the confidence reason and a satisfying 
   assert.equal(persistedSeverity(domainWithReason), "low");
 }));
 
-test("smart-contract findings (resolved from trusted surface routes) are never clamped in a web session", () => withTempHome(() => {
+test("a cross-stack session that routes any smart-contract surface skips the clamp entirely", () => withTempHome(() => {
   const domain = "severity-rise-cross-stack.example";
   initWebSession(domain);
-  // Cross-stack: the trusted, write-guarded surface routes classify one surface
-  // as web and one as smart_contract. The web finding's unproven rise must
-  // clamp; the smart-contract finding's legitimate on-chain re-judge survives.
+  // The trusted, write-guarded routes show this is a mixed web + smart_contract
+  // engagement. The pure-web clamp does not apply to such a session, so even a
+  // web finding's rise is left alone (and the SC re-judge is never clamped).
   writeSurfaceRoutes(domain, [
     routeForPack("surface-web-1", "web", "web"),
     routeForPack("surface-sc-1", "smart_contract_evm", "smart_contract"),
   ]);
-  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", title: "Web finding", surfaceIds: ["surface-web-1"] });
-  appendFrozenFindingClaim(domain, { findingId: "F-2", severity: "medium", title: "SC finding", surfaceIds: ["surface-sc-1"] });
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", surfaceIds: ["surface-web-1"] });
   freezeClaims(domain);
 
-  writeVerificationRound({
-    target_domain: domain,
-    round: "brutalist",
-    notes: null,
-    results: [
-      verificationResult("F-1", { severity: "critical" }),
-      verificationResult("F-2", { severity: "critical" }),
-    ],
-  });
-
-  assert.equal(persistedSeverity(domain, "brutalist", "F-1"), "low", "web finding clamps");
-  assert.equal(persistedSeverity(domain, "brutalist", "F-2"), "critical", "smart-contract finding is not clamped");
+  assert.equal(writeV1Round(domain, verificationResult("F-1", { severity: "critical" })), "critical");
 }));
 
-test("payload-injected sc_evidence cannot spoof the carve-out without a trusted SC route", () => withTempHome(() => {
+test("citing a smart-contract surface_id cannot dodge the clamp in a pure-web session", () => withTempHome(() => {
   const domain = "severity-rise-sc-spoof.example";
   initWebSession(domain);
-  // No surface route classifies this finding as smart_contract. An attacker
-  // injects sc_evidence/surface_type into the (agent-settable) claim payload to
-  // try to dodge the clamp. The guard ignores payload and still clamps.
+  // Pure-web session: routes classify the only surface as web. The claim cites a
+  // bogus/foreign surface_id and injects sc_evidence into its (agent-settable)
+  // payload to try to look smart-contract. The session-level gate ignores both —
+  // there are no SC routes — so the clamp still fires.
+  writeSurfaceRoutes(domain, [routeForPack("surface-web-1", "web", "web")]);
   appendFrozenFindingClaim(domain, {
     findingId: "F-1",
     severity: "low",
-    surfaceIds: ["surface-web-1"],
+    surfaceIds: ["surface-sc-totally-made-up"],
     payload: { finding: { surface_type: "smart_contract", sc_evidence: { contract_address: "0xfeed" } } },
   });
   freezeClaims(domain);
 
-  assert.equal(
-    writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
-    "low",
-  );
+  assert.equal(writeV1Round(domain, verificationResult("F-1", { severity: "critical" })), "low");
+}));
+
+test("the clamp is recorded in the persisted round document", () => withTempHome(() => {
+  const domain = "severity-rise-doc-audit.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low" });
+  freezeClaims(domain);
+
+  writeV1Round(domain, verificationResult("F-1", { severity: "critical" }));
+  const document = JSON.parse(fs.readFileSync(verificationRoundPaths(domain, "brutalist").json, "utf8"));
+  assert.deepEqual(document.severity_clamps, [{ finding_id: "F-1", from: "critical", to: "low" }]);
 }));
 
 test("scope is derived from validated state, so a drifted nucleus file cannot disable the guard", () => withTempHome(() => {

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -446,7 +446,13 @@ test("exploit_replay_confirmed is stripped from a result that did not back a val
 
   writeV2Round(domain, context, "brutalist", [
     v2VerificationResult("F-1", { severity: "critical", confidence_reasons: ["exploit_replay_confirmed"] }),
-    v2VerificationResult("F-2", { severity: "high", confidence_reasons: ["fresh_replay_passed", "exploit_replay_confirmed"] }),
+    v2VerificationResult("F-2", {
+      severity: "high",
+      confidence_reasons: ["fresh_replay_passed"],
+      // The proof claim hidden in the provenance arrays must also be stripped.
+      inherited_confidence_reasons: ["exploit_replay_confirmed"],
+      resolved_confidence_reasons: ["exploit_replay_confirmed"],
+    }),
   ]);
 
   const document = JSON.parse(fs.readFileSync(verificationRoundPaths(domain, "brutalist").json, "utf8"));
@@ -455,6 +461,8 @@ test("exploit_replay_confirmed is stripped from a result that did not back a val
   assert.equal(f1.severity, "low", "unproven rise is clamped");
   assert.ok(!f1.confidence_reasons.includes("exploit_replay_confirmed"), "stripped on the clamped rise");
   assert.ok(!f2.confidence_reasons.includes("exploit_replay_confirmed"), "stripped on the non-rise");
+  assert.ok(!f2.inherited_confidence_reasons.includes("exploit_replay_confirmed"), "stripped from inherited_");
+  assert.ok(!f2.resolved_confidence_reasons.includes("exploit_replay_confirmed"), "stripped from resolved_");
   assert.ok(f2.confidence_reasons.includes("fresh_replay_passed"), "other reasons are preserved");
 }));
 

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -22,9 +22,17 @@ const {
 } = require("../mcp/lib/handoff-signing-key.js");
 const {
   offensiveRunsJsonlPath,
+  sessionNucleusPath,
   statePath,
+  surfaceRoutesPath,
   verificationRoundPaths,
 } = require("../mcp/lib/paths.js");
+const {
+  getCapabilityPack,
+} = require("../mcp/lib/capability-packs.js");
+const {
+  SEVERITY_VALUES,
+} = require("../mcp/lib/constants.js");
 const {
   signOffensiveRunRow,
 } = require("../mcp/lib/offensive-row-mac.js");
@@ -148,6 +156,7 @@ function appendFrozenFindingClaim(domain, {
   exploitOutcome = null,
   title = null,
   payload = null,
+  surfaceIds = null,
 } = {}) {
   const claim = {
     target_domain: domain,
@@ -160,20 +169,30 @@ function appendFrozenFindingClaim(domain, {
   };
   if (exploitOutcome) claim.exploit_outcome = exploitOutcome;
   if (payload) claim.payload = payload;
+  if (surfaceIds) claim.surface_ids = surfaceIds;
   return appendCandidateClaim(claim);
 }
 
-// A claim recorded for a smart_contract surface carries the finding's
-// surface_type / sc_evidence on the claim payload (record-candidate-claim.js
-// buildClaimPayloadFromFinding). The guard reads it from there.
-function smartContractPayload(contractAddress = "0xabc") {
+// Build a conformant surface route for the given capability pack so
+// readSurfaceRoutesStrict accepts it (evaluator_agent/brief_profile must match
+// the pack). surface-routes.json is the WRITE-GUARDED, trusted source the guard
+// resolves SC-ness from — never the claim payload.
+function routeForPack(surfaceId, packId, surfaceType) {
+  const pack = getCapabilityPack(packId);
   return {
-    finding: {
-      surface_type: "smart_contract",
-      capability_pack: "smart_contract_evm",
-      sc_evidence: { contract_address: contractAddress },
-    },
+    surface_id: surfaceId,
+    surface_type: surfaceType,
+    capability_pack: packId,
+    capability_pack_version: pack.capability_pack_version,
+    evaluator_agent: pack.evaluator_agent,
+    brief_profile: pack.brief_profile,
   };
+}
+
+function writeSurfaceRoutes(domain, routes) {
+  const filePath = surfaceRoutesPath(domain);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileAtomic(filePath, `${JSON.stringify({ version: 1, route_version: 1, routes }, null, 2)}\n`);
 }
 
 function freezeClaims(domain) {
@@ -353,19 +372,18 @@ test("web v2 severity rises require both the confidence reason and a satisfying 
   assert.equal(persistedSeverity(domainWithReason), "low");
 }));
 
-test("smart-contract findings are never clamped in a web-scoped cross-stack session", () => withTempHome(() => {
+test("smart-contract findings (resolved from trusted surface routes) are never clamped in a web session", () => withTempHome(() => {
   const domain = "severity-rise-cross-stack.example";
   initWebSession(domain);
-  // Same web-scoped session carries BOTH a web finding and a smart-contract
-  // finding (cross-stack mode). The web finding's unproven rise must clamp; the
-  // smart-contract finding's legitimate on-chain upward re-judge must survive.
-  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", title: "Web finding" });
-  appendFrozenFindingClaim(domain, {
-    findingId: "F-2",
-    severity: "medium",
-    title: "Smart-contract finding",
-    payload: smartContractPayload(),
-  });
+  // Cross-stack: the trusted, write-guarded surface routes classify one surface
+  // as web and one as smart_contract. The web finding's unproven rise must
+  // clamp; the smart-contract finding's legitimate on-chain re-judge survives.
+  writeSurfaceRoutes(domain, [
+    routeForPack("surface-web-1", "web", "web"),
+    routeForPack("surface-sc-1", "smart_contract_evm", "smart_contract"),
+  ]);
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", title: "Web finding", surfaceIds: ["surface-web-1"] });
+  appendFrozenFindingClaim(domain, { findingId: "F-2", severity: "medium", title: "SC finding", surfaceIds: ["surface-sc-1"] });
   freezeClaims(domain);
 
   writeVerificationRound({
@@ -382,23 +400,64 @@ test("smart-contract findings are never clamped in a web-scoped cross-stack sess
   assert.equal(persistedSeverity(domain, "brutalist", "F-2"), "critical", "smart-contract finding is not clamped");
 }));
 
-test("smart-contract findings detected by sc_evidence alone are not clamped", () => withTempHome(() => {
-  const domain = "severity-rise-sc-evidence.example";
+test("payload-injected sc_evidence cannot spoof the carve-out without a trusted SC route", () => withTempHome(() => {
+  const domain = "severity-rise-sc-spoof.example";
   initWebSession(domain);
+  // No surface route classifies this finding as smart_contract. An attacker
+  // injects sc_evidence/surface_type into the (agent-settable) claim payload to
+  // try to dodge the clamp. The guard ignores payload and still clamps.
   appendFrozenFindingClaim(domain, {
     findingId: "F-1",
     severity: "low",
-    title: "SC finding via sc_evidence",
-    // No surface_type/capability_pack — only sc_evidence marks it smart-contract.
-    payload: { finding: { sc_evidence: { contract_address: "0xfeed" } } },
+    surfaceIds: ["surface-web-1"],
+    payload: { finding: { surface_type: "smart_contract", sc_evidence: { contract_address: "0xfeed" } } },
   });
   freezeClaims(domain);
 
   assert.equal(
     writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
-    "critical",
+    "low",
   );
 }));
+
+test("corrupt session nucleus fails the severity-rise guard closed", () => withTempHome(() => {
+  const domain = "severity-rise-bad-nucleus.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low" });
+  freezeClaims(domain);
+  fs.writeFileSync(sessionNucleusPath(domain), "{not-json\n", "utf8");
+
+  assert.throws(
+    () => writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
+    (error) => error && error.code === "STATE_CONFLICT" && /session nucleus/.test(error.message),
+  );
+}));
+
+test("clamps are surfaced in the tool response", () => withTempHome(() => {
+  const domain = "severity-rise-response-signal.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low" });
+  freezeClaims(domain);
+
+  const response = JSON.parse(writeVerificationRound({
+    target_domain: domain,
+    round: "brutalist",
+    notes: null,
+    results: [verificationResult("F-1", { severity: "critical" })],
+  }));
+
+  assert.ok(Array.isArray(response.severity_clamps), "response carries severity_clamps");
+  assert.deepEqual(response.severity_clamps, [{ finding_id: "F-1", from: "critical", to: "low" }]);
+}));
+
+test("every severity enum value maps to a non-zero VERIFY_SEVERITY_RANK", () => {
+  const { verifySeverityRank } = require("../mcp/lib/verification-round-store.js");
+  for (const severity of SEVERITY_VALUES) {
+    assert.ok(verifySeverityRank(severity) > 0, `${severity} must have a non-zero rank`);
+  }
+  // The claim enum uses "informational" where the round enum uses "info".
+  assert.ok(verifySeverityRank("informational") > 0, "informational must have a non-zero rank");
+});
 
 test("non-web repo sessions are not clamped", () => withTempHome((home) => {
   const domain = initRepoOnlySession(home, "severity-rise-repo.example");

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -24,12 +24,8 @@ const {
   offensiveRunsJsonlPath,
   sessionNucleusPath,
   statePath,
-  surfaceRoutesPath,
   verificationRoundPaths,
 } = require("../mcp/lib/paths.js");
-const {
-  getCapabilityPack,
-} = require("../mcp/lib/capability-packs.js");
 const {
   SEVERITY_VALUES,
 } = require("../mcp/lib/constants.js");
@@ -174,28 +170,6 @@ function appendFrozenFindingClaim(domain, {
   if (payload) claim.payload = payload;
   if (surfaceIds) claim.surface_ids = surfaceIds;
   return appendCandidateClaim(claim);
-}
-
-// Build a conformant surface route for the given capability pack so
-// readSurfaceRoutesStrict accepts it (evaluator_agent/brief_profile must match
-// the pack). surface-routes.json is the WRITE-GUARDED, trusted source the guard
-// resolves SC-ness from — never the claim payload.
-function routeForPack(surfaceId, packId, surfaceType) {
-  const pack = getCapabilityPack(packId);
-  return {
-    surface_id: surfaceId,
-    surface_type: surfaceType,
-    capability_pack: packId,
-    capability_pack_version: pack.capability_pack_version,
-    evaluator_agent: pack.evaluator_agent,
-    brief_profile: pack.brief_profile,
-  };
-}
-
-function writeSurfaceRoutes(domain, routes) {
-  const filePath = surfaceRoutesPath(domain);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileAtomic(filePath, `${JSON.stringify({ version: 1, route_version: 1, routes }, null, 2)}\n`);
 }
 
 function freezeClaims(domain) {
@@ -375,39 +349,45 @@ test("web v2 severity rises require both the confidence reason and a satisfying 
   assert.equal(persistedSeverity(domainWithReason), "low");
 }));
 
-test("a cross-stack session that routes any smart-contract surface skips the clamp entirely", () => withTempHome(() => {
-  const domain = "severity-rise-cross-stack.example";
+test("the clamp applies uniformly: a finding with smart-contract-looking signals is still clamped", () => withTempHome(() => {
+  const domain = "severity-rise-uniform.example";
   initWebSession(domain);
-  // The trusted, write-guarded routes show this is a mixed web + smart_contract
-  // engagement. The pure-web clamp does not apply to such a session, so even a
-  // web finding's rise is left alone (and the SC re-judge is never clamped).
-  writeSurfaceRoutes(domain, [
-    routeForPack("surface-web-1", "web", "web"),
-    routeForPack("surface-sc-1", "smart_contract_evm", "smart_contract"),
-  ]);
-  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", surfaceIds: ["surface-web-1"] });
-  freezeClaims(domain);
-
-  assert.equal(writeV1Round(domain, verificationResult("F-1", { severity: "critical" })), "critical");
-}));
-
-test("citing a smart-contract surface_id cannot dodge the clamp in a pure-web session", () => withTempHome(() => {
-  const domain = "severity-rise-sc-spoof.example";
-  initWebSession(domain);
-  // Pure-web session: routes classify the only surface as web. The claim cites a
-  // bogus/foreign surface_id and injects sc_evidence into its (agent-settable)
-  // payload to try to look smart-contract. The session-level gate ignores both —
-  // there are no SC routes — so the clamp still fires.
-  writeSurfaceRoutes(domain, [routeForPack("surface-web-1", "web", "web")]);
+  // No trusted, non-agent SC signal exists before VERIFY (surface_ids, payload,
+  // and even routes are agent-influenced), so the guard does NOT exempt
+  // smart-contract findings — it applies to every finding in a web-scoped
+  // session. A claim stuffed with SC-looking signals is still clamped.
   appendFrozenFindingClaim(domain, {
     findingId: "F-1",
     severity: "low",
-    surfaceIds: ["surface-sc-totally-made-up"],
-    payload: { finding: { surface_type: "smart_contract", sc_evidence: { contract_address: "0xfeed" } } },
+    surfaceIds: ["surface-claims-to-be-sc"],
+    payload: { finding: { surface_type: "smart_contract", capability_pack: "smart_contract_evm", sc_evidence: { contract_address: "0xfeed" } } },
   });
   freezeClaims(domain);
 
   assert.equal(writeV1Round(domain, verificationResult("F-1", { severity: "critical" })), "low");
+}));
+
+test("a multi-finding claim's exploit row cannot prove a sibling finding's rise", () => withTempHome(() => {
+  const domain = "severity-rise-multi-finding.example";
+  initWebSession(domain);
+  const ref = exploitRef(domain);
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "critical" });
+  // One claim references BOTH F-1 and F-2 plus a single exploit_run ref. The
+  // guard refuses to propagate that row to either finding (cross-finding
+  // spillover guard), so an exploit_replay_confirmed rise on F-2 is clamped.
+  appendFrozenFindingClaim(domain, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), findingRef("F-2"), ref],
+    exploitOutcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
+  });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+
+  writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", { severity: "low", confidence_reasons: ["fresh_replay_passed"] }),
+    v2VerificationResult("F-2", { severity: "critical", confidence_reasons: ["exploit_replay_confirmed"] }),
+  ]);
+  assert.equal(persistedSeverity(domain, "brutalist", "F-2"), "low");
 }));
 
 test("the clamp is recorded in the persisted round document", () => withTempHome(() => {
@@ -453,17 +433,29 @@ test("an exploit row that demonstrates a lower severity does not unlock a higher
   assert.equal(persistedSeverity(domain), "low", "low-impact row cannot prove a critical rise");
 }));
 
-test("malformed surface routes fails the guard closed on a web session", () => withTempHome(() => {
-  const domain = "severity-rise-bad-routes.example";
+test("exploit_replay_confirmed is stripped from a result that did not back a validated rise", () => withTempHome(() => {
+  const domain = "severity-rise-strip-reason.example";
   initWebSession(domain);
-  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", surfaceIds: ["surface-1"] });
+  // No offensive row exists, so the proof can never validate. A verifier asserts
+  // exploit_replay_confirmed on (a) a clamped rise and (b) a non-rise. Both must
+  // have the unproven proof-claim stripped from the persisted artifact.
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low" });
+  appendFrozenFindingClaim(domain, { findingId: "F-2", severity: "high" });
   freezeClaims(domain);
-  fs.writeFileSync(surfaceRoutesPath(domain), "{not-json\n", "utf8");
+  const context = enterVerifyV2(domain);
 
-  assert.throws(
-    () => writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
-    (error) => error && error.code === "STATE_CONFLICT" && /surface routes/.test(error.message),
-  );
+  writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", { severity: "critical", confidence_reasons: ["exploit_replay_confirmed"] }),
+    v2VerificationResult("F-2", { severity: "high", confidence_reasons: ["fresh_replay_passed", "exploit_replay_confirmed"] }),
+  ]);
+
+  const document = JSON.parse(fs.readFileSync(verificationRoundPaths(domain, "brutalist").json, "utf8"));
+  const f1 = document.results.find((r) => r.finding_id === "F-1");
+  const f2 = document.results.find((r) => r.finding_id === "F-2");
+  assert.equal(f1.severity, "low", "unproven rise is clamped");
+  assert.ok(!f1.confidence_reasons.includes("exploit_replay_confirmed"), "stripped on the clamped rise");
+  assert.ok(!f2.confidence_reasons.includes("exploit_replay_confirmed"), "stripped on the non-rise");
+  assert.ok(f2.confidence_reasons.includes("fresh_replay_passed"), "other reasons are preserved");
 }));
 
 test("clamps are surfaced in the tool response", () => withTempHome(() => {

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -1,0 +1,525 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  buildClaimFreeze,
+  readCurrentClaimFreeze,
+} = require("../mcp/lib/claim-freeze.js");
+const {
+  appendCandidateClaim,
+  canonicalizeExploitTarget,
+} = require("../mcp/lib/claims.js");
+const {
+  VERIFICATION_CONFIDENCE_REASON_VALUES,
+} = require("../mcp/lib/constants.js");
+const {
+  ensureHandoffSigningKey,
+} = require("../mcp/lib/handoff-signing-key.js");
+const {
+  offensiveRunsJsonlPath,
+  statePath,
+  verificationRoundPaths,
+} = require("../mcp/lib/paths.js");
+const {
+  signOffensiveRunRow,
+} = require("../mcp/lib/offensive-row-mac.js");
+const {
+  initRepoSession,
+} = require("../mcp/lib/repo-target.js");
+const {
+  initSession,
+} = require("../mcp/lib/session-state.js");
+const {
+  readSessionStateStrict,
+} = require("../mcp/lib/session-state-store.js");
+const {
+  writeFileAtomic,
+} = require("../mcp/lib/storage.js");
+const {
+  buildVerificationAdjudication,
+  prepareVerificationEntry,
+} = require("../mcp/lib/verification.js");
+const {
+  writeVerificationRound,
+} = require("../mcp/lib/verification-round-store.js");
+const writeVerificationRoundTool = require("../mcp/lib/tools/write-verification-round.js");
+const {
+  resetForTests: resetMaterializationDebounce,
+} = require("../mcp/lib/frontier-materialize-debounce.js");
+
+function withTempHome(fn) {
+  const previousHome = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-severity-rise-guard-"));
+  process.env.HOME = home;
+  try {
+    return fn(home);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    resetMaterializationDebounce();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function hex(char) {
+  return char.repeat(64);
+}
+
+function initWebSession(domain) {
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+}
+
+function initRepoOnlySession(home, domain) {
+  const repoRoot = path.join(home, domain);
+  fs.mkdirSync(repoRoot, { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "repo fixture\n", "utf8");
+  return initRepoSession({ repo_path: repoRoot, target_domain: domain }).target_domain;
+}
+
+function findingRef(findingId = "F-1", overrides = {}) {
+  return {
+    kind: "finding",
+    finding_id: findingId,
+    content_hash: hex("0"),
+    ...overrides,
+  };
+}
+
+function exploitRef(domain, overrides = {}) {
+  return {
+    kind: "exploit_run",
+    run_id: "run-exploit-1",
+    tool_id: "bob_http_confirm_reflected_canary",
+    target: canonicalizeExploitTarget(`https://${domain}/proof`),
+    offensive_outcome: "exploited_safely",
+    command_hash: hex("a"),
+    exit_code: 0,
+    stdout_hash: hex("b"),
+    stderr_hash: hex("c"),
+    ...overrides,
+  };
+}
+
+function offensiveRunRow(domain, ref = exploitRef(domain), overrides = {}) {
+  return {
+    version: 1,
+    target_domain: domain,
+    run_id: ref.run_id,
+    tool_id: ref.tool_id,
+    target: ref.target,
+    offensive_outcome: "exploited_safely",
+    dry_run: false,
+    timed_out: false,
+    command_hash: ref.command_hash,
+    exit_code: ref.exit_code,
+    stdout_hash: ref.stdout_hash,
+    stderr_hash: ref.stderr_hash,
+    ...overrides,
+  };
+}
+
+function writeOffensiveRunRows(domain, rows) {
+  const filePath = offensiveRunsJsonlPath(domain);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", "utf8");
+}
+
+function signedOffensiveRow(domain, ref = exploitRef(domain), overrides = {}) {
+  const row = offensiveRunRow(domain, ref, overrides);
+  signOffensiveRunRow(row, ensureHandoffSigningKey(domain));
+  return row;
+}
+
+function seedSignedOffensiveRow(domain, ref = exploitRef(domain), overrides = {}) {
+  const row = signedOffensiveRow(domain, ref, overrides);
+  writeOffensiveRunRows(domain, [row]);
+  return row;
+}
+
+function appendFrozenFindingClaim(domain, {
+  findingId = "F-1",
+  severity = "low",
+  evidenceRefs = null,
+  exploitOutcome = null,
+  title = null,
+  payload = null,
+} = {}) {
+  const claim = {
+    target_domain: domain,
+    title: title || `Frozen claim for ${findingId}`,
+    summary: "Frozen baseline for verification severity guard tests.",
+    severity,
+    status: "candidate",
+    evidence_refs: evidenceRefs || [findingRef(findingId)],
+    impact: "Bounded fixture impact.",
+  };
+  if (exploitOutcome) claim.exploit_outcome = exploitOutcome;
+  if (payload) claim.payload = payload;
+  return appendCandidateClaim(claim);
+}
+
+// A claim recorded for a smart_contract surface carries the finding's
+// surface_type / sc_evidence on the claim payload (record-candidate-claim.js
+// buildClaimPayloadFromFinding). The guard reads it from there.
+function smartContractPayload(contractAddress = "0xabc") {
+  return {
+    finding: {
+      surface_type: "smart_contract",
+      capability_pack: "smart_contract_evm",
+      sc_evidence: { contract_address: contractAddress },
+    },
+  };
+}
+
+function freezeClaims(domain) {
+  buildClaimFreeze(domain, {
+    write: true,
+    now: new Date("2026-06-01T00:00:00.000Z"),
+  });
+  const freeze = readCurrentClaimFreeze(domain);
+  assert.ok(freeze, "claim-freeze.json must exist");
+  assert.ok(Array.isArray(freeze.claims), "claim-freeze.json must carry claims[]");
+  return freeze;
+}
+
+function verificationResult(findingId = "F-1", overrides = {}) {
+  return {
+    finding_id: findingId,
+    disposition: "confirmed",
+    severity: "critical",
+    reportable: true,
+    reasoning: "Verifier attempted to raise severity.",
+    ...overrides,
+  };
+}
+
+function v2VerificationResult(findingId = "F-1", overrides = {}) {
+  return {
+    ...verificationResult(findingId),
+    confidence: "high",
+    confidence_reasons: ["fresh_replay_passed"],
+    state_sensitive: false,
+    artifact_hashes: {},
+    ...overrides,
+  };
+}
+
+function persistedSeverity(domain, round = "brutalist", findingId = "F-1") {
+  const document = JSON.parse(fs.readFileSync(verificationRoundPaths(domain, round).json, "utf8"));
+  const result = document.results.find((entry) => entry.finding_id === findingId);
+  assert.ok(result, `persisted ${round} result must include ${findingId}`);
+  return result.severity;
+}
+
+function writeV1Round(domain, result, round = "brutalist") {
+  writeVerificationRound({
+    target_domain: domain,
+    round,
+    notes: null,
+    results: [result],
+  });
+  return persistedSeverity(domain, round, result.finding_id);
+}
+
+function enterVerifyV2(domain) {
+  const { raw, state } = readSessionStateStrict(domain);
+  const entry = prepareVerificationEntry(domain, state, {
+    now: new Date("2026-06-01T00:00:00.000Z"),
+  });
+  const nextState = {
+    ...raw,
+    phase: "VERIFY",
+    lifecycle_state: "VERIFY",
+    ...entry.state_fields,
+  };
+  writeFileAtomic(statePath(domain), `${JSON.stringify(nextState, null, 2)}\n`);
+  return entry.state_fields;
+}
+
+function writeV2Round(domain, context, round, results, extra = {}) {
+  return JSON.parse(writeVerificationRound({
+    target_domain: domain,
+    round,
+    notes: null,
+    verification_attempt_id: context.verification_attempt_id,
+    verification_snapshot_hash: context.verification_snapshot_hash,
+    round_profile: round,
+    results,
+    ...extra,
+  }));
+}
+
+test("web v1 unproven severity rises are clamped to the frozen claim severity", () => withTempHome(() => {
+  const domain = "severity-rise-clamp.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { severity: "low" });
+  freezeClaims(domain);
+
+  assert.equal(
+    writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
+    "low",
+  );
+}));
+
+test("web guard uses the max frozen severity across claims for the same finding", () => withTempHome(() => {
+  const domain = "severity-rise-max-claim.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { severity: "low", title: "Low duplicate claim" });
+  appendFrozenFindingClaim(domain, { severity: "high", title: "High duplicate claim" });
+  freezeClaims(domain);
+
+  assert.equal(
+    writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
+    "high",
+  );
+}));
+
+test("web v2 exploit proof plus exploit_replay_confirmed allows a severity rise", () => withTempHome(() => {
+  const domain = "severity-rise-proof.example";
+  initWebSession(domain);
+  const ref = exploitRef(domain);
+  seedSignedOffensiveRow(domain, ref);
+  appendFrozenFindingClaim(domain, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), ref],
+    exploitOutcome: {
+      outcome: "exploited_safely",
+      safe_oracle: { kind: "reflected_canary" },
+    },
+  });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+
+  writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", {
+      severity: "critical",
+      confidence_reasons: ["exploit_replay_confirmed"],
+    }),
+  ]);
+
+  assert.equal(persistedSeverity(domain), "critical");
+}));
+
+test("web v2 severity rises require both the confidence reason and a satisfying exploit row", () => withTempHome(() => {
+  const domainWithRow = "severity-rise-row-no-reason.example";
+  initWebSession(domainWithRow);
+  const refWithRow = exploitRef(domainWithRow);
+  seedSignedOffensiveRow(domainWithRow, refWithRow);
+  appendFrozenFindingClaim(domainWithRow, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), refWithRow],
+    exploitOutcome: {
+      outcome: "exploited_safely",
+      safe_oracle: { kind: "reflected_canary" },
+    },
+  });
+  freezeClaims(domainWithRow);
+  let context = enterVerifyV2(domainWithRow);
+  writeV2Round(domainWithRow, context, "brutalist", [
+    v2VerificationResult("F-1", {
+      severity: "critical",
+      confidence_reasons: ["fresh_replay_passed"],
+    }),
+  ]);
+  assert.equal(persistedSeverity(domainWithRow), "low");
+
+  const domainWithReason = "severity-rise-reason-no-row.example";
+  initWebSession(domainWithReason);
+  const refWithReason = exploitRef(domainWithReason);
+  seedSignedOffensiveRow(domainWithReason, refWithReason);
+  appendFrozenFindingClaim(domainWithReason, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), refWithReason],
+    exploitOutcome: {
+      outcome: "exploited_safely",
+      safe_oracle: { kind: "reflected_canary" },
+    },
+  });
+  freezeClaims(domainWithReason);
+  const dryRunRow = signedOffensiveRow(domainWithReason, refWithReason, { dry_run: true });
+  writeOffensiveRunRows(domainWithReason, [dryRunRow]);
+  context = enterVerifyV2(domainWithReason);
+  writeV2Round(domainWithReason, context, "brutalist", [
+    v2VerificationResult("F-1", {
+      severity: "critical",
+      confidence_reasons: ["exploit_replay_confirmed"],
+    }),
+  ]);
+  assert.equal(persistedSeverity(domainWithReason), "low");
+}));
+
+test("smart-contract findings are never clamped in a web-scoped cross-stack session", () => withTempHome(() => {
+  const domain = "severity-rise-cross-stack.example";
+  initWebSession(domain);
+  // Same web-scoped session carries BOTH a web finding and a smart-contract
+  // finding (cross-stack mode). The web finding's unproven rise must clamp; the
+  // smart-contract finding's legitimate on-chain upward re-judge must survive.
+  appendFrozenFindingClaim(domain, { findingId: "F-1", severity: "low", title: "Web finding" });
+  appendFrozenFindingClaim(domain, {
+    findingId: "F-2",
+    severity: "medium",
+    title: "Smart-contract finding",
+    payload: smartContractPayload(),
+  });
+  freezeClaims(domain);
+
+  writeVerificationRound({
+    target_domain: domain,
+    round: "brutalist",
+    notes: null,
+    results: [
+      verificationResult("F-1", { severity: "critical" }),
+      verificationResult("F-2", { severity: "critical" }),
+    ],
+  });
+
+  assert.equal(persistedSeverity(domain, "brutalist", "F-1"), "low", "web finding clamps");
+  assert.equal(persistedSeverity(domain, "brutalist", "F-2"), "critical", "smart-contract finding is not clamped");
+}));
+
+test("smart-contract findings detected by sc_evidence alone are not clamped", () => withTempHome(() => {
+  const domain = "severity-rise-sc-evidence.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, {
+    findingId: "F-1",
+    severity: "low",
+    title: "SC finding via sc_evidence",
+    // No surface_type/capability_pack — only sc_evidence marks it smart-contract.
+    payload: { finding: { sc_evidence: { contract_address: "0xfeed" } } },
+  });
+  freezeClaims(domain);
+
+  assert.equal(
+    writeV1Round(domain, verificationResult("F-1", { severity: "critical" })),
+    "critical",
+  );
+}));
+
+test("non-web repo sessions are not clamped", () => withTempHome((home) => {
+  const domain = initRepoOnlySession(home, "severity-rise-repo.example");
+  appendFrozenFindingClaim(domain, { severity: "medium" });
+  freezeClaims(domain);
+
+  assert.equal(
+    writeV1Round(domain, verificationResult("F-1", { severity: "high" })),
+    "high",
+  );
+}));
+
+test("web equality, lowering, info/informational, null severity, and no-freeze paths pass through", () => withTempHome(() => {
+  const equalityDomain = "severity-rise-equality.example";
+  initWebSession(equalityDomain);
+  appendFrozenFindingClaim(equalityDomain, { severity: "high" });
+  freezeClaims(equalityDomain);
+  assert.equal(writeV1Round(equalityDomain, verificationResult("F-1", { severity: "high" })), "high");
+
+  const loweringDomain = "severity-rise-lowering.example";
+  initWebSession(loweringDomain);
+  appendFrozenFindingClaim(loweringDomain, { severity: "high" });
+  freezeClaims(loweringDomain);
+  assert.equal(writeV1Round(loweringDomain, verificationResult("F-1", { severity: "low" })), "low");
+
+  const infoDomain = "severity-rise-info.example";
+  initWebSession(infoDomain);
+  appendFrozenFindingClaim(infoDomain, { severity: "informational" });
+  freezeClaims(infoDomain);
+  assert.equal(writeV1Round(infoDomain, verificationResult("F-1", { severity: "info" })), "info");
+
+  const nullDomain = "severity-rise-null.example";
+  initWebSession(nullDomain);
+  appendFrozenFindingClaim(nullDomain, { severity: "low" });
+  freezeClaims(nullDomain);
+  assert.equal(writeV1Round(nullDomain, verificationResult("F-1", {
+    disposition: "denied",
+    severity: null,
+    reportable: false,
+  })), null);
+
+  const legacyDomain = "severity-rise-no-freeze.example";
+  initWebSession(legacyDomain);
+  appendFrozenFindingClaim(legacyDomain, { severity: "low" });
+  assert.equal(writeV1Round(legacyDomain, verificationResult("F-1", { severity: "critical" })), "critical");
+}));
+
+test("corrupt offensive ledger fails only when a proof-checked rise reads it", () => withTempHome(() => {
+  const domain = "severity-rise-corrupt-ledger.example";
+  initWebSession(domain);
+  const ref = exploitRef(domain);
+  seedSignedOffensiveRow(domain, ref);
+  appendFrozenFindingClaim(domain, {
+    severity: "low",
+    evidenceRefs: [findingRef("F-1"), ref],
+    exploitOutcome: {
+      outcome: "exploited_safely",
+      safe_oracle: { kind: "reflected_canary" },
+    },
+  });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+
+  fs.writeFileSync(offensiveRunsJsonlPath(domain), "{not-json}\n", "utf8");
+  writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", {
+      severity: "low",
+      confidence_reasons: ["exploit_replay_confirmed"],
+    }),
+  ]);
+  assert.equal(persistedSeverity(domain), "low");
+
+  assert.throws(
+    () => writeV2Round(domain, context, "brutalist", [
+      v2VerificationResult("F-1", {
+        severity: "critical",
+        confidence_reasons: ["exploit_replay_confirmed"],
+      }),
+    ]),
+    (error) => error && error.code === "STATE_CONFLICT" && /malformed row/.test(error.message),
+  );
+}));
+
+test("v2 final write and adjudication consume already-clamped rounds", () => withTempHome(() => {
+  const domain = "severity-rise-v2-final.example";
+  initWebSession(domain);
+  appendFrozenFindingClaim(domain, { severity: "low" });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+  const raised = v2VerificationResult("F-1", {
+    severity: "critical",
+    confidence_reasons: ["fresh_replay_passed"],
+  });
+
+  writeV2Round(domain, context, "brutalist", [raised]);
+  writeV2Round(domain, context, "balanced", [raised]);
+  assert.equal(persistedSeverity(domain, "brutalist"), "low");
+  assert.equal(persistedSeverity(domain, "balanced"), "low");
+
+  const adjudication = JSON.parse(buildVerificationAdjudication({ target_domain: domain }));
+  const final = writeV2Round(domain, context, "final", [raised], {
+    adjudication_plan_hash: adjudication.adjudication_plan_hash,
+  });
+
+  assert.match(final.final_verification_hash, /^[a-f0-9]{64}$/);
+  assert.equal(persistedSeverity(domain, "final"), "low");
+}));
+
+test("exploit_replay_confirmed is exposed by constants and every write schema confidence-reason enum", () => {
+  assert.ok(VERIFICATION_CONFIDENCE_REASON_VALUES.includes("exploit_replay_confirmed"));
+
+  const resultProperties = writeVerificationRoundTool.inputSchema
+    .properties.results.items.properties;
+  for (const field of [
+    "confidence_reasons",
+    "inherited_confidence_reasons",
+    "resolved_confidence_reasons",
+  ]) {
+    assert.ok(
+      resultProperties[field].items.enum.includes("exploit_replay_confirmed"),
+      `${field} enum must include exploit_replay_confirmed`,
+    );
+  }
+});


### PR DESCRIPTION
## What

Second PR in the offensive-Bob series (after #108's exploit-proof contract). Adds a **web-path severity-rise guard** to `writeVerificationRound`.

**The hole it closes:** a verification round sets each finding's `result.severity`, and today that value is only enum-validated — never compared to anything. On a **web** engagement, a verifier (over-eager or compromised) could raise a finding `low`→`critical` with **zero proof**, and the inflated severity flowed straight to the report.

**The guard:** on web sessions only, `result.severity` may exceed the frozen claim's severity **only** when backed by two-factor exploit proof:
1. `result.confidence_reasons` includes the new `exploit_replay_confirmed` reason, **and**
2. a frozen claim for that finding has an `exploit_run` evidence_ref satisfied by a real **MAC-signed** row in `offensive-runs.jsonl` (reuses the #108 `offensiveRunRowSatisfiesEvidence` / `readOffensiveRunRecords` primitives).

Otherwise the severity is **clamped** down to the frozen baseline (clamp, never reject — preserves round finding-coverage contracts). It runs inside `withSessionLock`, **before** the document build and the v2 `final_verification_hash`, so nothing inflated lands on the audit-graded path and the hash covers the clamped values.

## Scope decision (load-bearing)

The guard fires **only on web sessions** (`scope_policy.target_url != null`). Repo/OSS severity is independently capped at grade time; the **smart-contract** balanced-verifier is *supposed* to re-judge severity upward from on-chain effect — so the guard must not touch SC.

**Pre-merge review caught a real gap here and it's fixed in this PR:** `web`/`smart_contract` is a **per-finding** axis, and a web-scoped session can carry smart-contract surfaces in **cross-stack** mode (`web + smart_contract_evm`). The original session-scope-only check would have clamped those SC findings — the exact regression the design forbids. The guard now **carves out smart-contract findings** (detected via `surface_type` / `sc_evidence` / `capability_pack` stamped on the claim payload by `buildClaimPayloadFromFinding`). A web finding can never carry those signals, so pure-web guard strength is unchanged.

## Day-one behavior

No offensive runner writes rows yet, so `readOffensiveRunRecords` returns `[]` and **every unproven web rise clamps** — pure hole-closure. The exploit-backed *allow* branch is dormant by design and lights up automatically when a future runner PR (PR3) writes MAC-signed rows.

## Tests

`test/severity-rise-guard.test.js` — 11 cases on the **real** freeze/nucleus/round path (real `initSession`/`buildClaimFreeze`/`writeVerificationRound`, real `signOffensiveRunRow`): unproven-rise clamp, exploit-backed allow, both two-factor halves, **cross-stack web+SC carve-out (web clamps while SC stays raised)**, SC-via-`sc_evidence`-alone, equality/lowering/info/null/no-freeze, lazy-ledger tolerance (no-rise path never reads the ledger), v2 final+adjudication consume already-clamped rounds, and the three tool-schema enum copies.

- `npm run test:mcp` → **2421 pass / 0 fail** (2 skip)
- `npm run test:prompts` → 181 pass / 0
- `npm run test:hooks` clean · `check:syntax` clean · generators idempotent (no drift)

## Notes / honest boundaries

- **Cross-finding replay is intentionally out of scope.** A MAC-signed offensive row binds to its `(domain, target, command/hash)` fields, not to a `finding_id`. After a future runner PR ships, an agent with one genuine exploit row could in principle attach its public fields to another finding's `exploit_run` ref. That's a property of the **#108 contract + the future runner** (no agent-facing tool produces `exploit_run` refs today), not this guard — to be addressed where rows are first produced (bind row→finding).
- **Forward-compat note:** the exploit-backed allow path reads `result.confidence_reasons`, which only exists on v2 results; fresh web sessions are v2, and the path is dormant day-one regardless. A future runner PR should ensure v2 (or extend the signal) before relying on it.
- **Pre-existing flake (not introduced here):** the suite-wide `withTempHome` pattern mutates `process.env.HOME`; under the manifest's single-process concurrent run a rare cross-file race can transiently fail a `withTempHome` test. Observed once, not reproducible in repeated runs (4× clean full `test:mcp`); a re-run clears it. Worth a separate suite-wide hardening (`--test-concurrency=1` in the runner), out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `exploit_replay_confirmed` as an allowed verification confidence reason.
  * Enhanced “severity rise” guarding for web findings, including `severity_clamps` in verification outputs and a new `severity_clamped` pipeline event when clamping occurs.

* **Documentation**
  * Updated verifier v2 guidance and write-contract rules to require real exploit proof for web severity escalation and to govern when `exploit_replay_confirmed` is included.

* **Tests**
  * Added coverage for web vs non-web behavior, smart-contract special-casing, and v1/v2 verification flow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->