### PR TITLE
feat(offense): gate CLAIM_FREEZE->VERIFY on exploit-proof + per-tool demonstrated-severity ceiling

### DIFF
--- a/mcp/lib/claims.js
+++ b/mcp/lib/claims.js
@@ -752,6 +752,22 @@ const CLAIM_EXPLOIT_SEVERITY_RANK = Object.freeze(
   Object.fromEntries(SEVERITY_VALUES.map((severity, index) => [severity, SEVERITY_VALUES.length - index])),
 );
 
+// Per-offensive-tool cap on the demonstrated_severity a signed row may assert. REAL signable
+// producers ONLY. FAIL-CLOSED: any tool_id that is NOT an own key resolves to "info" (lowest tier);
+// `?? "critical"` would be fail-OPEN and is forbidden. Object.freeze + "use strict" means an
+// in-process actor's `MAP.x = "critical"` THROWS — the map cannot be widened at runtime.
+//
+//   bob_http_idor_confirm: the future PR-C second-test-identity IDOR producer (does NOT exist at
+//   HEAD; pre-seeded per design D5 so the ceiling enforces the day PR-C first writes a row). A safe
+//   cross-tenant READ of attacker-owned SYNTHETIC objects caps at MEDIUM by construction.
+// DELIBERATELY ABSENT: bob_http_confirm (real, but NEGATIVE-ONLY — mints no signed row in
+//   production; mapping it would grant a signable ceiling to a tool that must never sign).
+const OFFENSIVE_TOOL_DEMONSTRATED_CEILING = Object.freeze(
+  Object.assign(Object.create(null), {
+    bob_http_idor_confirm: "medium",
+  }),
+);
+
 function exploitSeverityRank(severity) {
   const normalized = severity === "informational" ? "info" : severity;
   return (typeof normalized === "string" && CLAIM_EXPLOIT_SEVERITY_RANK[normalized.toLowerCase()]) || 0;
@@ -1062,6 +1078,26 @@ function assertExploitedClaimHasProof(claim, { existingClaims = [] } = {}) {
       },
     );
   }
+
+  // Per-tool demonstrated_severity ceiling (PR-A). The claim-vs-row ceiling above bounds
+  // claim.severity by what the rows demonstrated; this bounds what any single row is even ALLOWED
+  // to demonstrate, per the tool that produced it. FAIL-CLOSED to "info" for unknown/forged tool_ids.
+  for (const row of backedRows) {
+    const toolCeil = OFFENSIVE_TOOL_DEMONSTRATED_CEILING[row.tool_id] ?? "info";
+    if (exploitSeverityRank(row.demonstrated_severity) > exploitSeverityRank(toolCeil)) {
+      throw new ToolError(
+        ERROR_CODES.INVALID_ARGUMENTS,
+        "offensive-runs row demonstrates a severity above the ceiling permitted for the tool that produced it.",
+        {
+          code: "exploit_proof_tool_demonstrated_ceiling_exceeded",
+          run_id: row.run_id || null,
+          tool_id: row.tool_id || null,
+          demonstrated_severity: row.demonstrated_severity,
+          tool_ceiling: toolCeil,
+        },
+      );
+    }
+  }
 }
 
 function appendCandidateClaim(input, options = {}) {
@@ -1096,6 +1132,7 @@ module.exports = {
   CLAIM_STATUSES,
   CLAIM_VERSION,
   EVIDENCE_REFERENCE_KIND_VALUES,
+  OFFENSIVE_TOOL_DEMONSTRATED_CEILING,
   OFFENSIVE_OUTCOME_VALUES,
   O_P4_NATIVE_LANGUAGES,
   O_P4_TRIGGERING_SEVERITIES,

--- a/mcp/lib/lifecycle-gates.js
+++ b/mcp/lib/lifecycle-gates.js
@@ -157,22 +157,35 @@ function gateClaimFreezeToVerify(context) {
     });
     return blockers;
   }
