### PR TITLE
feat(offense): exploit_run freeze-completeness + audit-grade offensive-runs capture dir

### DIFF
--- a/mcp/lib/claim-freeze.js
+++ b/mcp/lib/claim-freeze.js
@@ -9,6 +9,7 @@ const {
   offensiveRunsDir,
   repoChecksJsonlPath,
   repoRunsDir,
+  sessionDir,
 } = require("./paths.js");
 const {
   hashCanonicalJson,
@@ -36,6 +37,7 @@ const {
 const {
   readJsonFile,
   withSessionLock,
+  DEFAULT_ARTIFACT_READ_MAX_BYTES,
 } = require("./storage.js");
 
 const CLAIM_FREEZE_VERSION = 1;
@@ -414,31 +416,82 @@ function projectRepoCommandRunObservedRef(domain, frozenRef) {
   };
 }
 
-// Project an `exploit_run` observed ref by recomputing the sha256 of the on-disk
-// stdout capture file at `offensive-runs/<run_id>.stdout`. Mirrors
+// Securely recompute the sha256 of an offensive-runs capture leaf for projection.
+// `run_id` is only shape-validated upstream as a non-empty string (claims.js
+// assertExploitRunEvidenceShape), so the path/symlink discipline lives here.
+// Mirrors the realpath + O_NOFOLLOW + nlink + size-cap discipline that
+// readOffensiveRunRecords (claims.js) applies to the proof ledger:
+//   - lexical containment: the leaf must be a DIRECT child of offensive-runs/
+//     (rejects a "../x" traversal run_id);
+//   - symlinked-parent defense: the REAL capture dir must resolve to
+//     <real session dir>/offensive-runs (rejects a symlinked offensive-runs/ or
+//     session dir — O_NOFOLLOW on the leaf alone does not catch a symlinked parent);
+//   - O_NOFOLLOW + fstat: reject a symlinked leaf, a non-regular file, a
+//     hard-linked file, and a file over the artifact read cap.
+// Fail-closed: any of the above (or a missing/unreadable leaf) returns null, which
+// the completeness gate surfaces as `missing` so the lifecycle blocks. Without this,
+// a planted symlink would make sha256File follow the link and hash an
+// attacker-chosen inode (a content read-oracle), and an oversized leaf would force
+// an unbounded synchronous read on the lifecycle-gate path. None of this can launder
+// a `complete` verdict (the frozen stdout_hash is MAC-bound to a signed
+// offensive-runs.jsonl row). The identical repo_command_run twin and a shared
+// secure-hash helper are tracked in #114.
+function sha256OffensiveCaptureSecure(domain, runId) {
+  const runsDir = path.resolve(offensiveRunsDir(domain));
+  const leaf = path.resolve(path.join(runsDir, `${runId}.stdout`));
+  if (path.dirname(leaf) !== runsDir) return null;
+  let realDir;
+  let realSessionDir;
+  try {
+    realSessionDir = fs.realpathSync(sessionDir(domain));
+    realDir = fs.realpathSync(runsDir);
+  } catch {
+    return null;
+  }
+  if (realDir !== path.join(realSessionDir, "offensive-runs")) return null;
+  const realLeaf = path.join(realDir, path.basename(leaf));
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  // On platforms without O_NOFOLLOW, pre-check the leaf for a symlink.
+  if (!noFollow) {
+    let lst;
+    try {
+      lst = fs.lstatSync(realLeaf);
+    } catch {
+      return null;
+    }
+    if (lst.isSymbolicLink()) return null;
+  }
+  let fd = null;
+  try {
+    fd = fs.openSync(realLeaf, fs.constants.O_RDONLY | noFollow);
+    const stats = fs.fstatSync(fd);
+    if (!stats.isFile() || stats.nlink !== 1) return null;
+    if (DEFAULT_ARTIFACT_READ_MAX_BYTES != null && stats.size > DEFAULT_ARTIFACT_READ_MAX_BYTES) {
+      return null;
+    }
+    return crypto.createHash("sha256").update(fs.readFileSync(fd)).digest("hex");
+  } catch {
+    // ENOENT / ELOOP (symlinked leaf under O_NOFOLLOW) / any error -> missing.
+    return null;
+  } finally {
+    if (fd != null) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+}
+
+// Project an `exploit_run` observed ref by securely recomputing the sha256 of the
+// on-disk stdout capture file at `offensive-runs/<run_id>.stdout`. Mirrors
 // projectRepoCommandRunObservedRef: the frozen ref's `stdout_hash` is the
 // authoritative identity (the completeness gate's `evidenceReferenceIdentityHash`
-// selector already picks `stdout_hash` for kind="exploit_run"). A missing/unreadable
-// file → null (gate surfaces `missing`); a present-but-tampered file → the actually
-// recomputed sha (gate surfaces `mismatched`).
-//
-// Defense-in-depth (issue #114): `run_id` is only shape-validated upstream as a
-// non-empty string (claims.js assertExploitRunEvidenceShape), so a crafted run_id
-// like "../../x" would otherwise turn this projection into an arbitrary
-// `<path>.stdout` existence + sha256 read-oracle. It can never launder a `complete`
-// verdict (the frozen stdout_hash is MAC-bound to a signed offensive-runs.jsonl
-// row), but we still refuse to read outside the session capture dir: resolve the
-// joined path and return null if it escapes offensiveRunsDir. The source-level
-// run_id validator and the identical repo_command_run twin are tracked in #114.
+// selector already picks `stdout_hash` for kind="exploit_run"). A missing/unreadable/
+// suspicious file → null (gate surfaces `missing`); a present-but-tampered file → the
+// actually recomputed sha (gate surfaces `mismatched`). Path/symlink/size safety is
+// enforced by sha256OffensiveCaptureSecure (see #114 for the twin + shared helper).
 function projectExploitRunObservedRef(domain, frozenRef) {
   if (!frozenRef || frozenRef.kind !== "exploit_run") return null;
   if (typeof frozenRef.run_id !== "string" || !frozenRef.run_id) return null;
-  const runsDir = path.resolve(offensiveRunsDir(domain));
-  const stdoutPath = path.resolve(path.join(runsDir, `${frozenRef.run_id}.stdout`));
-  if (stdoutPath !== runsDir && !stdoutPath.startsWith(`${runsDir}${path.sep}`)) {
-    return null;
-  }
-  const observed = sha256File(stdoutPath);
+  const observed = sha256OffensiveCaptureSecure(domain, frozenRef.run_id);
   if (observed == null) return null;
   return {
     ...frozenRef,

--- a/mcp/lib/claim-freeze.js
+++ b/mcp/lib/claim-freeze.js
@@ -9,7 +9,7 @@ const {
   offensiveRunsDir,
   repoChecksJsonlPath,
   repoRunsDir,
-  sessionDir,
+  sessionsRoot,
 } = require("./paths.js");
 const {
   hashCanonicalJson,
@@ -440,15 +440,21 @@ function sha256OffensiveCaptureSecure(domain, runId) {
   const runsDir = path.resolve(offensiveRunsDir(domain));
   const leaf = path.resolve(path.join(runsDir, `${runId}.stdout`));
   if (path.dirname(leaf) !== runsDir) return null;
+  // Anchor the expected capture dir to the REAL sessions root + safe domain, the
+  // way claims.js::resolveOffensiveRunsFilePathSecure does — NOT to
+  // realpathSync(sessionDir(domain)), which would resolve a symlinked session dir
+  // before comparing and silently accept it (the recording path rejects it, so
+  // anchoring to realpath of the session dir would be a split-brain bypass).
   let realDir;
-  let realSessionDir;
+  let expectedDir;
   try {
-    realSessionDir = fs.realpathSync(sessionDir(domain));
+    const realRoot = fs.realpathSync(sessionsRoot());
+    expectedDir = path.join(realRoot, assertSafeDomain(domain), "offensive-runs");
     realDir = fs.realpathSync(runsDir);
   } catch {
     return null;
   }
-  if (realDir !== path.join(realSessionDir, "offensive-runs")) return null;
+  if (realDir !== expectedDir) return null;
   const realLeaf = path.join(realDir, path.basename(leaf));
   const noFollow = fs.constants.O_NOFOLLOW || 0;
   // On platforms without O_NOFOLLOW, pre-check the leaf for a symlink.

--- a/mcp/lib/claim-freeze.js
+++ b/mcp/lib/claim-freeze.js
@@ -6,6 +6,7 @@ const crypto = require("crypto");
 const {
   assertSafeDomain,
   claimFreezePath,
+  offensiveRunsDir,
   repoChecksJsonlPath,
   repoRunsDir,
 } = require("./paths.js");
@@ -413,6 +414,25 @@ function projectRepoCommandRunObservedRef(domain, frozenRef) {
   };
 }
 
+// Project an `exploit_run` observed ref by recomputing the sha256 of the on-disk
+// stdout capture file at `offensive-runs/<run_id>.stdout`. Mirrors
+// projectRepoCommandRunObservedRef exactly: the frozen ref's `stdout_hash` is the
+// authoritative identity (the completeness gate's `evidenceReferenceIdentityHash`
+// selector already picks `stdout_hash` for kind="exploit_run"). A missing/unreadable
+// file → null (gate surfaces `missing`); a present-but-tampered file → the actually
+// recomputed sha (gate surfaces `mismatched`).
+function projectExploitRunObservedRef(domain, frozenRef) {
+  if (!frozenRef || frozenRef.kind !== "exploit_run") return null;
+  if (typeof frozenRef.run_id !== "string" || !frozenRef.run_id) return null;
+  const stdoutPath = path.join(offensiveRunsDir(domain), `${frozenRef.run_id}.stdout`);
+  const observed = sha256File(stdoutPath);
+  if (observed == null) return null;
+  return {
+    ...frozenRef,
+    stdout_hash: observed,
+  };
+}
+
 // Build the full observed-ref set for the code-bound kinds in a freeze. The
 // caller (typically `assertEvidenceCompletenessForFreeze`) folds these into
 // the existing finding/etc observed set before invoking
@@ -431,6 +451,9 @@ function projectCodeBoundObservedRefs(domain, freeze) {
     } else if (kind === "repo_command_run") {
       const obs = projectRepoCommandRunObservedRef(domain, entry.ref);
       if (obs) projected.push(obs);
+    } else if (kind === "exploit_run") {
+      const obs = projectExploitRunObservedRef(domain, entry.ref);
+      if (obs) projected.push(obs);
     }
   }
   return projected;
@@ -447,6 +470,7 @@ module.exports = {
   iterateFrozenEvidenceRefs,
   normalizeEvidenceReferenceShape,
   projectCodeBoundObservedRefs,
+  projectExploitRunObservedRef,
   projectRepoCommandRunObservedRef,
   projectRepoFileObservedRef,
   readCurrentClaimFreeze,

--- a/mcp/lib/claim-freeze.js
+++ b/mcp/lib/claim-freeze.js
@@ -437,6 +437,19 @@ function projectRepoCommandRunObservedRef(domain, frozenRef) {
 // offensive-runs.jsonl row). The identical repo_command_run twin and a shared
 // secure-hash helper are tracked in #114.
 function sha256OffensiveCaptureSecure(domain, runId) {
+  // run_id is only shape-validated upstream as a non-empty string (claims.js
+  // assertExploitRunEvidenceShape, tracked for a source-level fix in #114). Reject
+  // any run_id that is not a single clean path segment BEFORE building the leaf: a
+  // separator/NUL or a "."/".." segment (e.g. "subdir/../victim") can normalize
+  // back inside offensive-runs/ and alias a DIFFERENT capture file, slipping the
+  // `dirname === runsDir` guard below instead of failing closed.
+  if (typeof runId !== "string" || !runId) return null;
+  if (
+    runId.includes("/") || runId.includes("\\") || runId.includes("\0") ||
+    runId === "." || runId === ".."
+  ) {
+    return null;
+  }
   const runsDir = path.resolve(offensiveRunsDir(domain));
   const leaf = path.resolve(path.join(runsDir, `${runId}.stdout`));
   if (path.dirname(leaf) !== runsDir) return null;

--- a/mcp/lib/claim-freeze.js
+++ b/mcp/lib/claim-freeze.js
@@ -416,15 +416,28 @@ function projectRepoCommandRunObservedRef(domain, frozenRef) {
 
 // Project an `exploit_run` observed ref by recomputing the sha256 of the on-disk
 // stdout capture file at `offensive-runs/<run_id>.stdout`. Mirrors
-// projectRepoCommandRunObservedRef exactly: the frozen ref's `stdout_hash` is the
+// projectRepoCommandRunObservedRef: the frozen ref's `stdout_hash` is the
 // authoritative identity (the completeness gate's `evidenceReferenceIdentityHash`
 // selector already picks `stdout_hash` for kind="exploit_run"). A missing/unreadable
 // file → null (gate surfaces `missing`); a present-but-tampered file → the actually
 // recomputed sha (gate surfaces `mismatched`).
+//
+// Defense-in-depth (issue #114): `run_id` is only shape-validated upstream as a
+// non-empty string (claims.js assertExploitRunEvidenceShape), so a crafted run_id
+// like "../../x" would otherwise turn this projection into an arbitrary
+// `<path>.stdout` existence + sha256 read-oracle. It can never launder a `complete`
+// verdict (the frozen stdout_hash is MAC-bound to a signed offensive-runs.jsonl
+// row), but we still refuse to read outside the session capture dir: resolve the
+// joined path and return null if it escapes offensiveRunsDir. The source-level
+// run_id validator and the identical repo_command_run twin are tracked in #114.
 function projectExploitRunObservedRef(domain, frozenRef) {
   if (!frozenRef || frozenRef.kind !== "exploit_run") return null;
   if (typeof frozenRef.run_id !== "string" || !frozenRef.run_id) return null;
-  const stdoutPath = path.join(offensiveRunsDir(domain), `${frozenRef.run_id}.stdout`);
+  const runsDir = path.resolve(offensiveRunsDir(domain));
+  const stdoutPath = path.resolve(path.join(runsDir, `${frozenRef.run_id}.stdout`));
+  if (stdoutPath !== runsDir && !stdoutPath.startsWith(`${runsDir}${path.sep}`)) {
+    return null;
+  }
   const observed = sha256File(stdoutPath);
   if (observed == null) return null;
   return {

--- a/mcp/lib/paths.js
+++ b/mcp/lib/paths.js
@@ -457,6 +457,7 @@ const AUDIT_GRADED_RELATIVE_DIRS = Object.freeze([
   "verification-replay-leases",
   "wave-handoffs",
   "claim-freeze",
+  "offensive-runs",
 ]);
 
 // Wave-handoff per-agent files live at the session root and follow the

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -99,6 +99,7 @@
   "test/oss-blocked-harness.test.js",
   "test/oss-evidence-reference.test.js",
   "test/offensive-proof-contract.test.js",
+  "test/offensive-run-freeze-completeness.test.js",
   "test/severity-rise-guard.test.js",
   "test/sarif-ingest.test.js",
   "test/static-analysis-index.test.js",

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -21,6 +21,7 @@ const {
   isAuditGradedPath,
   offensiveRunsDir,
   offensiveRunsJsonlPath,
+  sessionDir,
 } = require("../mcp/lib/paths.js");
 const {
   ensureHandoffSigningKey,
@@ -294,4 +295,49 @@ test("#freeze-completeness: projectExploitRunObservedRef refuses a traversal run
     stdout_hash: hex("a"),
   });
   assert.equal(obs, null, "a traversal run_id must NOT read a file outside offensive-runs/, even if it exists");
+}));
+
+// Defense-in-depth (issue #114 / Codex P1): the lexical containment guard does
+// not stop a SYMLINKED capture leaf — bare sha256File would follow the link and
+// hash an attacker-chosen inode (a content read-oracle). The secure read must
+// reject a symlinked leaf (O_NOFOLLOW / lstat) → null.
+test("#freeze-completeness: projectExploitRunObservedRef refuses a SYMLINKED capture leaf (no hash oracle)", () => withTempHome(() => {
+  const domain = "exploit-symlink-leaf.example";
+  const runId = "run-symlink-leaf-1";
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  // A real secret file outside the capture dir.
+  const secretPath = path.join(offensiveRunsDir(domain), "..", "SECRET.txt");
+  fs.writeFileSync(secretPath, "out-of-dir secret body the oracle must not hash\n");
+  // Plant a symlink at offensive-runs/<run_id>.stdout -> the secret file.
+  fs.symlinkSync(secretPath, path.join(offensiveRunsDir(domain), `${runId}.stdout`));
+
+  const obs = projectExploitRunObservedRef(domain, {
+    kind: "exploit_run",
+    run_id: runId,
+    stdout_hash: hex("a"),
+  });
+  assert.equal(obs, null, "a symlinked capture leaf must project null, never hash the link target");
+}));
+
+// Defense-in-depth (issue #114): a symlinked offensive-runs/ DIRECTORY also
+// bypasses an O_NOFOLLOW-on-the-leaf-only check. The realpath parent check must
+// reject a capture dir that does not resolve to <session>/offensive-runs → null.
+test("#freeze-completeness: projectExploitRunObservedRef refuses a SYMLINKED capture directory", () => withTempHome(() => {
+  const domain = "exploit-symlink-dir.example";
+  const runId = "run-symlink-dir-1";
+  // Build a real attacker dir holding a real <run_id>.stdout, then point the
+  // session's offensive-runs/ at it via a directory symlink.
+  const sessDir = sessionDir(domain);
+  fs.mkdirSync(sessDir, { recursive: true });
+  const evilDir = path.join(sessDir, "evil-capture-store");
+  fs.mkdirSync(evilDir, { recursive: true });
+  fs.writeFileSync(path.join(evilDir, `${runId}.stdout`), "planted body via symlinked dir\n");
+  fs.symlinkSync(evilDir, offensiveRunsDir(domain));
+
+  const obs = projectExploitRunObservedRef(domain, {
+    kind: "exploit_run",
+    run_id: runId,
+    stdout_hash: hex("a"),
+  });
+  assert.equal(obs, null, "a symlinked offensive-runs/ dir must project null, never hash through the link");
 }));

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -22,6 +22,7 @@ const {
   offensiveRunsDir,
   offensiveRunsJsonlPath,
   sessionDir,
+  sessionsRoot,
 } = require("../mcp/lib/paths.js");
 const {
   ensureHandoffSigningKey,
@@ -340,4 +341,28 @@ test("#freeze-completeness: projectExploitRunObservedRef refuses a SYMLINKED cap
     stdout_hash: hex("a"),
   });
   assert.equal(obs, null, "a symlinked offensive-runs/ dir must project null, never hash through the link");
+}));
+
+// Defense-in-depth (issue #114 / Codex high): a symlinked SESSION directory must
+// also be rejected. The secure read must anchor the expected capture dir to the
+// real sessions root + safe domain (like resolveOffensiveRunsFilePathSecure),
+// NOT to realpath(sessionDir) — which would resolve the session symlink and
+// silently accept attacker-substituted capture bytes.
+test("#freeze-completeness: projectExploitRunObservedRef refuses a SYMLINKED session directory", () => withTempHome(() => {
+  const domain = "exploit-symlink-sess.example";
+  const runId = "run-symlink-sess-1";
+  // A real attacker tree OUTSIDE the sessions root, holding a real capture leaf.
+  const attacker = path.join(process.env.HOME, "attacker-evil");
+  fs.mkdirSync(path.join(attacker, "offensive-runs"), { recursive: true });
+  fs.writeFileSync(path.join(attacker, "offensive-runs", `${runId}.stdout`), "planted body via session symlink\n");
+  // Point the whole session dir at the attacker tree via a symlink.
+  fs.mkdirSync(sessionsRoot(), { recursive: true });
+  fs.symlinkSync(attacker, sessionDir(domain));
+
+  const obs = projectExploitRunObservedRef(domain, {
+    kind: "exploit_run",
+    run_id: runId,
+    stdout_hash: hex("a"),
+  });
+  assert.equal(obs, null, "a symlinked session dir must project null, never hash attacker-substituted bytes");
 }));

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -1,0 +1,222 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  EVIDENCE_REFERENCE_KIND_VALUES,
+  OFFENSIVE_OUTCOME_VALUES,
+  SAFE_ORACLE_KINDS,
+  appendCandidateClaim,
+  canonicalizeExploitTarget,
+  evidenceReferenceLookupKey,
+  normalizeCandidateClaim,
+  normalizeEvidenceReferenceShape,
+  readCandidateClaims,
+} = require("../mcp/lib/claims.js");
+const {
+  buildClaimFreeze,
+  projectCodeBoundObservedRefs,
+  projectExploitRunObservedRef,
+  assertCompletenessAgainstFreeze,
+} = require("../mcp/lib/claim-freeze.js");
+const {
+  claimsJsonlPath,
+  isAuditGradedPath,
+  offensiveRunsDir,
+  offensiveRunsJsonlPath,
+  repoCommandRunsJsonlPath,
+} = require("../mcp/lib/paths.js");
+const {
+  ensureHandoffSigningKey,
+} = require("../mcp/lib/handoff-signing-key.js");
+const {
+  signOffensiveRunRow,
+} = require("../mcp/lib/offensive-row-mac.js");
+
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function withTempHome(fn) {
+  const previousHome = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-offensive-proof-"));
+  process.env.HOME = home;
+  try {
+    return fn(home);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function hex(char) {
+  return char.repeat(64);
+}
+
+// The cited target host must be in scope for the claim domain (Codex P1 binding),
+// so the ref/row target is derived from the domain unless a test overrides it.
+function exploitRef(domain = "example.com", overrides = {}) {
+  return {
+    kind: "exploit_run",
+    run_id: "run-exploit-1",
+    tool_id: "bob_http_confirm_reflected_canary",
+    target: `https://${domain}/search?q=BOB_CANARY_1`,
+    offensive_outcome: "exploited_safely",
+    command_hash: hex("a"),
+    exit_code: 0,
+    stdout_hash: hex("b"),
+    stderr_hash: hex("c"),
+    ...overrides,
+  };
+}
+
+// issue #111: an exploited_safely claim must carry exactly one surface_id that
+// matches its backed row's surface_id. Default both helpers to the same value so
+// the positive record path passes; binding tests override one side.
+const DEFAULT_SURFACE_ID = "surface-proof-default";
+
+function exploitedClaim(domain, overrides = {}) {
+  return {
+    target_domain: domain,
+    title: "Reflected canary was exploited safely",
+    summary: "A benign canary was reflected in the target response.",
+    severity: "low",
+    exploit_outcome: {
+      outcome: "exploited_safely",
+      safe_oracle: { kind: "reflected_canary" },
+    },
+    evidence_refs: [exploitRef(domain)],
+    surface_ids: [DEFAULT_SURFACE_ID],
+    ...overrides,
+  };
+}
+
+function buildOffensiveRunRow(domain, overrides = {}) {
+  const ref = exploitRef(domain);
+  const row = {
+    version: 1,
+    target_domain: domain,
+    run_id: ref.run_id,
+    tool_id: ref.tool_id,
+    target: ref.target,
+    offensive_outcome: "exploited_safely",
+    dry_run: false,
+    timed_out: false,
+    command_hash: ref.command_hash,
+    exit_code: ref.exit_code,
+    stdout_hash: ref.stdout_hash,
+    stderr_hash: ref.stderr_hash,
+    demonstrated_severity: "low",
+    // issue #111: surface the safe exploit ran against (MAC-covered); must equal
+    // the citing claim's single surface_id.
+    surface_id: DEFAULT_SURFACE_ID,
+    ...overrides,
+  };
+  // The runner records the same canonical (redacted) target the claim ref carries
+  // so the row and ref stay byte-identical for the proof binding.
+  row.target = canonicalizeExploitTarget(row.target);
+  return row;
+}
+
+function writeOffensiveRunRow(domain, row) {
+  fs.mkdirSync(path.dirname(offensiveRunsJsonlPath(domain)), { recursive: true });
+  fs.appendFileSync(offensiveRunsJsonlPath(domain), `${JSON.stringify(row)}\n`);
+  return row;
+}
+
+function appendOffensiveRunRow(domain, overrides = {}) {
+  const row = buildOffensiveRunRow(domain, overrides);
+  signOffensiveRunRow(row, ensureHandoffSigningKey(domain));
+  return writeOffensiveRunRow(domain, row);
+}
+
+test("#freeze-completeness: projectExploitRunObservedRef re-hashes the on-disk capture file", () => withTempHome(() => {
+  const domain = "exploit-proj-match.example";
+  const runId = "run-proj-match-1";
+  const content = "BOB_SYNTH_CANARY_match synthetic cross-tenant body\n";
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  fs.writeFileSync(path.join(offensiveRunsDir(domain), `${runId}.stdout`), content);
+
+  const frozenRef = { kind: "exploit_run", run_id: runId, stdout_hash: sha256Hex(content) };
+  const obs = projectExploitRunObservedRef(domain, frozenRef);
+  assert.ok(obs, "must project an observed ref when the capture file exists");
+  assert.equal(obs.kind, "exploit_run");
+  assert.equal(obs.stdout_hash, sha256Hex(content), "observed hash is the file's recomputed sha256");
+}));
+
+test("#freeze-completeness: projectExploitRunObservedRef returns null when the capture file is missing", () => withTempHome(() => {
+  const domain = "exploit-proj-missing.example";
+  const frozenRef = { kind: "exploit_run", run_id: "run-absent", stdout_hash: sha256Hex("x") };
+  assert.equal(projectExploitRunObservedRef(domain, frozenRef), null);
+}));
+
+test("#freeze-completeness: projectExploitRunObservedRef projects the TAMPERED sha when the file changed", () => withTempHome(() => {
+  const domain = "exploit-proj-mismatch.example";
+  const runId = "run-proj-mismatch-1";
+  const original = "ORIGINAL synthetic body\n";
+  const tampered = "TAMPERED synthetic body\n";
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  fs.writeFileSync(path.join(offensiveRunsDir(domain), `${runId}.stdout`), tampered);
+
+  const frozenRef = { kind: "exploit_run", run_id: runId, stdout_hash: sha256Hex(original) };
+  const obs = projectExploitRunObservedRef(domain, frozenRef);
+  assert.ok(obs);
+  assert.equal(obs.stdout_hash, sha256Hex(tampered), "projects the actual on-disk sha (a mismatch the gate will catch)");
+  assert.notEqual(obs.stdout_hash, frozenRef.stdout_hash);
+}));
+
+test("#freeze-completeness: projectExploitRunObservedRef ignores non-exploit_run refs", () => withTempHome(() => {
+  assert.equal(
+    projectExploitRunObservedRef("k.example", { kind: "repo_command_run", run_id: "x", stdout_hash: "y" }),
+    null,
+  );
+  assert.equal(projectExploitRunObservedRef("k.example", { kind: "exploit_run" }), null, "no run_id → null");
+}));
+
+test("#freeze-completeness: offensive-runs capture dir is audit-graded", () => withTempHome(() => {
+  const domain = "exploit-audit.example";
+  const capture = path.join(offensiveRunsDir(domain), "run-x.stdout");
+  assert.equal(isAuditGradedPath(capture, domain), true, "offensive-runs/<run_id>.stdout must be audit-graded");
+}));
+
+test("#freeze-completeness: a recorded exploited_safely claim freezes and projects its exploit_run capture", () => withTempHome(() => {
+  const domain = "exploit-freeze-e2e.example";
+  const runId = "run-e2e-1";
+  const captureContent = "BOB_SYNTH_CANARY_e2e synthetic cross-tenant body\n";
+  const stdoutHash = sha256Hex(captureContent);
+
+  // 1. Seed a signed offensive-runs row (run_id + stdout_hash overridden so the
+  //    capture file will hash to the same value). appendOffensiveRunRow signs + writes it.
+  appendOffensiveRunRow(domain, { run_id: runId, stdout_hash: stdoutHash });
+
+  // 2. Write the capture file at offensive-runs/<run_id>.stdout (sha256 == stdoutHash).
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  fs.writeFileSync(path.join(offensiveRunsDir(domain), `${runId}.stdout`), captureContent);
+
+  // 3. Record the exploited_safely claim citing a ref with the SAME run_id + stdout_hash.
+  //    (exploitedClaim defaults the surface to DEFAULT_SURFACE_ID, which the seeded row also
+  //    carries, so the record-time proof gate passes.)
+  appendCandidateClaim(exploitedClaim(domain, {
+    evidence_refs: [exploitRef(domain, { run_id: runId, stdout_hash: stdoutHash })],
+  }));
+
+  // 4. Freeze.
+  const freeze = buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+  assert.equal(freeze.claim_count, 1);
+
+  // 5. Project from disk — the exploit_run observed ref MUST now be included (this is the bug fix).
+  const projected = projectCodeBoundObservedRefs(domain, freeze);
+  const exploitObs = projected.find((r) => r.kind === "exploit_run");
+  assert.ok(exploitObs, "projectCodeBoundObservedRefs must now include the exploit_run observed ref");
+  assert.equal(exploitObs.stdout_hash, stdoutHash, "projected hash matches the frozen ref → completeness will pass");
+
+  // 6. The completeness gate passes when supplied the projected observed refs.
+  const verdict = assertCompletenessAgainstFreeze(freeze, projected);
+  assert.equal(verdict.complete, true, `expected complete; got ${JSON.stringify(verdict)}`);
+}));

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -8,15 +8,8 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
-  EVIDENCE_REFERENCE_KIND_VALUES,
-  OFFENSIVE_OUTCOME_VALUES,
-  SAFE_ORACLE_KINDS,
   appendCandidateClaim,
   canonicalizeExploitTarget,
-  evidenceReferenceLookupKey,
-  normalizeCandidateClaim,
-  normalizeEvidenceReferenceShape,
-  readCandidateClaims,
 } = require("../mcp/lib/claims.js");
 const {
   buildClaimFreeze,
@@ -25,11 +18,9 @@ const {
   assertCompletenessAgainstFreeze,
 } = require("../mcp/lib/claim-freeze.js");
 const {
-  claimsJsonlPath,
   isAuditGradedPath,
   offensiveRunsDir,
   offensiveRunsJsonlPath,
-  repoCommandRunsJsonlPath,
 } = require("../mcp/lib/paths.js");
 const {
   ensureHandoffSigningKey,
@@ -219,4 +210,88 @@ test("#freeze-completeness: a recorded exploited_safely claim freezes and projec
   // 6. The completeness gate passes when supplied the projected observed refs.
   const verdict = assertCompletenessAgainstFreeze(freeze, projected);
   assert.equal(verdict.complete, true, `expected complete; got ${JSON.stringify(verdict)}`);
+}));
+
+// Negative end-to-end: the WHOLE point of exploit_run being a content-bound
+// kind is tamper-evidence. If the on-disk capture is altered after freeze, the
+// re-projected sha no longer matches the frozen stdout_hash and the completeness
+// gate MUST report complete:false with an exploit_run mismatch — blocking the
+// lifecycle. This exercises the hash-differs branch (claim-freeze.js:287) through
+// the real record→freeze→project path.
+test("#freeze-completeness: a TAMPERED exploit_run capture drives completeness to false (not silently complete)", () => withTempHome(() => {
+  const domain = "exploit-freeze-tamper.example";
+  const runId = "run-tamper-1";
+  const originalContent = "BOB_SYNTH_CANARY_orig synthetic cross-tenant body\n";
+  const stdoutHash = sha256Hex(originalContent);
+
+  // Seed a signed row + claim whose frozen stdout_hash == sha256(originalContent).
+  appendOffensiveRunRow(domain, { run_id: runId, stdout_hash: stdoutHash });
+  appendCandidateClaim(exploitedClaim(domain, {
+    evidence_refs: [exploitRef(domain, { run_id: runId, stdout_hash: stdoutHash })],
+  }));
+
+  // Write a TAMPERED capture file at offensive-runs/<run_id>.stdout (sha != frozen stdout_hash).
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  fs.writeFileSync(
+    path.join(offensiveRunsDir(domain), `${runId}.stdout`),
+    "TAMPERED synthetic body — altered after freeze\n",
+  );
+
+  const freeze = buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+  const projected = projectCodeBoundObservedRefs(domain, freeze);
+  // The projection still emits an exploit_run observed ref (the file exists), but
+  // carrying the TAMPERED sha — so the gate must flag a mismatch, not satisfy.
+  const verdict = assertCompletenessAgainstFreeze(freeze, projected);
+  assert.equal(verdict.complete, false, "a tampered capture must NOT satisfy completeness");
+  assert.ok(
+    verdict.mismatched.some((m) => m.kind === "exploit_run"),
+    `the gate must report the exploit_run ref as mismatched; got ${JSON.stringify(verdict.mismatched)}`,
+  );
+}));
+
+// Focused unit coverage for the exploit_run-specific anti-silent-satisfy guard
+// (claim-freeze.js:277): an observed exploit_run ref that is present by key but
+// omits its stdout_hash must count as a mismatch, NOT a key-presence satisfy.
+// Without this guard a verifier could satisfy the freeze without ever proving the
+// capture's content identity.
+test("#freeze-completeness: an exploit_run observed ref missing its stdout_hash is a mismatch, never a silent satisfy", () => withTempHome(() => {
+  const domain = "exploit-null-hash.example";
+  const runId = "run-nullhash-1";
+  const stdoutHash = sha256Hex("BOB_SYNTH_CANARY_nullhash body\n");
+
+  appendOffensiveRunRow(domain, { run_id: runId, stdout_hash: stdoutHash });
+  appendCandidateClaim(exploitedClaim(domain, {
+    evidence_refs: [exploitRef(domain, { run_id: runId, stdout_hash: stdoutHash })],
+  }));
+  const freeze = buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  // Supply an observed exploit_run ref that matches the frozen key (run_id) but
+  // carries no stdout_hash — the gate must NOT treat key-presence as satisfaction.
+  const observedWithoutHash = [{ kind: "exploit_run", run_id: runId }];
+  const verdict = assertCompletenessAgainstFreeze(freeze, observedWithoutHash);
+  assert.equal(verdict.complete, false, "key-present-but-hash-null must not satisfy the freeze");
+  assert.ok(
+    verdict.mismatched.some((m) => m.kind === "exploit_run" && m.observed_hash === null),
+    `the null-observed-hash guard must flag a mismatch; got ${JSON.stringify(verdict.mismatched)}`,
+  );
+}));
+
+// Defense-in-depth (issue #114): a crafted run_id must never let the projection
+// read a file OUTSIDE offensive-runs/. Plant a real file one level up that a
+// "../" run_id would resolve to; without the containment guard the projection
+// would read it and return its sha (an arbitrary <path>.stdout read-oracle). With
+// the guard the resolved path escapes offensiveRunsDir → null.
+test("#freeze-completeness: projectExploitRunObservedRef refuses a traversal run_id even when the target file exists", () => withTempHome(() => {
+  const domain = "exploit-traversal.example";
+  // offensiveRunsDir(domain)/../OUTSIDE.stdout — a real file just outside the capture dir.
+  const outsidePath = path.join(offensiveRunsDir(domain), "..", "OUTSIDE.stdout");
+  fs.mkdirSync(path.dirname(outsidePath), { recursive: true });
+  fs.writeFileSync(outsidePath, "secret body outside the capture dir\n");
+
+  const obs = projectExploitRunObservedRef(domain, {
+    kind: "exploit_run",
+    run_id: "../OUTSIDE",
+    stdout_hash: hex("a"),
+  });
+  assert.equal(obs, null, "a traversal run_id must NOT read a file outside offensive-runs/, even if it exists");
 }));

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -298,6 +298,24 @@ test("#freeze-completeness: projectExploitRunObservedRef refuses a traversal run
   assert.equal(obs, null, "a traversal run_id must NOT read a file outside offensive-runs/, even if it exists");
 }));
 
+// Defense-in-depth (issue #114 / Codex P2): a run_id that NORMALIZES back inside
+// the dir (e.g. "subdir/../victim") would otherwise resolve to victim.stdout and
+// pass the dirname guard, aliasing a DIFFERENT capture. Reject raw separators →
+// null, fail-closed.
+test("#freeze-completeness: projectExploitRunObservedRef refuses a normalizing run_id that aliases another capture", () => withTempHome(() => {
+  const domain = "exploit-alias.example";
+  fs.mkdirSync(offensiveRunsDir(domain), { recursive: true });
+  // A real capture for run "victim" that the aliasing run_id would resolve to.
+  fs.writeFileSync(path.join(offensiveRunsDir(domain), "victim.stdout"), "victim capture body\n");
+
+  const obs = projectExploitRunObservedRef(domain, {
+    kind: "exploit_run",
+    run_id: "subdir/../victim",
+    stdout_hash: hex("a"),
+  });
+  assert.equal(obs, null, "a run_id with separators/normalization must project null, not alias victim's capture");
+}));
+
 // Defense-in-depth (issue #114 / Codex P1): the lexical containment guard does
 // not stop a SYMLINKED capture leaf — bare sha256File would follow the link and
 // hash an attacker-chosen inode (a content read-oracle). The secure read must


### PR DESCRIPTION
## What

Adds the `exploit_run` branch to freeze-completeness projection and audit-grades the `offensive-runs/` capture directory. This is the dormant foundation for the offensive IDOR producer — it ships inert (nothing writes `exploit_run` evidence in production yet).

- `mcp/lib/claim-freeze.js`: new `projectExploitRunObservedRef` (re-hashes `offensive-runs/<run_id>.stdout`), dispatched in `projectCodeBoundObservedRefs`, exported.
- `mcp/lib/paths.js`: `"offensive-runs"` added to `AUDIT_GRADED_RELATIVE_DIRS` so the capture files are tamper-evident.

## Why

`exploit_run` is a content-bound evidence kind, but `projectCodeBoundObservedRefs` only had branches for `repo_file` + `repo_command_run`. A frozen `exploit_run` ref was therefore never re-projected from disk → the completeness gate reported it `missing` → the lifecycle blocked. The comparison side was already wired (`evidenceReferenceIdentityHash` routes `exploit_run` → `stdout_hash`, and the anti-silent-satisfy guard already exists); the only gap was projection.

## Design

`projectExploitRunObservedRef` mirrors the proven `projectRepoCommandRunObservedRef` precedent (same null-on-missing / recompute-on-tamper semantics). **No false-`complete` is possible:** the re-projected sha is compared against the frozen `stdout_hash`, which at record time is MAC-bound to a signed `offensive-runs.jsonl` row — tamper → `mismatched`, missing → `missing`. Audit-grading is segment-matched, so it covers `offensive-runs/<run_id>.stdout` without touching the sibling `offensive-runs.jsonl` (already graded as a basename).

## Review fixes folded in (2nd commit)

This branch was put through an independent 5-lens adversarial review. Source change came back correct/faithful/complete; the fixes below address the review's findings:

- **Pruned 9 unused imports** from the new test (copy-paste cruft).
- **Added negative coverage** that was missing: a tampered capture → `complete:false` with an `exploit_run` mismatch (end-to-end), and the null-observed-hash anti-silent-satisfy guard (previously zero coverage).
- **Hardened `run_id` path-join** (issue #114): a crafted `run_id` (e.g. `"../../x"`) would otherwise make the projection an out-of-dir `<path>.stdout` read-oracle. It can never launder a `complete` verdict (frozen hash is MAC-bound), but the projection now resolves the joined path and returns `null` on escape. New test plants a real out-of-dir file and asserts a `"../"` run_id projects `null`.

## Tracked follow-up

**#114** — the proper class fix: tighten the source-level `run_id` validators in `claims.js` and bring the **live** `repo_command_run` twin (`projectRepoCommandRunObservedRef`, same unsanitized join) into line. Out of this PR's declared scope; this PR adds only the in-helper containment guard for the new code.

## Tests

- New suite `test/offensive-run-freeze-completeness.test.js`: **9/9** (projection match/missing/tampered/wrong-kind, audit-graded, record→freeze→project e2e, tamper→incomplete e2e, null-hash mismatch, traversal-refusal). The e2e and traversal tests genuinely fail when the respective branch/guard is reverted.
- `npm run test:mcp`: **2464 pass / 0 fail** / 2 pre-existing skips. `npm run check:syntax` clean.

## Scope

4 files: `claim-freeze.js`, `paths.js`, the new test, and the test manifest registration. No lifecycle-gate, hook, or `claims.js` changes; no new tool/runner/network.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strengthened exploit-run freeze verification by recomputing the `stdout_hash` from the corresponding on-disk capture when projecting observed refs.
  * Expanded audit-graded path handling to include `offensive-runs` capture locations under the session directory.

* **Bug Fixes**
  * Fail-closed behavior now prevents silent completeness when captures are missing, tampered, or unsafe (including traversal/aliasing and symlink/hardlink cases).

* **Tests**
  * Added end-to-end and security-focused coverage to validate correct matching/mismatching and completeness outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->