-  // No freeze doc yet, or a freeze with no claims: nothing to re-verify (does not brick).
-  if (!freeze || !Array.isArray(freeze.claims) || freeze.claims.length === 0) {
+  // No freeze doc yet: not this gate's concern, and a normal pre-freeze advance must not brick.
+  if (!freeze) return blockers;
+  // A freeze that exists but whose claims[] is not an array is corrupt/tampered — fail closed
+  // (CodeRabbit): a malformed freeze must not silently advance to VERIFY. An empty claims[] is
+  // legitimate (nothing to re-verify) and falls through to the [] return below.
+  if (!Array.isArray(freeze.claims)) {
+    blockers.push({
+      code: "claim_freeze_invalid_shape",
+      blocked_by: "claim_freeze_invalid_shape",
+      message: "CLAIM_FREEZE -> VERIFY blocked: claim-freeze.json must contain a claims[] array.",
+      remediation: "rebuild claim-freeze.json from the persisted candidate claims before advancing to VERIFY",
+    });
     return blockers;
   }
 
-  // (2) NO-BRICK EARLY EXIT. Keep only frozen claims that both assert exploited_safely AND carry
-  // an exploit_run ref. A normal session (no offensive rows, hence no such claims) returns []
-  // here WITHOUT reading the offensive ledger or the signing key, so a session with NO signing
-  // key on disk is never bricked.
+  // (2) NO-BRICK EARLY EXIT. Select EVERY frozen claim asserting exploited_safely (NOT only those
+  // that already carry an exploit_run ref). A normal session has zero such claims and returns []
+  // here WITHOUT reading the offensive ledger or the signing key, so a session with NO signing key
+  // on disk is never bricked. FAIL-CLOSED (CodeRabbit/brutalist): an exploited_safely claim that
+  // lacks a valid exploit_run ref — only possible via claim-freeze.json tampering, since the record
+  // gate rejects it — is NOT silently skipped; it flows into assertExploitedClaimHasProof below,
+  // which throws exploit_proof_missing_exploit_run_evidence BEFORE any ledger/key read, and that
+  // throw is converted to a blocker in step (3). No-brick is unaffected: the filter still requires
+  // exploited_safely, and the missing-ref throw fires before the conditional signing-key read.
   const exploitedClaims = freeze.claims.filter((claim) => (
     claim
     && typeof claim === "object"
     && claim.exploit_outcome
     && claim.exploit_outcome.outcome === "exploited_safely"
-    && Array.isArray(claim.evidence_refs)
-    && claim.evidence_refs.some((ref) => ref && ref.kind === "exploit_run")
   ));
   if (exploitedClaims.length === 0) return blockers;
 

--- a/mcp/lib/lifecycle-gates.js
+++ b/mcp/lib/lifecycle-gates.js
@@ -46,6 +46,7 @@ const TRANSITION_GATES = Object.freeze({
   "VERIFY->GRADE": gateVerifyToGrade,
   "GRADE->REPORT": gateGradeToReport,
   "OPEN_FRONTIER->CLAIM_FREEZE": gateOpenFrontierToClaimFreeze,
+  "CLAIM_FREEZE->VERIFY": gateClaimFreezeToVerify,
 });
 
 function compactError(error) {
@@ -132,6 +133,79 @@ function gateGradeToReport(context) {
       message: `GRADE -> REPORT blocked: ${message}`,
       error: message,
     });
+  }
+  return blockers;
+}
+
+function gateClaimFreezeToVerify(context) {
+  const blockers = [];
+
+  // (1) Read the frozen claim batch. The authoritative frozen set is the claims[] array inside
+  // claim-freeze.json (written by buildClaimFreeze(write:true) during CLAIM_FREEZE), NOT a
+  // status filter on claims.jsonl — claim-freeze.js never mutates a claim's status to "frozen".
+  let freeze;
+  try {
+    freeze = require("./claim-freeze.js").readCurrentClaimFreeze(context.target_domain);
+  } catch (error) {
+    blockers.push({
+      code: "claim_freeze_unreadable",
+      blocked_by: "claim_freeze_unreadable",
+      message: `CLAIM_FREEZE -> VERIFY blocked: could not read claim-freeze.json: ${compactError(error)}`,
+      error: compactError(error),
+      remediation:
+        "re-run the claim freeze (bob_record_candidate_claim / freeze flow) so claim-freeze.json is valid before advancing to VERIFY",
+    });
+    return blockers;
+  }
+  // No freeze doc yet, or a freeze with no claims: nothing to re-verify (does not brick).
+  if (!freeze || !Array.isArray(freeze.claims) || freeze.claims.length === 0) {
+    return blockers;
+  }
+
+  // (2) NO-BRICK EARLY EXIT. Keep only frozen claims that both assert exploited_safely AND carry
+  // an exploit_run ref. A normal session (no offensive rows, hence no such claims) returns []
+  // here WITHOUT reading the offensive ledger or the signing key, so a session with NO signing
+  // key on disk is never bricked.
+  const exploitedClaims = freeze.claims.filter((claim) => (
+    claim
+    && typeof claim === "object"
+    && claim.exploit_outcome
+    && claim.exploit_outcome.outcome === "exploited_safely"
+    && Array.isArray(claim.evidence_refs)
+    && claim.evidence_refs.some((ref) => ref && ref.kind === "exploit_run")
+  ));
+  if (exploitedClaims.length === 0) return blockers;
+
+  // (3) Re-confirm each exploited_safely claim still has a fresh, matching, signed offensive row
+  // backing every cited exploit_run ref. Reuse the record-time contract verbatim. The assert
+  // reads the offensive ledger and reads the signing key ONLY when runRows.length > 0, so the
+  // conditional-key-read no-brick rule holds via reuse. existingClaims:[] avoids re-tripping
+  // run_id-single-use against the frozen siblings themselves (single-use was enforced at record
+  // time; this gate re-checks backing/MAC/surface/severity/tool-ceiling freshness).
+  const { assertExploitedClaimHasProof } = require("./claims.js");
+  for (const claim of exploitedClaims) {
+    try {
+      assertExploitedClaimHasProof(claim, { existingClaims: [] });
+    } catch (error) {
+      // Gate RETURNS blockers; the assert THROWS. Convert any throw into a structured blocker.
+      const underlying = (error && error.details && typeof error.details.code === "string")
+        ? error.details.code
+        : null;
+      blockers.push({
+        code: "exploited_claim_proof_unbacked_at_freeze",
+        blocked_by: "exploited_claim_proof_unbacked_at_freeze",
+        claim_id: typeof claim.claim_id === "string" ? claim.claim_id : null,
+        underlying_code: underlying,
+        message:
+          `CLAIM_FREEZE -> VERIFY blocked: frozen exploited_safely claim`
+          + ` ${typeof claim.claim_id === "string" ? claim.claim_id : "(unknown)"}`
+          + ` is no longer backed by a fresh signed offensive-runs row: ${compactError(error)}`,
+        error: compactError(error),
+        remediation:
+          "re-run the offensive confirmer/producer for this finding so a fresh MAC-signed"
+          + " offensive-runs.jsonl row backs every cited exploit_run ref, then re-freeze before VERIFY",
+      });
+    }
   }
   return blockers;
 }

--- a/mcp/lib/lifecycle-gates.js
+++ b/mcp/lib/lifecycle-gates.js
@@ -53,6 +53,20 @@ function compactError(error) {
   return error && error.message ? error.message : String(error);
 }
 
+// Mirrors session-state.js isSensitiveMaterialError (the two messages
+// validateNoSensitiveMaterial raises). Replicated locally to avoid a require
+// cycle (session-state.js requires this module). readCandidateClaims re-runs the
+// sensitive-material validator over every persisted claim; when one carries
+// legitimately secret-shaped evidence without a persisted bypass, the read throws.
+// That is the VERIFY snapshot bootstrap's concern (it raises the specific
+// claim_evidence_secret_blocked block and honors operator_force) — the
+// CLAIM_FREEZE->VERIFY gate must DEFER it, not preempt it with its own blocker.
+function isSensitiveMaterialReadError(error) {
+  const message = error && typeof error.message === "string" ? error.message : "";
+  return /appears to contain secrets, auth headers, cookies, or tokens/.test(message)
+    || /is too large; do not persist raw large response bodies/.test(message);
+}
+
 function gateVerifyToGrade(context) {
   const blockers = [];
   try {
@@ -140,65 +154,69 @@ function gateGradeToReport(context) {
 function gateClaimFreezeToVerify(context) {
   const blockers = [];
 
-  // (1) Read the frozen claim batch. The authoritative frozen set is the claims[] array inside
-  // claim-freeze.json (written by buildClaimFreeze(write:true) during CLAIM_FREEZE), NOT a
-  // status filter on claims.jsonl — claim-freeze.js never mutates a claim's status to "frozen".
-  let freeze;
+  // (1) Read the CANDIDATE claims — the authoritative set at THIS transition. The claim-freeze.json
+  // SNAPSHOT does not exist yet here: bob_advance_session evaluates this gate (session-state.js:502)
+  // BEFORE the durable write, and the freeze snapshot is built lazily by the VERIFY bootstrap
+  // (prepareVerificationEntry -> buildClaimFreeze, session-state.js:590) only AFTER this gate passes.
+  // Reading readCurrentClaimFreeze here would therefore see null and no-op (the gate would never
+  // fire in production). readCandidateClaims (claims.jsonl) is exactly the set buildClaimFreeze will
+  // snapshot verbatim, and it exists now — recorded during the hunt before CLAIM_FREEZE. It also
+  // re-normalizes each record and fail-closes on a malformed line (readJsonlStrict), so a tampered
+  // claims.jsonl surfaces as a read error -> blocker below.
+  let claims;
   try {
-    freeze = require("./claim-freeze.js").readCurrentClaimFreeze(context.target_domain);
+    claims = require("./claims.js").readCandidateClaims(context.target_domain);
   } catch (error) {
+    // A persisted claim's secret-shaped evidence trips the sensitive-material re-scan inside
+    // readCandidateClaims. That is the VERIFY snapshot bootstrap's job (it raises the specific
+    // claim_evidence_secret_blocked block and honors operator_force); this gate defers rather than
+    // preempting it with a generic blocker.
+    if (isSensitiveMaterialReadError(error)) return blockers;
     blockers.push({
-      code: "claim_freeze_unreadable",
-      blocked_by: "claim_freeze_unreadable",
-      message: `CLAIM_FREEZE -> VERIFY blocked: could not read claim-freeze.json: ${compactError(error)}`,
+      code: "candidate_claims_unreadable",
+      blocked_by: "candidate_claims_unreadable",
+      message: `CLAIM_FREEZE -> VERIFY blocked: could not read the candidate claims: ${compactError(error)}`,
       error: compactError(error),
       remediation:
-        "re-run the claim freeze (bob_record_candidate_claim / freeze flow) so claim-freeze.json is valid before advancing to VERIFY",
+        "repair claims.jsonl (it failed the strict read) before advancing to VERIFY",
     });
     return blockers;
   }
-  // No freeze doc yet: not this gate's concern, and a normal pre-freeze advance must not brick.
-  if (!freeze) return blockers;
-  // A freeze that exists but whose claims[] is not an array is corrupt/tampered — fail closed
-  // (CodeRabbit): a malformed freeze must not silently advance to VERIFY. An empty claims[] is
-  // legitimate (nothing to re-verify) and falls through to the [] return below.
-  if (!Array.isArray(freeze.claims)) {
-    blockers.push({
-      code: "claim_freeze_invalid_shape",
-      blocked_by: "claim_freeze_invalid_shape",
-      message: "CLAIM_FREEZE -> VERIFY blocked: claim-freeze.json must contain a claims[] array.",
-      remediation: "rebuild claim-freeze.json from the persisted candidate claims before advancing to VERIFY",
-    });
-    return blockers;
-  }
+  if (!Array.isArray(claims) || claims.length === 0) return blockers;
 
-  // (2) NO-BRICK EARLY EXIT. Select EVERY frozen claim asserting exploited_safely (NOT only those
-  // that already carry an exploit_run ref). A normal session has zero such claims and returns []
-  // here WITHOUT reading the offensive ledger or the signing key, so a session with NO signing key
-  // on disk is never bricked. FAIL-CLOSED (CodeRabbit/brutalist): an exploited_safely claim that
-  // lacks a valid exploit_run ref — only possible via claim-freeze.json tampering, since the record
-  // gate rejects it — is NOT silently skipped; it flows into assertExploitedClaimHasProof below,
-  // which throws exploit_proof_missing_exploit_run_evidence BEFORE any ledger/key read, and that
-  // throw is converted to a blocker in step (3). No-brick is unaffected: the filter still requires
-  // exploited_safely, and the missing-ref throw fires before the conditional signing-key read.
-  const exploitedClaims = freeze.claims.filter((claim) => (
+  // (2) NO-BRICK EARLY EXIT. Select every claim that the exploit-proof contract has anything to say
+  // about: it either asserts exploited_safely OR carries an exploit_run evidence_ref. A normal
+  // session has zero such claims and returns [] here WITHOUT reading the offensive ledger or the
+  // signing key, so a session with NO signing key on disk is never bricked. FAIL-CLOSED
+  // (CodeRabbit/Codex): both tamper shapes are caught — (a) an exploited_safely claim lacking an
+  // exploit_run ref, and (b) a claim still carrying an exploit_run ref after its outcome was
+  // changed/removed (the VERIFY severity-rise guard consumes exploit_run refs regardless of
+  // outcome) — because both flow into assertExploitedClaimHasProof below, which throws
+  // (exploit_proof_missing_exploit_run_evidence / exploit_run_ref_without_exploited_outcome) BEFORE
+  // any ledger/key read. No-brick is unaffected: a normal claim matches neither arm of the filter.
+  const claimsRequiringProof = claims.filter((claim) => (
     claim
     && typeof claim === "object"
-    && claim.exploit_outcome
-    && claim.exploit_outcome.outcome === "exploited_safely"
+    && (
+      (claim.exploit_outcome && claim.exploit_outcome.outcome === "exploited_safely")
+      || (Array.isArray(claim.evidence_refs)
+        && claim.evidence_refs.some((ref) => ref && ref.kind === "exploit_run"))
+    )
   ));
-  if (exploitedClaims.length === 0) return blockers;
+  if (claimsRequiringProof.length === 0) return blockers;
 
-  // (3) Re-confirm each exploited_safely claim still has a fresh, matching, signed offensive row
-  // backing every cited exploit_run ref. Reuse the record-time contract verbatim. The assert
-  // reads the offensive ledger and reads the signing key ONLY when runRows.length > 0, so the
-  // conditional-key-read no-brick rule holds via reuse. existingClaims:[] avoids re-tripping
-  // run_id-single-use against the frozen siblings themselves (single-use was enforced at record
-  // time; this gate re-checks backing/MAC/surface/severity/tool-ceiling freshness).
+  // (3) Re-confirm each proof-bearing claim still has a fresh, matching, signed offensive row
+  // backing every cited exploit_run ref. Reuse the record-time contract verbatim. The assert reads
+  // the offensive ledger and reads the signing key ONLY when runRows.length > 0, so the
+  // conditional-key-read no-brick rule holds via reuse. Pass the FULL candidate-claim set as
+  // existingClaims (Codex) so the assert's run_id-single-use check catches a tampered claims.jsonl
+  // that duplicates one signed exploit_run across multiple findings; the assert self-skips the same
+  // claim_id, so a legitimately unique frozen set never false-blocks (record-time single-use
+  // already guarantees uniqueness on the normal path).
   const { assertExploitedClaimHasProof } = require("./claims.js");
-  for (const claim of exploitedClaims) {
+  for (const claim of claimsRequiringProof) {
     try {
-      assertExploitedClaimHasProof(claim, { existingClaims: [] });
+      assertExploitedClaimHasProof(claim, { existingClaims: claims });
     } catch (error) {
       // Gate RETURNS blockers; the assert THROWS. Convert any throw into a structured blocker.
       const underlying = (error && error.details && typeof error.details.code === "string")
@@ -210,13 +228,13 @@ function gateClaimFreezeToVerify(context) {
         claim_id: typeof claim.claim_id === "string" ? claim.claim_id : null,
         underlying_code: underlying,
         message:
-          `CLAIM_FREEZE -> VERIFY blocked: frozen exploited_safely claim`
+          `CLAIM_FREEZE -> VERIFY blocked: claim`
           + ` ${typeof claim.claim_id === "string" ? claim.claim_id : "(unknown)"}`
-          + ` is no longer backed by a fresh signed offensive-runs row: ${compactError(error)}`,
+          + ` cites exploit-proof that no longer holds: ${compactError(error)}`,
         error: compactError(error),
         remediation:
           "re-run the offensive confirmer/producer for this finding so a fresh MAC-signed"
-          + " offensive-runs.jsonl row backs every cited exploit_run ref, then re-freeze before VERIFY",
+          + " offensive-runs.jsonl row backs every cited exploit_run ref, then re-record/re-freeze before VERIFY",
       });
     }
   }

--- a/mcp/lib/verification-round-store.js
+++ b/mcp/lib/verification-round-store.js
@@ -49,6 +49,7 @@ const {
 const {
   readOffensiveRunRecords,
   offensiveRunRowSatisfiesEvidence,
+  OFFENSIVE_TOOL_DEMONSTRATED_CEILING,
 } = require("./claims.js");
 const {
   readHandoffSigningKey,
@@ -281,7 +282,17 @@ function clampResultSeveritiesInPlace(domain, results) {
               && typeof row.surface_id === "string"
               && row.surface_id.trim() === surfaceId
             ) {
-              maxDemonstratedRank = Math.max(maxDemonstratedRank, verifySeverityRank(row.demonstrated_severity));
+              // Per-tool demonstrated_severity ceiling (PR-A), applied HERE too so the cap is a true
+              // system invariant — enforced at the record gate, the CLAIM_FREEZE->VERIFY gate, AND
+              // this verify-time severity-rise path. Cap the row's demonstrated rank at its tool's
+              // ceiling before it can unlock a rise: a forged/over-ceiling row, or a session advanced
+              // past the gate with operator_force, cannot raise severity above the tool's ceiling. An
+              // unknown/forged tool_id fail-closes to "info" (lowest tier).
+              const toolCeilRank = verifySeverityRank(
+                OFFENSIVE_TOOL_DEMONSTRATED_CEILING[row.tool_id] ?? "info",
+              );
+              const cappedRowRank = Math.min(verifySeverityRank(row.demonstrated_severity), toolCeilRank);
+              maxDemonstratedRank = Math.max(maxDemonstratedRank, cappedRowRank);
             }
           }
         }

--- a/test/offensive-confirmer.test.js
+++ b/test/offensive-confirmer.test.js
@@ -212,7 +212,7 @@ function seedSignedLowRow(domain, surfaceId) {
   const ref = {
     kind: "exploit_run",
     run_id: "oconf-seed-low-1",
-    tool_id: "bob_http_confirm",
+    tool_id: "bob_http_idor_confirm",
     target,
     offensive_outcome: "exploited_safely",
     command_hash: "a".repeat(64),

--- a/test/offensive-proof-contract.test.js
+++ b/test/offensive-proof-contract.test.js
@@ -53,7 +53,7 @@ function exploitRef(domain = "example.com", overrides = {}) {
   return {
     kind: "exploit_run",
     run_id: "run-exploit-1",
-    tool_id: "bob_http_confirm_reflected_canary",
+    tool_id: "bob_http_idor_confirm",
     target: `https://${domain}/search?q=BOB_CANARY_1`,
     offensive_outcome: "exploited_safely",
     command_hash: hex("a"),
@@ -375,6 +375,70 @@ test("exploited_safely claim severity cannot exceed demonstrated_severity", () =
     severity: "low",
   }));
   assert.equal(lowClaim.severity, "low");
+}));
+
+test("offensive tool demonstrated-severity ceiling rejects above-medium IDOR rows", () => withTempHome(() => {
+  const criticalDomain = "offensive-tool-ceiling-critical.example";
+  appendOffensiveRunRow(criticalDomain, {
+    tool_id: "bob_http_idor_confirm",
+    demonstrated_severity: "critical",
+  });
+  const criticalError = mustThrow(() => appendCandidateClaim(exploitedClaim(criticalDomain, {
+    severity: "critical",
+    evidence_refs: [exploitRef(criticalDomain, { tool_id: "bob_http_idor_confirm" })],
+  })));
+  assertInvalidArgumentsCode(criticalError, "exploit_proof_tool_demonstrated_ceiling_exceeded");
+  assert.equal(criticalError.details.tool_ceiling, "medium");
+
+  const mediumDomain = "offensive-tool-ceiling-medium.example";
+  appendOffensiveRunRow(mediumDomain, {
+    tool_id: "bob_http_idor_confirm",
+    demonstrated_severity: "medium",
+  });
+  const ok = appendCandidateClaim(exploitedClaim(mediumDomain, {
+    severity: "medium",
+    evidence_refs: [exploitRef(mediumDomain, { tool_id: "bob_http_idor_confirm" })],
+  }));
+  assert.equal(ok.severity, "medium");
+}));
+
+test("unknown offensive tool ids fail closed to the info demonstrated-severity ceiling", () => withTempHome(() => {
+  const toolId = "totally_unknown_tool";
+
+  const criticalDomain = "offensive-tool-ceiling-unknown-critical.example";
+  appendOffensiveRunRow(criticalDomain, {
+    tool_id: toolId,
+    demonstrated_severity: "critical",
+  });
+  const criticalError = mustThrow(() => appendCandidateClaim(exploitedClaim(criticalDomain, {
+    severity: "critical",
+    evidence_refs: [exploitRef(criticalDomain, { tool_id: toolId })],
+  })));
+  assertInvalidArgumentsCode(criticalError, "exploit_proof_tool_demonstrated_ceiling_exceeded");
+  assert.equal(criticalError.details.tool_ceiling, "info");
+
+  const lowDomain = "offensive-tool-ceiling-unknown-low.example";
+  appendOffensiveRunRow(lowDomain, {
+    tool_id: toolId,
+    demonstrated_severity: "low",
+  });
+  const lowError = mustThrow(() => appendCandidateClaim(exploitedClaim(lowDomain, {
+    severity: "low",
+    evidence_refs: [exploitRef(lowDomain, { tool_id: toolId })],
+  })));
+  assertInvalidArgumentsCode(lowError, "exploit_proof_tool_demonstrated_ceiling_exceeded");
+  assert.equal(lowError.details.tool_ceiling, "info");
+
+  const infoDomain = "offensive-tool-ceiling-unknown-info.example";
+  appendOffensiveRunRow(infoDomain, {
+    tool_id: toolId,
+    demonstrated_severity: "info",
+  });
+  const ok = appendCandidateClaim(exploitedClaim(infoDomain, {
+    severity: "informational",
+    evidence_refs: [exploitRef(infoDomain, { tool_id: toolId })],
+  }));
+  assert.equal(ok.severity, "informational");
 }));
 
 test("exploit_run canonicalizes targets to origin+path (strips secrets value-blind)", () => {

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -18,12 +18,23 @@ const {
   assertCompletenessAgainstFreeze,
 } = require("../mcp/lib/claim-freeze.js");
 const {
+  handoffSigningKeyPath,
   isAuditGradedPath,
   offensiveRunsDir,
   offensiveRunsJsonlPath,
   sessionDir,
   sessionsRoot,
 } = require("../mcp/lib/paths.js");
+const {
+  evaluateLifecycleTransition,
+} = require("../mcp/lib/lifecycle-gates.js");
+const {
+  advanceSession,
+  initSession,
+} = require("../mcp/lib/session-state.js");
+const {
+  readSessionNucleus,
+} = require("../mcp/lib/governance-store.js");
 const {
   ensureHandoffSigningKey,
 } = require("../mcp/lib/handoff-signing-key.js");
@@ -58,7 +69,7 @@ function exploitRef(domain = "example.com", overrides = {}) {
   return {
     kind: "exploit_run",
     run_id: "run-exploit-1",
-    tool_id: "bob_http_confirm_reflected_canary",
+    tool_id: "bob_http_idor_confirm",
     target: `https://${domain}/search?q=BOB_CANARY_1`,
     offensive_outcome: "exploited_safely",
     command_hash: hex("a"),
@@ -128,6 +139,91 @@ function appendOffensiveRunRow(domain, overrides = {}) {
   signOffensiveRunRow(row, ensureHandoffSigningKey(domain));
   return writeOffensiveRunRow(domain, row);
 }
+
+function advance(domain, toState) {
+  return JSON.parse(advanceSession({ target_domain: domain, to_state: toState }));
+}
+
+function evaluateFreezeToVerify(domain) {
+  return evaluateLifecycleTransition({
+    target_domain: domain,
+    from_state: "CLAIM_FREEZE",
+    to_state: "VERIFY",
+    nucleus: readSessionNucleus(domain),
+  });
+}
+
+function captureThrow(fn) {
+  let captured = null;
+  try {
+    fn();
+  } catch (error) {
+    captured = error;
+  }
+  assert.ok(captured, "expected function to throw");
+  return captured;
+}
+
+test("#freeze-verify-gate: non-exploit frozen claims do not require a signing key", () => withTempHome(() => {
+  const domain = "freeze-verify-no-brick.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  appendCandidateClaim({
+    target_domain: domain,
+    title: "Plain reflected behavior",
+    summary: "A non-offensive finding fixture.",
+    severity: "low",
+    evidence_refs: [{
+      kind: "finding",
+      finding_id: "F-plain",
+      content_hash: hex("0"),
+    }],
+  });
+  advance(domain, "CLAIM_FREEZE");
+  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  assert.equal(fs.existsSync(handoffSigningKeyPath(domain)), false);
+  assert.deepEqual(evaluateFreezeToVerify(domain).blockers, []);
+
+  const envelope = advance(domain, "VERIFY");
+  assert.equal(envelope.to_state, "VERIFY");
+  assert.equal(envelope.advanced, true);
+}));
+
+test("#freeze-verify-gate: vanished offensive row blocks CLAIM_FREEZE -> VERIFY", () => withTempHome(() => {
+  const domain = "freeze-verify-missing-row.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  appendOffensiveRunRow(domain);
+  appendCandidateClaim(exploitedClaim(domain));
+  advance(domain, "CLAIM_FREEZE");
+  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  fs.rmSync(offensiveRunsJsonlPath(domain), { force: true });
+  const blockers = evaluateFreezeToVerify(domain).blockers;
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].code, "exploited_claim_proof_unbacked_at_freeze");
+  assert.equal(blockers[0].underlying_code, "exploit_proof_unbacked_exploit_run_evidence");
+
+  const error = captureThrow(() => advanceSession({ target_domain: domain, to_state: "VERIFY" }));
+  assert.equal(error.code, "STATE_CONFLICT");
+  assert.equal(error.details && error.details.code, "exploited_claim_proof_unbacked_at_freeze");
+}));
+
+test("#freeze-verify-gate: backed exploited claim advances without single-use false positive", () => withTempHome(() => {
+  const domain = "freeze-verify-backed.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  appendOffensiveRunRow(domain);
+  appendCandidateClaim(exploitedClaim(domain));
+  advance(domain, "CLAIM_FREEZE");
+  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  assert.deepEqual(evaluateFreezeToVerify(domain).blockers, []);
+  const envelope = advance(domain, "VERIFY");
+  assert.equal(envelope.to_state, "VERIFY");
+  assert.equal(envelope.advanced, true);
+}));
 
 test("#freeze-completeness: projectExploitRunObservedRef re-hashes the on-disk capture file", () => withTempHome(() => {
   const domain = "exploit-proj-match.example";

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -16,8 +16,10 @@ const {
   projectCodeBoundObservedRefs,
   projectExploitRunObservedRef,
   assertCompletenessAgainstFreeze,
+  readCurrentClaimFreeze,
 } = require("../mcp/lib/claim-freeze.js");
 const {
+  claimFreezePath,
   handoffSigningKeyPath,
   isAuditGradedPath,
   offensiveRunsDir,
@@ -223,6 +225,56 @@ test("#freeze-verify-gate: backed exploited claim advances without single-use fa
   const envelope = advance(domain, "VERIFY");
   assert.equal(envelope.to_state, "VERIFY");
   assert.equal(envelope.advanced, true);
+}));
+
+test("#freeze-verify-gate: a tampered freeze with a ref-less exploited_safely claim is blocked (fail-closed)", () => withTempHome(() => {
+  const domain = "freeze-verify-tampered-refless.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  appendCandidateClaim({
+    target_domain: domain,
+    title: "Plain reflected behavior",
+    summary: "A non-offensive finding fixture.",
+    severity: "low",
+    evidence_refs: [{ kind: "finding", finding_id: "F-plain", content_hash: hex("0") }],
+  });
+  advance(domain, "CLAIM_FREEZE");
+  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  // Simulate claim-freeze.json tampering: inject an exploited_safely claim that carries NO
+  // exploit_run ref. The record gate would have rejected it, so only direct tampering produces it;
+  // the gate must NOT silently skip it (fail-closed), it must block.
+  const freeze = readCurrentClaimFreeze(domain);
+  freeze.claims.push({
+    claim_id: "C-tampered",
+    target_domain: domain,
+    severity: "critical",
+    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "differential_response" } },
+    evidence_refs: [{ kind: "finding", finding_id: "F-x", content_hash: hex("1") }],
+  });
+  fs.writeFileSync(claimFreezePath(domain), JSON.stringify(freeze));
+
+  const blockers = evaluateFreezeToVerify(domain).blockers;
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].code, "exploited_claim_proof_unbacked_at_freeze");
+  assert.equal(blockers[0].underlying_code, "exploit_proof_missing_exploit_run_evidence");
+  assert.equal(blockers[0].claim_id, "C-tampered");
+}));
+
+test("#freeze-verify-gate: a freeze whose claims[] is not an array is blocked (fail-closed)", () => withTempHome(() => {
+  const domain = "freeze-verify-malformed-shape.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  advance(domain, "CLAIM_FREEZE");
+  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
+
+  const freeze = readCurrentClaimFreeze(domain);
+  freeze.claims = "not-an-array";
+  fs.writeFileSync(claimFreezePath(domain), JSON.stringify(freeze));
+
+  const blockers = evaluateFreezeToVerify(domain).blockers;
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].code, "claim_freeze_invalid_shape");
 }));
 
 test("#freeze-completeness: projectExploitRunObservedRef re-hashes the on-disk capture file", () => withTempHome(() => {

--- a/test/offensive-run-freeze-completeness.test.js
+++ b/test/offensive-run-freeze-completeness.test.js
@@ -10,16 +10,16 @@ const path = require("node:path");
 const {
   appendCandidateClaim,
   canonicalizeExploitTarget,
+  normalizeCandidateClaim,
 } = require("../mcp/lib/claims.js");
 const {
   buildClaimFreeze,
   projectCodeBoundObservedRefs,
   projectExploitRunObservedRef,
   assertCompletenessAgainstFreeze,
-  readCurrentClaimFreeze,
 } = require("../mcp/lib/claim-freeze.js");
 const {
-  claimFreezePath,
+  claimsJsonlPath,
   handoffSigningKeyPath,
   isAuditGradedPath,
   offensiveRunsDir,
@@ -166,6 +166,21 @@ function captureThrow(fn) {
   return captured;
 }
 
+// Append a normalized claim straight to claims.jsonl, bypassing the record-time proof gate
+// (appendCandidateClaim). Models a tampered claims.jsonl that the CLAIM_FREEZE->VERIFY gate must
+// catch, since the record gate would reject every shape these tests construct.
+function appendRawClaim(domain, claimInput) {
+  const claim = normalizeCandidateClaim({ target_domain: domain, ...claimInput });
+  const filePath = claimsJsonlPath(domain);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, `${JSON.stringify(claim)}\n`, "utf8");
+  return claim;
+}
+
+function findingRef(findingId, char = "0") {
+  return { kind: "finding", finding_id: findingId, content_hash: hex(char) };
+}
+
 test("#freeze-verify-gate: non-exploit frozen claims do not require a signing key", () => withTempHome(() => {
   const domain = "freeze-verify-no-brick.example";
   JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
@@ -182,8 +197,10 @@ test("#freeze-verify-gate: non-exploit frozen claims do not require a signing ke
     }],
   });
   advance(domain, "CLAIM_FREEZE");
-  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
 
+  // No buildClaimFreeze here: the gate reads the CANDIDATE claims (claims.jsonl), which exist now —
+  // NOT the freeze snapshot, which the VERIFY bootstrap builds only after this gate passes. This
+  // mirrors production: at CLAIM_FREEZE->VERIFY there is no freeze doc yet and no signing key.
   assert.equal(fs.existsSync(handoffSigningKeyPath(domain)), false);
   assert.deepEqual(evaluateFreezeToVerify(domain).blockers, []);
 
@@ -199,8 +216,9 @@ test("#freeze-verify-gate: vanished offensive row blocks CLAIM_FREEZE -> VERIFY"
   appendOffensiveRunRow(domain);
   appendCandidateClaim(exploitedClaim(domain));
   advance(domain, "CLAIM_FREEZE");
-  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
 
+  // No buildClaimFreeze: the gate reads candidate claims. Remove the backing row AFTER record to
+  // model post-record tampering the gate must catch before VERIFY snapshots the now-unbacked claim.
   fs.rmSync(offensiveRunsJsonlPath(domain), { force: true });
   const blockers = evaluateFreezeToVerify(domain).blockers;
   assert.equal(blockers.length, 1);
@@ -219,7 +237,6 @@ test("#freeze-verify-gate: backed exploited claim advances without single-use fa
   appendOffensiveRunRow(domain);
   appendCandidateClaim(exploitedClaim(domain));
   advance(domain, "CLAIM_FREEZE");
-  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
 
   assert.deepEqual(evaluateFreezeToVerify(domain).blockers, []);
   const envelope = advance(domain, "VERIFY");
@@ -227,54 +244,91 @@ test("#freeze-verify-gate: backed exploited claim advances without single-use fa
   assert.equal(envelope.advanced, true);
 }));
 
-test("#freeze-verify-gate: a tampered freeze with a ref-less exploited_safely claim is blocked (fail-closed)", () => withTempHome(() => {
+test("#freeze-verify-gate: a tampered claims.jsonl exploited_safely claim with no exploit_run ref is blocked (fail-closed)", () => withTempHome(() => {
   const domain = "freeze-verify-tampered-refless.example";
   JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
   advance(domain, "OPEN_FRONTIER");
-  appendCandidateClaim({
-    target_domain: domain,
-    title: "Plain reflected behavior",
-    summary: "A non-offensive finding fixture.",
-    severity: "low",
-    evidence_refs: [{ kind: "finding", finding_id: "F-plain", content_hash: hex("0") }],
+  // Tamper: an exploited_safely claim carrying NO exploit_run ref (only a finding ref). The record
+  // gate would reject it, so only a direct claims.jsonl write produces it. The gate must not
+  // silently skip it (CodeRabbit/brutalist) — it flows into the proof assert and blocks.
+  appendRawClaim(domain, {
+    title: "Ref-less exploited fixture",
+    summary: "exploited_safely asserted with no exploit_run ref.",
+    severity: "critical",
+    status: "candidate",
+    surface_ids: [DEFAULT_SURFACE_ID],
+    evidence_refs: [findingRef("F-refless")],
+    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "differential_response" } },
+    impact: "Bounded fixture impact.",
   });
   advance(domain, "CLAIM_FREEZE");
-  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
-
-  // Simulate claim-freeze.json tampering: inject an exploited_safely claim that carries NO
-  // exploit_run ref. The record gate would have rejected it, so only direct tampering produces it;
-  // the gate must NOT silently skip it (fail-closed), it must block.
-  const freeze = readCurrentClaimFreeze(domain);
-  freeze.claims.push({
-    claim_id: "C-tampered",
-    target_domain: domain,
-    severity: "critical",
-    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "differential_response" } },
-    evidence_refs: [{ kind: "finding", finding_id: "F-x", content_hash: hex("1") }],
-  });
-  fs.writeFileSync(claimFreezePath(domain), JSON.stringify(freeze));
 
   const blockers = evaluateFreezeToVerify(domain).blockers;
   assert.equal(blockers.length, 1);
   assert.equal(blockers[0].code, "exploited_claim_proof_unbacked_at_freeze");
   assert.equal(blockers[0].underlying_code, "exploit_proof_missing_exploit_run_evidence");
-  assert.equal(blockers[0].claim_id, "C-tampered");
 }));
 
-test("#freeze-verify-gate: a freeze whose claims[] is not an array is blocked (fail-closed)", () => withTempHome(() => {
-  const domain = "freeze-verify-malformed-shape.example";
+test("#freeze-verify-gate: a tampered claim carrying an exploit_run ref with a non-exploited outcome is blocked (Codex P2)", () => withTempHome(() => {
+  const domain = "freeze-verify-tampered-outcome.example";
   JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
   advance(domain, "OPEN_FRONTIER");
+  // Tamper: the outcome was changed away from exploited_safely, but the exploit_run ref remains. The
+  // VERIFY severity-rise guard consumes exploit_run refs regardless of outcome, so the gate must
+  // catch this too — the union filter routes it into the assert, which rejects the outcome/ref mix.
+  appendRawClaim(domain, {
+    title: "Changed-outcome exploit-ref fixture",
+    summary: "exploit_run ref retained after the outcome was flipped to blocked_by_defense.",
+    severity: "low",
+    status: "candidate",
+    evidence_refs: [findingRef("F-out"), exploitRef(domain)],
+    exploit_outcome: { outcome: "blocked_by_defense" },
+    impact: "Bounded fixture impact.",
+  });
   advance(domain, "CLAIM_FREEZE");
-  buildClaimFreeze(domain, { write: true, now: new Date("2026-06-16T00:00:00.000Z") });
-
-  const freeze = readCurrentClaimFreeze(domain);
-  freeze.claims = "not-an-array";
-  fs.writeFileSync(claimFreezePath(domain), JSON.stringify(freeze));
 
   const blockers = evaluateFreezeToVerify(domain).blockers;
   assert.equal(blockers.length, 1);
-  assert.equal(blockers[0].code, "claim_freeze_invalid_shape");
+  assert.equal(blockers[0].code, "exploited_claim_proof_unbacked_at_freeze");
+  assert.equal(blockers[0].underlying_code, "exploit_run_ref_without_exploited_outcome");
+}));
+
+test("#freeze-verify-gate: a tampered claims.jsonl that reuses one run_id across two findings is blocked (Codex P2)", () => withTempHome(() => {
+  const domain = "freeze-verify-dup-runid.example";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  advance(domain, "OPEN_FRONTIER");
+  appendOffensiveRunRow(domain); // one signed row for run-exploit-1
+  // Two distinct frozen findings both cite the SAME run_id. The record gate enforces run_id
+  // single-use, so only a tampered claims.jsonl produces this; the gate re-checks single-use across
+  // the full candidate set (existingClaims) and blocks the duplication.
+  appendRawClaim(domain, {
+    title: "First finding citing run-exploit-1",
+    summary: "Frozen exploited claim A.",
+    severity: "low",
+    status: "candidate",
+    surface_ids: [DEFAULT_SURFACE_ID],
+    evidence_refs: [findingRef("F-A"), exploitRef(domain)],
+    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
+    impact: "Bounded fixture impact.",
+  });
+  appendRawClaim(domain, {
+    title: "Second finding reusing run-exploit-1",
+    summary: "Frozen exploited claim B (duplicate run_id).",
+    severity: "low",
+    status: "candidate",
+    surface_ids: [DEFAULT_SURFACE_ID],
+    evidence_refs: [findingRef("F-B"), exploitRef(domain)],
+    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
+    impact: "Bounded fixture impact.",
+  });
+  advance(domain, "CLAIM_FREEZE");
+
+  const blockers = evaluateFreezeToVerify(domain).blockers;
+  assert.ok(blockers.length >= 1);
+  assert.ok(
+    blockers.some((b) => b.underlying_code === "exploit_run_run_id_already_consumed"),
+    "duplicate run_id across frozen findings must be caught",
+  );
 }));
 
 test("#freeze-completeness: projectExploitRunObservedRef re-hashes the on-disk capture file", () => withTempHome(() => {

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -983,7 +983,10 @@ test("#111 verify mirror: a same-surface row still unlocks a legitimate rise", (
   const domain = "surface-bind-verify-same.example";
   initWebSession(domain);
   const ref = exploitRef(domain);
-  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "critical", surface_id: "surface-A" });
+  // Re-expressed at medium: the row's tool (bob_http_idor_confirm) caps at medium, and the PR-A
+  // verify-mirror cap now bounds the demonstrated rank by that ceiling, so the legitimate rise this
+  // test exercises lands at the tool's true ceiling (medium), not critical.
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "medium", surface_id: "surface-A" });
   appendRawClaim(domain, {
     title: "Same-surface verify fixture",
     summary: "Frozen exploited claim on surface-A citing a surface-A row.",
@@ -997,9 +1000,36 @@ test("#111 verify mirror: a same-surface row still unlocks a legitimate rise", (
   freezeClaims(domain);
   const context = enterVerifyV2(domain);
   writeV2Round(domain, context, "brutalist", [
+    v2VerificationResult("F-1", { severity: "medium", confidence_reasons: ["exploit_replay_confirmed"] }),
+  ]);
+  assert.equal(persistedSeverity(domain, "brutalist"), "medium", "matching surface -> proof-backed rise allowed");
+}));
+
+test("#PR-A verify mirror: a row demonstrating above its tool ceiling cannot unlock a rise past the ceiling", () => withTempHome(() => {
+  const domain = "verify-mirror-tool-ceiling.example";
+  initWebSession(domain);
+  const ref = exploitRef(domain); // tool_id bob_http_idor_confirm, ceiling = medium
+  // Over-ceiling row: demonstrates critical though the tool caps at medium. appendRawClaim bypasses
+  // the record gate (which would reject this), modelling a tampered ledger or a session advanced
+  // past the CLAIM_FREEZE->VERIFY gate with operator_force. The verify-mirror cap must still bound
+  // the row's contribution to the tool ceiling, so a critical rise cannot be proven.
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "critical", surface_id: "surface-A" });
+  appendRawClaim(domain, {
+    title: "Over-ceiling verify fixture",
+    summary: "Frozen exploited claim citing a critical-demonstrated row from a medium-ceiling tool.",
+    severity: "low",
+    status: "candidate",
+    surface_ids: ["surface-A"],
+    evidence_refs: [findingRef("F-1"), ref],
+    exploit_outcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
+    impact: "Bounded fixture impact.",
+  });
+  freezeClaims(domain);
+  const context = enterVerifyV2(domain);
+  writeV2Round(domain, context, "brutalist", [
     v2VerificationResult("F-1", { severity: "critical", confidence_reasons: ["exploit_replay_confirmed"] }),
   ]);
-  assert.equal(persistedSeverity(domain, "brutalist"), "critical", "matching surface -> proof-backed rise allowed");
+  assert.equal(persistedSeverity(domain, "brutalist"), "low", "over-ceiling row cannot unlock a critical rise -> clamped to baseline");
 }));
 
 test("#111 verify mirror: a forged freeze with an empty claim surface fails closed (brutalist r1)", () => withTempHome(() => {

--- a/test/severity-rise-guard.test.js
+++ b/test/severity-rise-guard.test.js
@@ -107,7 +107,7 @@ function exploitRef(domain, overrides = {}) {
   return {
     kind: "exploit_run",
     run_id: "run-exploit-1",
-    tool_id: "bob_http_confirm_reflected_canary",
+    tool_id: "bob_http_idor_confirm",
     target: canonicalizeExploitTarget(`https://${domain}/proof`),
     offensive_outcome: "exploited_safely",
     command_hash: hex("a"),
@@ -304,7 +304,7 @@ test("web v2 exploit proof plus exploit_replay_confirmed allows a severity rise"
   const domain = "severity-rise-proof.example";
   initWebSession(domain);
   const ref = exploitRef(domain);
-  seedSignedOffensiveRow(domain, ref);
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "medium" });
   appendFrozenFindingClaim(domain, {
     severity: "low",
     evidenceRefs: [findingRef("F-1"), ref],
@@ -318,12 +318,12 @@ test("web v2 exploit proof plus exploit_replay_confirmed allows a severity rise"
 
   writeV2Round(domain, context, "brutalist", [
     v2VerificationResult("F-1", {
-      severity: "critical",
+      severity: "medium",
       confidence_reasons: ["exploit_replay_confirmed"],
     }),
   ]);
 
-  assert.equal(persistedSeverity(domain), "critical");
+  assert.equal(persistedSeverity(domain), "medium");
 }));
 
 test("web v2 low demonstrated row without finding_id unlocks only an info to low rise", () => withTempHome(() => {
@@ -432,7 +432,7 @@ test("web v2 severity rises require both the confidence reason and a satisfying 
   const domainWithRow = "severity-rise-row-no-reason.example";
   initWebSession(domainWithRow);
   const refWithRow = exploitRef(domainWithRow);
-  seedSignedOffensiveRow(domainWithRow, refWithRow);
+  seedSignedOffensiveRow(domainWithRow, refWithRow, { demonstrated_severity: "medium" });
   appendFrozenFindingClaim(domainWithRow, {
     severity: "low",
     evidenceRefs: [findingRef("F-1"), refWithRow],
@@ -454,7 +454,7 @@ test("web v2 severity rises require both the confidence reason and a satisfying 
   const domainWithReason = "severity-rise-reason-no-row.example";
   initWebSession(domainWithReason);
   const refWithReason = exploitRef(domainWithReason);
-  seedSignedOffensiveRow(domainWithReason, refWithReason);
+  seedSignedOffensiveRow(domainWithReason, refWithReason, { demonstrated_severity: "medium" });
   appendFrozenFindingClaim(domainWithReason, {
     severity: "low",
     evidenceRefs: [findingRef("F-1"), refWithReason],
@@ -498,7 +498,7 @@ test("a multi-finding claim's exploit row cannot prove a sibling finding's rise"
   const domain = "severity-rise-multi-finding.example";
   initWebSession(domain);
   const ref = exploitRef(domain);
-  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "critical" });
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "medium" });
   // One claim references BOTH F-1 and F-2 plus a single exploit_run ref. The
   // guard refuses to propagate that row to either finding (cross-finding
   // spillover guard), so an exploit_replay_confirmed rise on F-2 is clamped.
@@ -736,7 +736,7 @@ test("corrupt offensive ledger fails closed for exploit-backed ceiling checks", 
   const domain = "severity-rise-corrupt-ledger.example";
   initWebSession(domain);
   const ref = exploitRef(domain);
-  seedSignedOffensiveRow(domain, ref);
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "medium" });
   appendFrozenFindingClaim(domain, {
     severity: "low",
     evidenceRefs: [findingRef("F-1"), ref],
@@ -837,9 +837,9 @@ test("#111: a claim whose single surface matches its row records (positive contr
   const domain = "surface-bind-match.example";
   initWebSession(domain);
   const ref = exploitRef(domain);
-  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "critical", surface_id: "surface-B" });
+  seedSignedOffensiveRow(domain, ref, { demonstrated_severity: "medium", surface_id: "surface-B" });
   const claim = appendFrozenFindingClaim(domain, {
-    severity: "critical",
+    severity: "medium",
     surfaceIds: ["surface-B"],
     evidenceRefs: [findingRef("F-1"), ref],
     exploitOutcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },
@@ -924,10 +924,10 @@ test("#111: multi-row claim rejects when any cited row is out-of-surface, accept
   const refB2 = exploitRef(posDomain, { run_id: "run-B", target: canonicalizeExploitTarget(`https://${posDomain}/b`) });
   writeOffensiveRunRows(posDomain, [
     signedOffensiveRow(posDomain, refA2, { demonstrated_severity: "low", surface_id: "surface-A" }),
-    signedOffensiveRow(posDomain, refB2, { demonstrated_severity: "critical", surface_id: "surface-A" }),
+    signedOffensiveRow(posDomain, refB2, { demonstrated_severity: "medium", surface_id: "surface-A" }),
   ]);
   const claim = appendFrozenFindingClaim(posDomain, {
-    severity: "critical",
+    severity: "medium",
     surfaceIds: ["surface-A"],
     evidenceRefs: [findingRef("F-1"), refA2, refB2],
     exploitOutcome: { outcome: "exploited_safely", safe_oracle: { kind: "reflected_canary" } },


### PR DESCRIPTION
## Summary

Closes two standing gaps in the merged exploit-proof contract (#108/#110/#111), both **pure server-side** (no hooks, no new tool, no generated artifacts). The offensive allow-path is **dormant in production** (no tool writes `exploited_safely` rows today; `bob_http_confirm` is negative-only), so these gates are inert against real traffic — they lock the contract before the producer (PR-C) lands.

### ITEM 1 — gate the `CLAIM_FREEZE → VERIFY` transition
The transition was **ungated**: a frozen `exploited_safely` claim whose backing `offensive-runs.jsonl` row was deleted/tampered *after* the freeze would advance to VERIFY with no re-check. `gateClaimFreezeToVerify` (in `lifecycle-gates.js`) re-confirms, at the transition, that every frozen `exploited_safely` claim is still backed — by **reusing the record-time gate** `assertExploitedClaimHasProof` (so it cannot drift from the contract), wrapped in try/catch to convert throws into structured blockers.

**The single most important property — no-brick:** a normal web/OSS session (no offensive rows, hence no `exploited_safely` exploit_run claims, and no signing key on disk) returns zero blockers *without* reading the offensive ledger or the signing key. The gate filters to exploited claims first, and the reused assert reads the signing key only when `runRows.length > 0`. Test #1 asserts this end-to-end (`handoffSigningKeyPath` does not exist → `blockers === []` → advance succeeds).

### ITEM 2 — per-tool `demonstrated_severity` ceiling
`OFFENSIVE_TOOL_DEMONSTRATED_CEILING` (in `claims.js`) caps what each offensive tool's signed row may demonstrate. Fail-closed: any `tool_id` that is not an own-key resolves to `"info"` (the lowest tier) — `?? "critical"` would be fail-open and is forbidden. Built with `Object.create(null)` so a prototype-key `tool_id` (`__proto__`/`toString`) can't return an inherited value; `Object.freeze` + strict mode means it can't be widened at runtime. Map = `{ bob_http_idor_confirm: "medium" }` (the future PR-C IDOR producer, pre-seeded per design D5; a safe cross-tenant READ of attacker-owned synthetic objects caps at MEDIUM by construction). `bob_http_confirm` is deliberately **absent** (negative-only — must never sign).

## Notable design points

- **Gate-ceiling coupling (intended):** because the gate reuses `assertExploitedClaimHasProof`, the ITEM-2 ceiling also fires at `CLAIM_FREEZE→VERIFY`. A frozen claim whose backing row demonstrates above its tool ceiling blocks the advance with `underlying_code: exploit_proof_tool_demonstrated_ceiling_exceeded`. Correct — a record-valid claim can't become over-ceiling without ledger tampering, which *should* block.
- **Strictly tightens, never loosens.** The merged contract (MAC-signed backing, run_id single-use, #111 strict single-surface, the existing `claim.severity <= max(row.demonstrated_severity)` ceiling with rank-0 fail-close) is preserved and extended with the per-tool ceiling.
- **Test-corpus migration:** the fail-closed ceiling required renaming the test-only fixture `tool_id "bob_http_confirm_reflected_canary"` (and `bob_http_confirm`) to the real mapped producer `bob_http_idor_confirm`, and re-capping the few `critical`-tier seed rows to `medium` (no real tool demonstrates critical now). Every demotion preserves the test's actual assertion target (the rise mechanism, the spillover guard, the corrupt-ledger fail-close, the #111 surface binding) — only the severity tier drops. The claim-vs-row ceiling mechanism is still tested at the boundary (`offensive-proof-contract.test.js` low-row + critical-claim → `exploit_proof_severity_exceeds_demonstrated`).

## Scope (deliberately excluded)

The node-`fs` write-guard / signing-key read-guard hook hardening + kimi mirrors (design item 3) is **deferred to #113**, per the #112 lesson against bundling defense-in-depth hook hardening with a server-side-gate PR. It touches no `.claude/hooks/` file, adds no tool, runs no generator. It remains a hard gate before the live producer arm — just not in this PR. The verify-time severity-rise mirror is intentionally untouched (the per-tool ceiling lives at the record gate and is transitively enforced at freeze→verify via the gate's reuse).

## Verification
```
check:syntax                pass
4 offensive suites          89 pass / 0 fail
lifecycle + server          473 pass / 0 fail
test:mcp                    2482 pass / 0 fail / 2 skipped
check:authority-inventory   pass
```

## Residual (honest boundary)

Like the merged #108 MAC, the per-tool ceiling raises forgery cost but does not make the contract un-fakeable against a same-UID in-process actor (`node -e` can read the 0600 signing key and hand-MAC a row). That class is only closed by the deferred offensive-sandbox PR. No PII-safety is claimed here (that's PR-PII/#116 + the future PR-PROV).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-offensive-evidence tool severity ceilings for backed claims, preventing claim severity from exceeding the maximum demonstrated severity allowed for that tool.
  * Strengthened the freeze → verify lifecycle gate to revalidate backed exploited claims with newly read signed proof evidence, blocking advancement when backing evidence is missing or inconsistent.

* **Tests**
  * Updated offensive proof and lifecycle gate tests to use the new default evidence tool identity.
  * Added coverage for severity-ceiling enforcement (including unknown tool behavior) and additional freeze → verify fail-closed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->