### PR TITLE
refactor(offense): extract shared confirmer helpers into offensive-http-common (PR-B)

### DIFF
--- a/mcp/lib/offensive-confirmer.js
+++ b/mcp/lib/offensive-confirmer.js
@@ -12,12 +12,6 @@ const {
   readSessionStateStrict,
 } = require("./session-state-store.js");
 const {
-  readSurfaceRoutesStrict,
-} = require("./surface-router.js");
-const {
-  currentSurfaces,
-} = require("./frontier-projections.js");
-const {
   createProxyAgent,
 } = require("./egress-profiles.js");
 const {
@@ -27,15 +21,29 @@ const {
   assertSafeRequestUrl,
   safeFetch,
 } = require("./safe-fetch.js");
-const { redactUrlSensitiveValues } = require("../redaction.js");
-const {
-  appendHttpAuditRecord,
-} = require("./http-records.js");
 const {
   assertEnumValue,
   assertNonEmptyString,
   assertRequiredText,
 } = require("./validation.js");
+// Shared HTTP/surface primitives (extracted in PR-B so the forthcoming
+// bob_http_idor_confirm producer reuses the same security-reviewed logic). The
+// confirmer passes its own TOOL_ID to the parameterized assertNoForbiddenInputs
+// + auditConfirmRequest so its behavior is byte-identical to before the move.
+const {
+  rejectInvalidArguments,
+  assertReadOnlyPath,
+  normalizePathTemplate,
+  pathTemplateMatchesEndpoint,
+  findRoutedSurface,
+  resolveBaselineFromSurface,
+  isAuthChallenge,
+  isLoginRedirect,
+  isResourceShapedResponse,
+  auditConfirmRequest,
+  assertNoForbiddenInputs,
+  SCOPE_VALIDATION_OPTS,
+} = require("./offensive-http-common.js");
 
 const TOOL_ID = "bob_http_confirm";
 const READ_ONLY_METHODS = Object.freeze(["GET", "HEAD", "OPTIONS"]);
@@ -45,66 +53,9 @@ const HEADER_SUBSET = Object.freeze({
   accept: "application/json, text/plain;q=0.9, */*;q=0.1",
   "user-agent": "HackerBob-readonly-confirmer/1",
 });
-// The REAL safety boundary against "confirm emits a state-changing GET against
-// the real recorded id" is STRUCTURAL: {id} must be the final path segment
-// (normalizePathTemplate), so no action segment (`/{id}/capture`, `/{id}/transfer`)
-// can follow it. A verb denylist can NEVER enumerate the open-ended mutation
-// surface (capture/settle/promote/enable/...), so this list is kept deliberately
-// NARROW — only unambiguous destructive verbs that are almost never legitimate
-// resource-collection nouns — and is best-effort defense-in-depth ONLY, to catch
-// a verb-named collection BEFORE the id (`/delete/{id}`). It must NOT include
-// ambiguous nouns (order/charge/transfer/block/run) or it would wrongly reject
-// legitimate single-resource reads like /api/order/{id}.
-// The verb may be followed by `/`, end-of-path, OR a format/matrix suffix
-// (`.json`, `;v=1`) that many routers strip before dispatch — so /api/delete.json/{id}
-// and /api/reset;v=1/{id} are caught too.
-const STATE_CHANGE_PATH_SEGMENT_RE = /(?:^|\/)(?:delete|logout|remove|destroy|deactivate|disable|revoke|reset|unsubscribe|terminate|purge|wipe)(?:[./;,]|\/|$)/i;
-const VERB_LIKE_TOKEN_RE = /^(?:delete|remove|destroy|logout|create|update|patch|put|post|submit|send|transfer|refund|reset|revoke|disable|enable|drop|truncate|mutation)$/i;
-
-// An encoded path separator at ANY encoding depth: %2F / %5C, %252F, %2525252F,
-// etc. (`(25)*` absorbs each extra `%25` layer). Layer-count-independent, so it
-// does not depend on how many times decodePathSegments iterates.
-const ENCODED_SEPARATOR_RE = /%(?:25)*(?:2f|5c)/i;
-// The ONLY suffix allowed after {id}: an inert data/serialization file extension.
-// Deliberately a closed allowlist (NOT `\.\w+`) so a verb-shaped dot suffix like
-// `{id}.capture` / `{id}.delete` — which routes to an action on the real id — is
-// rejected, while `{id}.json` / `{id}.xml` direct reads pass.
-const INERT_EXTENSION_RE = /^\.(?:json|xml|csv|tsv|txt|yaml|yml|html?|pdf|md|ndjson|geojson)$/i;
-// Pre-fetch URL validation hardcodes blockInternalHosts:false ON PURPOSE — these
-// are domain-scope/URL-shape range checks; the session's real SSRF policy
-// (block_internal_hosts) is enforced at FETCH time in safeFetch. The named
-// constant signals the `false` is intentional, not a dropped policy, so a future
-// refactor of the validation layer can't silently strip SSRF enforcement.
-const SCOPE_VALIDATION_OPTS = Object.freeze({ blockInternalHosts: false });
-
-// Recursively percent-decode each path segment until stable (defeats double /
-// multi encoding like %2564elete) so the deny-list sees the real verb.
-function decodePathSegments(pathname) {
-  return pathname
-    .split("/")
-    .map((seg) => {
-      let decoded = seg;
-      for (let i = 0; i < 8; i += 1) {
-        let next;
-        try {
-          next = decodeURIComponent(decoded);
-        } catch {
-          break;
-        }
-        if (next === decoded) break;
-        decoded = next;
-      }
-      return decoded;
-    })
-    .join("/");
-}
 
 function syntheticResourceId() {
   return `bob-synthetic-nonexistent-${crypto.randomUUID()}`;
-}
-
-function rejectInvalidArguments(message, details = null) {
-  throw new ToolError(ERROR_CODES.INVALID_ARGUMENTS, message, details);
 }
 
 function normalizeMethod(value) {
@@ -114,251 +65,6 @@ function normalizeMethod(value) {
 
 function normalizeOracleKind(value) {
   return assertEnumValue(assertRequiredText(value, "oracle_kind"), ORACLE_KIND_VALUES, "oracle_kind");
-}
-
-function assertNoForbiddenInputs(args) {
-  for (const field of ["url", "body", "headers", "severity", "demonstrated_severity", "finding_id", "resource_id", "id"]) {
-    if (Object.prototype.hasOwnProperty.call(args || {}, field)) {
-      rejectInvalidArguments(`bob_http_confirm does not accept ${field}; the request is derived server-side from surface_id and path_template`);
-    }
-  }
-}
-
-function assertReadOnlyPath(url) {
-  const parsed = new URL(url);
-  const pathAndQuery = `${parsed.pathname}${parsed.search}`;
-  const decodedPath = decodePathSegments(parsed.pathname);
-  if (STATE_CHANGE_PATH_SEGMENT_RE.test(parsed.pathname) || STATE_CHANGE_PATH_SEGMENT_RE.test(decodedPath)) {
-    rejectInvalidArguments(
-      "path_template resolves to a state-changing path segment; bob_http_confirm only shrinks, not eliminates, GET-side-effect risk and rejects mutation-shaped paths",
-      { path: parsed.pathname },
-    );
-  }
-  const params = new URLSearchParams(parsed.search);
-  for (const [rawKey, rawValue] of params.entries()) {
-    const key = String(rawKey || "").trim();
-    const value = String(rawValue || "").trim();
-    if (/^action$/i.test(key) || /^_method$/i.test(key)) {
-      rejectInvalidArguments(`query parameter ${key} is not allowed for bob_http_confirm`);
-    }
-    if (VERB_LIKE_TOKEN_RE.test(key) || VERB_LIKE_TOKEN_RE.test(value)) {
-      rejectInvalidArguments(`query parameter ${key} carries a mutation-shaped token`);
-    }
-    if (/graphql|query/i.test(key) && /\bmutation\b/i.test(value)) {
-      rejectInvalidArguments("GraphQL mutation-shaped query is not allowed for bob_http_confirm");
-    }
-  }
-  // Check the raw AND the recursively-decoded path so an encoded `mutation`
-  // segment (e.g. /api/%6Dutation/{id}) that routers decode before dispatch is
-  // also rejected, not just the literal form.
-  if (/\bmutation\b/i.test(pathAndQuery) || /\bmutation\b/i.test(decodedPath)) {
-    rejectInvalidArguments("mutation-shaped path or query is not allowed for bob_http_confirm");
-  }
-}
-
-function normalizePathTemplate(rawTemplate) {
-  const template = assertRequiredText(rawTemplate, "path_template");
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(template)) {
-    rejectInvalidArguments("path_template must be a path, not an absolute URL");
-  }
-  if (!template.startsWith("/")) {
-    rejectInvalidArguments("path_template must start with /");
-  }
-  if (template.includes("#")) {
-    rejectInvalidArguments("path_template must not include a fragment");
-  }
-  // No query string: the oracle reads a resource by id, and the baseline (real
-  // id) request is built from the recorded endpoint WITHOUT the template query,
-  // so a template-only query would make the differential turn on the query
-  // rather than on id/auth. Forbid it so baseline and target are symmetric.
-  if (template.includes("?")) {
-    rejectInvalidArguments("path_template must not include a query string");
-  }
-  const slotMatches = template.match(/\{id\}/g) || [];
-  if (slotMatches.length !== 1) {
-    rejectInvalidArguments("path_template must contain exactly one {id} slot");
-  }
-  const slotIndex = template.indexOf("{id}");
-  const queryIndex = template.indexOf("?");
-  if (queryIndex !== -1 && slotIndex > queryIndex) {
-    rejectInvalidArguments("path_template {id} slot must be in the path, not the query string");
-  }
-  // STRUCTURAL read-only boundary: {id} must be the FINAL path segment. The
-  // baseline request hits the REAL recorded id, so any segment after {id}
-  // (`/accounts/{id}/transfer`, `/payments/{id}/capture`) would emit an unauth
-  // state-changing GET against a real resource — the incident class this tool
-  // exists to prevent — and a verb denylist can never enumerate that surface.
-  // Forbidding a trailing segment closes it outright. (Consequence: PR3's oracle
-  // confirms only DIRECT resource reads, not sub-resource/action endpoints; a
-  // sub-resource read oracle that synthesizes its own baseline is deferred.)
-  const pathPart = queryIndex === -1 ? template : template.slice(0, queryIndex);
-  const afterSlot = pathPart.slice(pathPart.indexOf("{id}") + "{id}".length);
-  // {id} must TERMINATE the final path segment: nothing may follow it except an
-  // inert file extension (.json/.xml). This single allowlist rejects, in one rule,
-  //  - a following path segment (/accounts/{id}/transfer),
-  //  - an encoded separator at ANY depth (/payments/{id}%2Fcapture, %252F...),
-  //  - a same-segment action / matrix suffix (/payments/{id}:capture, {id};delete),
-  // each of which would make the unauth baseline GET (which hits the REAL recorded
-  // id) reach a sub-resource/action — the incident class this tool exists to
-  // prevent. A verb denylist can never enumerate that surface; an allowlist closes
-  // it structurally. (Consequence: PR3's oracle confirms only DIRECT resource
-  // reads; a sub-resource read oracle that synthesizes its own baseline is deferred.)
-  if (afterSlot !== "" && !INERT_EXTENSION_RE.test(afterSlot)) {
-    rejectInvalidArguments("path_template {id} must terminate the final path segment (optionally followed by an inert file extension like .json); bob_http_confirm confirms only direct resource reads, so nothing else may follow {id}");
-  }
-  return template;
-}
-
-function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-// The recorded baseline id segment must be a CLEAN single resource id. The unauth
-// baseline GET hits this REAL recorded id, so anything that can route to a
-// sub-resource/action must be rejected, whether it lives in the surface record
-// (which normalizePathTemplate never sees) or is supplied raw:
-//  - a path separator, literal OR encoded at any depth (%2F, %252F, %25%32%46),
-//  - action/matrix punctuation (: ; ,), literal OR percent-escaped (%3A…).
-// Decode each segment to a FIXED POINT so multi-layer / split-hex encodings are
-// seen, and fail closed on a remnant escape that 8 passes could not resolve.
-// KNOWN RESIDUAL: a dot-action suffix in a RECORDED id (e.g. /payments/pay_123.capture
-// captured via template /payments/{id}) is NOT rejected here, because real ids
-// legitimately contain dots (user.name, 1.2.3, file.bin) and there is no rule that
-// separates an action suffix from a dotted id without false-rejecting legit reads.
-// Accepted as a conservative-scope limitation: the unreached cases require the
-// surface record to already contain an action-shaped path, and the request is a
-// read-only GET the scanner would also issue. The template side ({id}.capture) IS
-// closed by the inert-extension allowlist in normalizePathTemplate.
-function capturedIdSegmentIsSafe(idSegment) {
-  if (!idSegment || idSegment.includes("/") || idSegment.includes("\\")) return false;
-  if (/[:;,]/.test(idSegment)) return false;
-  if (ENCODED_SEPARATOR_RE.test(idSegment)) return false;
-  const decoded = decodePathSegments(idSegment);
-  if (decoded.includes("/") || decoded.includes("\\")) return false;
-  if (/[:;,]/.test(decoded)) return false;
-  if (/%[0-9a-f]{2}/i.test(decoded)) return false;
-  return true;
-}
-
-function pathTemplateMatchesEndpoint(templatePathname, endpointPathname) {
-  const parts = templatePathname.split("{id}");
-  if (parts.length !== 2) return false;
-  const pattern = new RegExp(`^${escapeRegExp(parts[0])}([^/]+)${escapeRegExp(parts[1])}$`);
-  const match = pattern.exec(endpointPathname);
-  if (!match) return false;
-  return capturedIdSegmentIsSafe(match[1]);
-}
-
-function originFromState(domain, state) {
-  const targetUrl = state && state.target_url;
-  if (typeof targetUrl !== "string" || !targetUrl.trim()) {
-    rejectInvalidArguments("bob_http_confirm requires a web session with target_url");
-  }
-  let parsed;
-  try {
-    parsed = new URL(targetUrl);
-  } catch {
-    rejectInvalidArguments("session target_url is not a valid URL");
-  }
-  assertSafeRequestUrl(parsed.toString(), domain, SCOPE_VALIDATION_OPTS);
-  return parsed.origin;
-}
-
-function urlFromEndpoint(endpoint, origin, fieldName) {
-  const raw = assertRequiredText(endpoint, fieldName);
-  try {
-    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) return new URL(raw);
-    if (raw.startsWith("/")) return new URL(raw, origin);
-  } catch {
-    rejectInvalidArguments(`${fieldName} could not be resolved as a URL`);
-  }
-  rejectInvalidArguments(`${fieldName} must be an absolute http(s) URL or an absolute path`);
-}
-
-function findRoutedSurface(domain, surfaceId) {
-  const routed = readSurfaceRoutesStrict(domain);
-  const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
-  if (!route) {
-    rejectInvalidArguments(`unknown or unrouted surface_id ${surfaceId}`);
-  }
-  const surfaces = currentSurfaces(domain);
-  const surface = (surfaces.surfaces || []).find((entry) => entry && entry.id === surfaceId) || null;
-  if (!surface) {
-    rejectInvalidArguments(`surface_id ${surfaceId} is routed but not present in current surfaces`);
-  }
-  return { route, surface };
-}
-
-function candidateSurfaceEndpoints(surface) {
-  const candidates = [];
-  if (surface && typeof surface.uri === "string" && surface.uri.trim()) {
-    candidates.push({ value: surface.uri, field: "surface.uri" });
-  }
-  if (surface && Array.isArray(surface.endpoints)) {
-    for (let index = 0; index < surface.endpoints.length; index += 1) {
-      const endpoint = surface.endpoints[index];
-      if (typeof endpoint === "string" && endpoint.trim()) {
-        candidates.push({ value: endpoint, field: `surface.endpoints[${index}]` });
-      }
-    }
-  }
-  return candidates;
-}
-
-function resolveSurfaceOrigins(surface, stateOrigin) {
-  const origins = new Set([stateOrigin]);
-  for (const { value } of candidateSurfaceEndpoints(surface)) {
-    try {
-      const parsed = new URL(value);
-      if (parsed.protocol === "http:" || parsed.protocol === "https:") origins.add(parsed.origin);
-    } catch {}
-  }
-  if (surface && Array.isArray(surface.hosts)) {
-    let protocol = "https:";
-    try {
-      protocol = new URL(stateOrigin).protocol;
-    } catch {}
-    for (const host of surface.hosts) {
-      if (typeof host !== "string" || !host.trim()) continue;
-      try {
-        origins.add(new URL(`${protocol}//${host.trim().replace(/^https?:\/\//i, "")}`).origin);
-      } catch {}
-    }
-  }
-  return Array.from(origins);
-}
-
-function resolveBaselineFromSurface({ domain, surface, pathTemplate, state }) {
-  const stateOrigin = originFromState(domain, state);
-  const origins = resolveSurfaceOrigins(surface, stateOrigin);
-  for (const endpoint of candidateSurfaceEndpoints(surface)) {
-    for (const origin of origins) {
-      let candidate;
-      try {
-        candidate = urlFromEndpoint(endpoint.value, origin, endpoint.field);
-      } catch {
-        continue;
-      }
-      try {
-        assertSafeRequestUrl(candidate.toString(), domain, SCOPE_VALIDATION_OPTS);
-      } catch {
-        continue;
-      }
-      if (pathTemplateMatchesEndpoint(pathTemplate.split("?")[0], candidate.pathname)) {
-        // Drop any query the recorded endpoint carried: the target is built from
-        // the (query-free) template, so a baseline query would make the
-        // differential turn on query params rather than the id/auth gate.
-        // KNOWN RESIDUAL (safe false-negative): a query-ROUTED endpoint
-        // (/api/items?format=json, /report?type=summary) whose required param is
-        // dropped may 400/404 on the baseline, so classifyDifferential returns
-        // baseline_not_auth_challenge instead of testing the gate. The confirmer
-        // simply does not cover query-routed endpoints; it never mis-confirms one.
-        candidate.search = "";
-        return candidate;
-      }
-    }
-  }
-  rejectInvalidArguments("path_template path shape does not match any recorded endpoint for surface_id");
 }
 
 function resolveConfirmSurface({ domain, surfaceId, pathTemplate, state }) {
@@ -391,151 +97,6 @@ function resolveConfirmSurface({ domain, surfaceId, pathTemplate, state }) {
     baseline_url: baselineUrl.toString(),
     target_url: targetUrl.toString(),
   };
-}
-
-function isAuthChallenge(response) {
-  return response && (response.status === 401 || response.status === 403);
-}
-
-function isLoginRedirect(response) {
-  if (!response) return false;
-  if (![301, 302, 303, 307, 308].includes(response.status)) return false;
-  const location = response.headers && response.headers.get ? response.headers.get("location") : "";
-  return /login|signin|auth|sso/i.test(String(location || ""));
-}
-
-function responseLooksLikeLoginPage(response) {
-  if (!response || !Buffer.isBuffer(response.bodyBytes)) return false;
-  const contentType = response.headers && response.headers.get ? String(response.headers.get("content-type") || "") : "";
-  if (!/html|text/i.test(contentType)) return false;
-  const text = response.bodyBytes.toString("utf8", 0, Math.min(response.bodyBytes.length, 8192));
-  return /<form\b/i.test(text) && /\b(password|login|sign\s*in|signin|csrf)\b/i.test(text);
-}
-
-// Soft-404 / "no such resource" markers: a 200 carrying these is an existence
-// oracle, not a leaked resource — must NOT classify as resource-shaped.
-const NON_RESOURCE_TEXT_RE = /not[ _-]?found|no such (?:record|resource|user|object|item|account|entity|row)|does(?:n['’]?t| not) exist|invalid (?:id|identifier|resource)|unknown (?:id|identifier|resource)|"(?:exists|found|present)"\s*:\s*false/i;
-// Keys that, alone, mark a response as an error/status envelope rather than a
-// resource. (Deliberately excludes "ok"/"id"/"data-payload" keys.)
-const ERROR_ENVELOPE_KEYS = new Set(["error", "errors", "message", "detail", "details", "title", "code", "status", "reason"]);
-const DATA_WRAPPER_KEYS = Object.freeze(["data", "result", "results", "items", "records", "rows", "entries"]);
-// Pagination/listing metadata that is never itself the leaked payload — so an
-// object whose only non-envelope keys are an EMPTY data-wrapper plus these
-// (e.g. {items:[],total:0,page:1}) is an empty collection, not a resource.
-const PAGINATION_METADATA_KEYS = new Set([
-  "total", "count", "page", "pages", "per_page", "perpage", "page_size", "pagesize",
-  "limit", "offset", "has_more", "hasmore", "has_next", "next", "prev", "previous",
-  "cursor", "size", "start", "end", "links", "meta", "pagination",
-]);
-// Status/health/infra keys that are never themselves a leaked resource — so a
-// generic 200 like {ok:true}, {success:false}, or {service:"api",region:"us"}
-// from a catch-all/health endpoint is not "resource-shaped". (Canonical resource
-// fields like id/name/email are deliberately NOT here.)
-const STATUS_HEALTH_KEYS = new Set([
-  "ok", "success", "healthy", "alive", "ready", "up", "pong", "ping", "state",
-  "version", "service", "uptime", "build", "commit", "hostname", "region",
-  "environment", "env", "mode", "timestamp", "time",
-]);
-
-function contentTypeOf(response) {
-  return response && response.headers && response.headers.get
-    ? String(response.headers.get("content-type") || "")
-    : "";
-}
-
-// Read the FULL body (bounded only by safe-fetch's 1 MB response cap) — a fixed
-// sub-body window would window-truncate a large genuine JSON resource into
-// invalid JSON and fail it closed, silently dropping real missing-auth findings.
-function bodyTextOf(response, limit = 1_048_576) {
-  if (!response || !Buffer.isBuffer(response.bodyBytes) || response.bodyBytes.length === 0) return "";
-  return response.bodyBytes.toString("utf8", 0, Math.min(response.bodyBytes.length, limit));
-}
-
-// For a JSON body that did not parse: distinguish a malformed/non-resource body
-// (fail closed) from a genuine resource truncated at safe-fetch's 1 MB cap. A
-// large structured resource has multiple "key": value pairs; a catch-all ("OK",
-// a banner) does not.
-function looksStructurallyLikeJsonResource(text) {
-  return (text.match(/"[^"\\]+"\s*:/g) || []).length >= 2;
-}
-
-function jsonIsGenuineResource(parsed) {
-  if (Array.isArray(parsed)) return parsed.length > 0;
-  if (parsed == null || typeof parsed !== "object") return false;
-  const keys = Object.keys(parsed);
-  if (keys.length === 0) return false;
-  const isEmptyValue = (value) => value == null
-    || (Array.isArray(value) && value.length === 0)
-    || (typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0);
-  // The leaked PAYLOAD is any key that is not an error/status envelope key, not
-  // pagination/listing metadata, and not an EMPTY data-wrapper. An object with
-  // no such key — {error:..}, {data:null}, {results:[]}, OR an empty paginated
-  // list like {items:[],total:0,page:1} (metadata siblings included) — exposed
-  // nothing and is not a resource.
-  const payloadKeys = keys.filter((key) => {
-    const lower = key.toLowerCase();
-    if (ERROR_ENVELOPE_KEYS.has(lower)) return false;
-    if (PAGINATION_METADATA_KEYS.has(lower)) return false;
-    if (STATUS_HEALTH_KEYS.has(lower)) return false;
-    if (DATA_WRAPPER_KEYS.includes(lower) && isEmptyValue(parsed[key])) return false;
-    return true;
-  });
-  return payloadKeys.length > 0;
-}
-
-// Affirmative resource-shape check (rejects the false-positive class: soft-404 /
-// generic-200 JSON, empty collections, and SPA/app-shell HTML). Returns true only
-// when the target genuinely returned resource-like content — never on "not
-// 401/403" alone, and never on HEAD/OPTIONS (no body to inspect). Ambiguous /
-// unparseable bodies fail CLOSED (return false). Used purely as a diagnostic by
-// the negative-only classifyDifferential; it never gates a signed row.
-function isResourceShapedResponse(response) {
-  if (!response || response.status < 200 || response.status >= 300) return false;
-  if (isLoginRedirect(response)) return false;
-  if (response.headers && response.headers.get && response.headers.get("www-authenticate")) return false;
-  if (!Buffer.isBuffer(response.bodyBytes) || response.bodyBytes.length === 0) return false;
-  if (responseLooksLikeLoginPage(response)) return false;
-  const text = bodyTextOf(response);
-  if (!text.trim()) return false;
-  if (NON_RESOURCE_TEXT_RE.test(text)) return false;
-  const contentType = contentTypeOf(response);
-  const trimmed = text.trim();
-  const looksJson = /json/i.test(contentType) || trimmed.startsWith("{") || trimmed.startsWith("[");
-  if (looksJson) {
-    let parsed;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      // Unparseable JSON is malformed (fail closed) UNLESS the body was
-      // truncated at safe-fetch's 1 MB cap — a genuine large resource — which we
-      // keep via a structural key:value heuristic so the finding is not dropped.
-      return response.bodyTruncated === true && looksStructurallyLikeJsonResource(trimmed);
-    }
-    return jsonIsGenuineResource(parsed);
-  }
-  if (/xml/i.test(contentType)) {
-    // Genuine XML resource: count DATA leaf elements (<tag>text</tag>) that are
-    // NOT status/error envelope tags. >=1 data leaf (e.g. <account><balance>5000
-    // </balance></account>) is a resource; a pure status/error envelope
-    // (<response><status>ok</status><code>0</code></response>) has 0.
-    const leaves = trimmed.match(/<([a-z][\w-]*)\b[^>]*>[^<]+<\/\1\s*>/gi) || [];
-    const dataLeaves = leaves.filter((leaf) => {
-      const tag = (leaf.match(/^<([a-z][\w-]*)/i) || [])[1] || "";
-      return !/^(?:status|code|error|errors|message|msg|reason|detail|title|success|fault|result)$/i.test(tag);
-    });
-    return dataLeaves.length >= 1;
-  }
-  if (/html|text/i.test(contentType)) {
-    const stripped = text.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
-    if (/<(?:div|main|app-root)[^>]*\bid=["']?(?:root|app|__next)["']?/i.test(text) && stripped.length < 200) {
-      return false;
-    }
-    return stripped.length >= 64;
-  }
-  // Unrecognized / missing content-type: fail CLOSED. A 200 with no content-type
-  // (catch-all / health / default handler) is a manufacture vector, not proof of
-  // a leaked resource; genuine binary/download resources are a deferred oracle.
-  return false;
 }
 
 // Read-only differential REPORTER (negative-only). It classifies what the
@@ -592,56 +153,8 @@ async function fetchConfirmRequest(url, {
   });
 }
 
-// Record each confirm request in http-audit.jsonl so the session request budget
-// and circuit-breaker summary (built from http-audit records) count confirm
-// traffic — the tool makes 2 live requests per call and must not be invisible to
-// the breaker.
-function auditConfirmRequest({ domain, surfaceId, method, url, egressProfile, status, scopeDecision, error, startedAt }) {
-  if (!domain) return;
-  let parsed = null;
-  try {
-    parsed = new URL(url);
-  } catch {}
-  const auditUrl = redactUrlSensitiveValues(url);
-  let auditParsed = parsed;
-  try {
-    auditParsed = new URL(auditUrl);
-  } catch {}
-  try {
-    appendHttpAuditRecord({
-      version: 1,
-      ts: new Date().toISOString(),
-      target_domain: domain,
-      method,
-      url: auditUrl,
-      host: parsed ? parsed.hostname.toLowerCase() : null,
-      path: auditParsed ? `${auditParsed.pathname}${auditParsed.search}` : null,
-      surface_id: surfaceId || null,
-      tool: TOOL_ID,
-      egress_profile: egressProfile || null,
-      status: status == null ? null : status,
-      // normalizeHttpAuditRecord REQUIRES a non-empty scope_decision; a null here
-      // throws and is swallowed by the catch below, dropping the record entirely
-      // (and with it the circuit-breaker/budget visibility). Default a normal
-      // probe to "allowed" and a non-scope transport failure to "request_error",
-      // matching bob_http_scan's audit convention.
-      scope_decision: scopeDecision || (error ? "request_error" : "allowed"),
-      error: error || null,
-      duration_ms: startedAt ? Date.now() - startedAt : null,
-    });
-  } catch (auditError) {
-    // A swallowed audit-write failure makes this probe invisible to the circuit
-    // breaker / request budget — a control-plane gap. We still must not let an
-    // audit failure abort the confirm, but surface it to stderr so it is
-    // detectable outside the control plane.
-    try {
-      process.stderr.write(`bob_http_confirm: http-audit write failed: ${auditError && auditError.message ? auditError.message : String(auditError)}\n`);
-    } catch {}
-  }
-}
-
 async function httpConfirm(args = {}) {
-  assertNoForbiddenInputs(args);
+  assertNoForbiddenInputs(args, TOOL_ID);
   const startedAt = Date.now();
   const domain = assertNonEmptyString(args.target_domain, "target_domain");
   const surfaceId = assertNonEmptyString(args.surface_id, "surface_id");
@@ -698,6 +211,7 @@ async function httpConfirm(args = {}) {
     auditConfirmRequest({
       domain, surfaceId, method, url: surface.baseline_url,
       egressProfile: egressProfileName, status: baselineResponse.status, startedAt,
+      toolId: TOOL_ID,
     });
     inFlightUrl = surface.target_url;
     targetResponse = await fetchConfirmRequest(surface.target_url, {
@@ -710,6 +224,7 @@ async function httpConfirm(args = {}) {
     auditConfirmRequest({
       domain, surfaceId, method, url: surface.target_url,
       egressProfile: egressProfileName, status: targetResponse.status, startedAt,
+      toolId: TOOL_ID,
     });
   } catch (error) {
     const scopeBlocked = error && error.scope_decision === "blocked";
@@ -718,6 +233,7 @@ async function httpConfirm(args = {}) {
       egressProfile: egressProfileName, status: null,
       scopeDecision: scopeBlocked ? "blocked" : null,
       error: error.message || String(error), startedAt,
+      toolId: TOOL_ID,
     });
     // NOTE: `failure_reason`, NOT `error` — executeTool treats any returned
     // object with an `error` string as an MCP error, which would surface this

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -531,6 +531,13 @@ const FORBIDDEN_INPUT_FIELDS = Object.freeze([
 ]);
 
 function assertNoForbiddenInputs(args, toolName, extraFields = []) {
+  // Fail fast on a mis-wired caller: a non-array extraFields (e.g. the string
+  // "object_id" instead of ["object_id"]) would spread into single characters
+  // and silently DROP the intended extra forbidden field — weakening the guard.
+  // Throw loudly rather than degrade security quietly.
+  if (!Array.isArray(extraFields)) {
+    rejectInvalidArguments(`${toolName} forbidden-input guard misconfigured: extraFields must be an array of field names`);
+  }
   for (const field of [...FORBIDDEN_INPUT_FIELDS, ...extraFields]) {
     if (Object.prototype.hasOwnProperty.call(args || {}, field)) {
       rejectInvalidArguments(`${toolName} does not accept ${field}; the request is derived server-side from surface_id and path_template`);

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -1,0 +1,562 @@
+"use strict";
+
+// Shared HTTP/surface primitives for the offensive confirmer family
+// (bob_http_confirm and the forthcoming bob_http_idor_confirm producer).
+// Everything here is extracted VERBATIM from offensive-confirmer.js so the
+// negative-only confirmer behaves byte-identically; the only parameterized
+// surfaces are assertNoForbiddenInputs (toolName + extraFields) and
+// auditConfirmRequest (toolId), so a second offensive tool can reuse them
+// without forking the security-reviewed logic.
+
+const {
+  ERROR_CODES,
+  ToolError,
+} = require("./envelope.js");
+const {
+  readSurfaceRoutesStrict,
+} = require("./surface-router.js");
+const {
+  currentSurfaces,
+} = require("./frontier-projections.js");
+const {
+  assertSafeRequestUrl,
+} = require("./safe-fetch.js");
+const {
+  assertRequiredText,
+} = require("./validation.js");
+const {
+  appendHttpAuditRecord,
+} = require("./http-records.js");
+const { redactUrlSensitiveValues } = require("../redaction.js");
+
+// The REAL safety boundary against "confirm emits a state-changing GET against
+// the real recorded id" is STRUCTURAL: {id} must be the final path segment
+// (normalizePathTemplate), so no action segment (`/{id}/capture`, `/{id}/transfer`)
+// can follow it. A verb denylist can NEVER enumerate the open-ended mutation
+// surface (capture/settle/promote/enable/...), so this list is kept deliberately
+// NARROW — only unambiguous destructive verbs that are almost never legitimate
+// resource-collection nouns — and is best-effort defense-in-depth ONLY, to catch
+// a verb-named collection BEFORE the id (`/delete/{id}`). It must NOT include
+// ambiguous nouns (order/charge/transfer/block/run) or it would wrongly reject
+// legitimate single-resource reads like /api/order/{id}.
+// The verb may be followed by `/`, end-of-path, OR a format/matrix suffix
+// (`.json`, `;v=1`) that many routers strip before dispatch — so /api/delete.json/{id}
+// and /api/reset;v=1/{id} are caught too.
+const STATE_CHANGE_PATH_SEGMENT_RE = /(?:^|\/)(?:delete|logout|remove|destroy|deactivate|disable|revoke|reset|unsubscribe|terminate|purge|wipe)(?:[./;,]|\/|$)/i;
+const VERB_LIKE_TOKEN_RE = /^(?:delete|remove|destroy|logout|create|update|patch|put|post|submit|send|transfer|refund|reset|revoke|disable|enable|drop|truncate|mutation)$/i;
+
+// An encoded path separator at ANY encoding depth: %2F / %5C, %252F, %2525252F,
+// etc. (`(25)*` absorbs each extra `%25` layer). Layer-count-independent, so it
+// does not depend on how many times decodePathSegments iterates.
+const ENCODED_SEPARATOR_RE = /%(?:25)*(?:2f|5c)/i;
+// The ONLY suffix allowed after {id}: an inert data/serialization file extension.
+// Deliberately a closed allowlist (NOT `\.\w+`) so a verb-shaped dot suffix like
+// `{id}.capture` / `{id}.delete` — which routes to an action on the real id — is
+// rejected, while `{id}.json` / `{id}.xml` direct reads pass.
+const INERT_EXTENSION_RE = /^\.(?:json|xml|csv|tsv|txt|yaml|yml|html?|pdf|md|ndjson|geojson)$/i;
+// Pre-fetch URL validation hardcodes blockInternalHosts:false ON PURPOSE — these
+// are domain-scope/URL-shape range checks; the session's real SSRF policy
+// (block_internal_hosts) is enforced at FETCH time in safeFetch. The named
+// constant signals the `false` is intentional, not a dropped policy, so a future
+// refactor of the validation layer can't silently strip SSRF enforcement.
+const SCOPE_VALIDATION_OPTS = Object.freeze({ blockInternalHosts: false });
+
+function rejectInvalidArguments(message, details = null) {
+  throw new ToolError(ERROR_CODES.INVALID_ARGUMENTS, message, details);
+}
+
+// Recursively percent-decode each path segment until stable (defeats double /
+// multi encoding like %2564elete) so the deny-list sees the real verb.
+function decodePathSegments(pathname) {
+  return pathname
+    .split("/")
+    .map((seg) => {
+      let decoded = seg;
+      for (let i = 0; i < 8; i += 1) {
+        let next;
+        try {
+          next = decodeURIComponent(decoded);
+        } catch {
+          break;
+        }
+        if (next === decoded) break;
+        decoded = next;
+      }
+      return decoded;
+    })
+    .join("/");
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// The recorded baseline id segment must be a CLEAN single resource id. The unauth
+// baseline GET hits this REAL recorded id, so anything that can route to a
+// sub-resource/action must be rejected, whether it lives in the surface record
+// (which normalizePathTemplate never sees) or is supplied raw:
+//  - a path separator, literal OR encoded at any depth (%2F, %252F, %25%32%46),
+//  - action/matrix punctuation (: ; ,), literal OR percent-escaped (%3A…).
+// Decode each segment to a FIXED POINT so multi-layer / split-hex encodings are
+// seen, and fail closed on a remnant escape that 8 passes could not resolve.
+// KNOWN RESIDUAL: a dot-action suffix in a RECORDED id (e.g. /payments/pay_123.capture
+// captured via template /payments/{id}) is NOT rejected here, because real ids
+// legitimately contain dots (user.name, 1.2.3, file.bin) and there is no rule that
+// separates an action suffix from a dotted id without false-rejecting legit reads.
+// Accepted as a conservative-scope limitation: the unreached cases require the
+// surface record to already contain an action-shaped path, and the request is a
+// read-only GET the scanner would also issue. The template side ({id}.capture) IS
+// closed by the inert-extension allowlist in normalizePathTemplate.
+function capturedIdSegmentIsSafe(idSegment) {
+  if (!idSegment || idSegment.includes("/") || idSegment.includes("\\")) return false;
+  if (/[:;,]/.test(idSegment)) return false;
+  if (ENCODED_SEPARATOR_RE.test(idSegment)) return false;
+  const decoded = decodePathSegments(idSegment);
+  if (decoded.includes("/") || decoded.includes("\\")) return false;
+  if (/[:;,]/.test(decoded)) return false;
+  if (/%[0-9a-f]{2}/i.test(decoded)) return false;
+  return true;
+}
+
+function pathTemplateMatchesEndpoint(templatePathname, endpointPathname) {
+  const parts = templatePathname.split("{id}");
+  if (parts.length !== 2) return false;
+  const pattern = new RegExp(`^${escapeRegExp(parts[0])}([^/]+)${escapeRegExp(parts[1])}$`);
+  const match = pattern.exec(endpointPathname);
+  if (!match) return false;
+  return capturedIdSegmentIsSafe(match[1]);
+}
+
+function assertReadOnlyPath(url) {
+  const parsed = new URL(url);
+  const pathAndQuery = `${parsed.pathname}${parsed.search}`;
+  const decodedPath = decodePathSegments(parsed.pathname);
+  if (STATE_CHANGE_PATH_SEGMENT_RE.test(parsed.pathname) || STATE_CHANGE_PATH_SEGMENT_RE.test(decodedPath)) {
+    rejectInvalidArguments(
+      "path_template resolves to a state-changing path segment; bob_http_confirm only shrinks, not eliminates, GET-side-effect risk and rejects mutation-shaped paths",
+      { path: parsed.pathname },
+    );
+  }
+  const params = new URLSearchParams(parsed.search);
+  for (const [rawKey, rawValue] of params.entries()) {
+    const key = String(rawKey || "").trim();
+    const value = String(rawValue || "").trim();
+    if (/^action$/i.test(key) || /^_method$/i.test(key)) {
+      rejectInvalidArguments(`query parameter ${key} is not allowed for bob_http_confirm`);
+    }
+    if (VERB_LIKE_TOKEN_RE.test(key) || VERB_LIKE_TOKEN_RE.test(value)) {
+      rejectInvalidArguments(`query parameter ${key} carries a mutation-shaped token`);
+    }
+    if (/graphql|query/i.test(key) && /\bmutation\b/i.test(value)) {
+      rejectInvalidArguments("GraphQL mutation-shaped query is not allowed for bob_http_confirm");
+    }
+  }
+  // Check the raw AND the recursively-decoded path so an encoded `mutation`
+  // segment (e.g. /api/%6Dutation/{id}) that routers decode before dispatch is
+  // also rejected, not just the literal form.
+  if (/\bmutation\b/i.test(pathAndQuery) || /\bmutation\b/i.test(decodedPath)) {
+    rejectInvalidArguments("mutation-shaped path or query is not allowed for bob_http_confirm");
+  }
+}
+
+function normalizePathTemplate(rawTemplate) {
+  const template = assertRequiredText(rawTemplate, "path_template");
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(template)) {
+    rejectInvalidArguments("path_template must be a path, not an absolute URL");
+  }
+  if (!template.startsWith("/")) {
+    rejectInvalidArguments("path_template must start with /");
+  }
+  if (template.includes("#")) {
+    rejectInvalidArguments("path_template must not include a fragment");
+  }
+  // No query string: the oracle reads a resource by id, and the baseline (real
+  // id) request is built from the recorded endpoint WITHOUT the template query,
+  // so a template-only query would make the differential turn on the query
+  // rather than on id/auth. Forbid it so baseline and target are symmetric.
+  if (template.includes("?")) {
+    rejectInvalidArguments("path_template must not include a query string");
+  }
+  const slotMatches = template.match(/\{id\}/g) || [];
+  if (slotMatches.length !== 1) {
+    rejectInvalidArguments("path_template must contain exactly one {id} slot");
+  }
+  const slotIndex = template.indexOf("{id}");
+  const queryIndex = template.indexOf("?");
+  if (queryIndex !== -1 && slotIndex > queryIndex) {
+    rejectInvalidArguments("path_template {id} slot must be in the path, not the query string");
+  }
+  // STRUCTURAL read-only boundary: {id} must be the FINAL path segment. The
+  // baseline request hits the REAL recorded id, so any segment after {id}
+  // (`/accounts/{id}/transfer`, `/payments/{id}/capture`) would emit an unauth
+  // state-changing GET against a real resource — the incident class this tool
+  // exists to prevent — and a verb denylist can never enumerate that surface.
+  // Forbidding a trailing segment closes it outright. (Consequence: PR3's oracle
+  // confirms only DIRECT resource reads, not sub-resource/action endpoints; a
+  // sub-resource read oracle that synthesizes its own baseline is deferred.)
+  const pathPart = queryIndex === -1 ? template : template.slice(0, queryIndex);
+  const afterSlot = pathPart.slice(pathPart.indexOf("{id}") + "{id}".length);
+  // {id} must TERMINATE the final path segment: nothing may follow it except an
+  // inert file extension (.json/.xml). This single allowlist rejects, in one rule,
+  //  - a following path segment (/accounts/{id}/transfer),
+  //  - an encoded separator at ANY depth (/payments/{id}%2Fcapture, %252F...),
+  //  - a same-segment action / matrix suffix (/payments/{id}:capture, {id};delete),
+  // each of which would make the unauth baseline GET (which hits the REAL recorded
+  // id) reach a sub-resource/action — the incident class this tool exists to
+  // prevent. A verb denylist can never enumerate that surface; an allowlist closes
+  // it structurally. (Consequence: PR3's oracle confirms only DIRECT resource
+  // reads; a sub-resource read oracle that synthesizes its own baseline is deferred.)
+  if (afterSlot !== "" && !INERT_EXTENSION_RE.test(afterSlot)) {
+    rejectInvalidArguments("path_template {id} must terminate the final path segment (optionally followed by an inert file extension like .json); bob_http_confirm confirms only direct resource reads, so nothing else may follow {id}");
+  }
+  return template;
+}
+
+function findRoutedSurface(domain, surfaceId) {
+  const routed = readSurfaceRoutesStrict(domain);
+  const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
+  if (!route) {
+    rejectInvalidArguments(`unknown or unrouted surface_id ${surfaceId}`);
+  }
+  const surfaces = currentSurfaces(domain);
+  const surface = (surfaces.surfaces || []).find((entry) => entry && entry.id === surfaceId) || null;
+  if (!surface) {
+    rejectInvalidArguments(`surface_id ${surfaceId} is routed but not present in current surfaces`);
+  }
+  return { route, surface };
+}
+
+function candidateSurfaceEndpoints(surface) {
+  const candidates = [];
+  if (surface && typeof surface.uri === "string" && surface.uri.trim()) {
+    candidates.push({ value: surface.uri, field: "surface.uri" });
+  }
+  if (surface && Array.isArray(surface.endpoints)) {
+    for (let index = 0; index < surface.endpoints.length; index += 1) {
+      const endpoint = surface.endpoints[index];
+      if (typeof endpoint === "string" && endpoint.trim()) {
+        candidates.push({ value: endpoint, field: `surface.endpoints[${index}]` });
+      }
+    }
+  }
+  return candidates;
+}
+
+function resolveSurfaceOrigins(surface, stateOrigin) {
+  const origins = new Set([stateOrigin]);
+  for (const { value } of candidateSurfaceEndpoints(surface)) {
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") origins.add(parsed.origin);
+    } catch {}
+  }
+  if (surface && Array.isArray(surface.hosts)) {
+    let protocol = "https:";
+    try {
+      protocol = new URL(stateOrigin).protocol;
+    } catch {}
+    for (const host of surface.hosts) {
+      if (typeof host !== "string" || !host.trim()) continue;
+      try {
+        origins.add(new URL(`${protocol}//${host.trim().replace(/^https?:\/\//i, "")}`).origin);
+      } catch {}
+    }
+  }
+  return Array.from(origins);
+}
+
+function originFromState(domain, state) {
+  const targetUrl = state && state.target_url;
+  if (typeof targetUrl !== "string" || !targetUrl.trim()) {
+    rejectInvalidArguments("bob_http_confirm requires a web session with target_url");
+  }
+  let parsed;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    rejectInvalidArguments("session target_url is not a valid URL");
+  }
+  assertSafeRequestUrl(parsed.toString(), domain, SCOPE_VALIDATION_OPTS);
+  return parsed.origin;
+}
+
+function urlFromEndpoint(endpoint, origin, fieldName) {
+  const raw = assertRequiredText(endpoint, fieldName);
+  try {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) return new URL(raw);
+    if (raw.startsWith("/")) return new URL(raw, origin);
+  } catch {
+    rejectInvalidArguments(`${fieldName} could not be resolved as a URL`);
+  }
+  rejectInvalidArguments(`${fieldName} must be an absolute http(s) URL or an absolute path`);
+}
+
+function resolveBaselineFromSurface({ domain, surface, pathTemplate, state }) {
+  const stateOrigin = originFromState(domain, state);
+  const origins = resolveSurfaceOrigins(surface, stateOrigin);
+  for (const endpoint of candidateSurfaceEndpoints(surface)) {
+    for (const origin of origins) {
+      let candidate;
+      try {
+        candidate = urlFromEndpoint(endpoint.value, origin, endpoint.field);
+      } catch {
+        continue;
+      }
+      try {
+        assertSafeRequestUrl(candidate.toString(), domain, SCOPE_VALIDATION_OPTS);
+      } catch {
+        continue;
+      }
+      if (pathTemplateMatchesEndpoint(pathTemplate.split("?")[0], candidate.pathname)) {
+        // Drop any query the recorded endpoint carried: the target is built from
+        // the (query-free) template, so a baseline query would make the
+        // differential turn on query params rather than the id/auth gate.
+        // KNOWN RESIDUAL (safe false-negative): a query-ROUTED endpoint
+        // (/api/items?format=json, /report?type=summary) whose required param is
+        // dropped may 400/404 on the baseline, so classifyDifferential returns
+        // baseline_not_auth_challenge instead of testing the gate. The confirmer
+        // simply does not cover query-routed endpoints; it never mis-confirms one.
+        candidate.search = "";
+        return candidate;
+      }
+    }
+  }
+  rejectInvalidArguments("path_template path shape does not match any recorded endpoint for surface_id");
+}
+
+function isAuthChallenge(response) {
+  return response && (response.status === 401 || response.status === 403);
+}
+
+function isLoginRedirect(response) {
+  if (!response) return false;
+  if (![301, 302, 303, 307, 308].includes(response.status)) return false;
+  const location = response.headers && response.headers.get ? response.headers.get("location") : "";
+  return /login|signin|auth|sso/i.test(String(location || ""));
+}
+
+function responseLooksLikeLoginPage(response) {
+  if (!response || !Buffer.isBuffer(response.bodyBytes)) return false;
+  const contentType = response.headers && response.headers.get ? String(response.headers.get("content-type") || "") : "";
+  if (!/html|text/i.test(contentType)) return false;
+  const text = response.bodyBytes.toString("utf8", 0, Math.min(response.bodyBytes.length, 8192));
+  return /<form\b/i.test(text) && /\b(password|login|sign\s*in|signin|csrf)\b/i.test(text);
+}
+
+// Soft-404 / "no such resource" markers: a 200 carrying these is an existence
+// oracle, not a leaked resource — must NOT classify as resource-shaped.
+const NON_RESOURCE_TEXT_RE = /not[ _-]?found|no such (?:record|resource|user|object|item|account|entity|row)|does(?:n['’]?t| not) exist|invalid (?:id|identifier|resource)|unknown (?:id|identifier|resource)|"(?:exists|found|present)"\s*:\s*false/i;
+// Keys that, alone, mark a response as an error/status envelope rather than a
+// resource. (Deliberately excludes "ok"/"id"/"data-payload" keys.)
+const ERROR_ENVELOPE_KEYS = new Set(["error", "errors", "message", "detail", "details", "title", "code", "status", "reason"]);
+const DATA_WRAPPER_KEYS = Object.freeze(["data", "result", "results", "items", "records", "rows", "entries"]);
+// Pagination/listing metadata that is never itself the leaked payload — so an
+// object whose only non-envelope keys are an EMPTY data-wrapper plus these
+// (e.g. {items:[],total:0,page:1}) is an empty collection, not a resource.
+const PAGINATION_METADATA_KEYS = new Set([
+  "total", "count", "page", "pages", "per_page", "perpage", "page_size", "pagesize",
+  "limit", "offset", "has_more", "hasmore", "has_next", "next", "prev", "previous",
+  "cursor", "size", "start", "end", "links", "meta", "pagination",
+]);
+// Status/health/infra keys that are never themselves a leaked resource — so a
+// generic 200 like {ok:true}, {success:false}, or {service:"api",region:"us"}
+// from a catch-all/health endpoint is not "resource-shaped". (Canonical resource
+// fields like id/name/email are deliberately NOT here.)
+const STATUS_HEALTH_KEYS = new Set([
+  "ok", "success", "healthy", "alive", "ready", "up", "pong", "ping", "state",
+  "version", "service", "uptime", "build", "commit", "hostname", "region",
+  "environment", "env", "mode", "timestamp", "time",
+]);
+
+function contentTypeOf(response) {
+  return response && response.headers && response.headers.get
+    ? String(response.headers.get("content-type") || "")
+    : "";
+}
+
+// Read the FULL body (bounded only by safe-fetch's 1 MB response cap) — a fixed
+// sub-body window would window-truncate a large genuine JSON resource into
+// invalid JSON and fail it closed, silently dropping real missing-auth findings.
+function bodyTextOf(response, limit = 1_048_576) {
+  if (!response || !Buffer.isBuffer(response.bodyBytes) || response.bodyBytes.length === 0) return "";
+  return response.bodyBytes.toString("utf8", 0, Math.min(response.bodyBytes.length, limit));
+}
+
+// For a JSON body that did not parse: distinguish a malformed/non-resource body
+// (fail closed) from a genuine resource truncated at safe-fetch's 1 MB cap. A
+// large structured resource has multiple "key": value pairs; a catch-all ("OK",
+// a banner) does not.
+function looksStructurallyLikeJsonResource(text) {
+  return (text.match(/"[^"\\]+"\s*:/g) || []).length >= 2;
+}
+
+function jsonIsGenuineResource(parsed) {
+  if (Array.isArray(parsed)) return parsed.length > 0;
+  if (parsed == null || typeof parsed !== "object") return false;
+  const keys = Object.keys(parsed);
+  if (keys.length === 0) return false;
+  const isEmptyValue = (value) => value == null
+    || (Array.isArray(value) && value.length === 0)
+    || (typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0);
+  // The leaked PAYLOAD is any key that is not an error/status envelope key, not
+  // pagination/listing metadata, and not an EMPTY data-wrapper. An object with
+  // no such key — {error:..}, {data:null}, {results:[]}, OR an empty paginated
+  // list like {items:[],total:0,page:1} (metadata siblings included) — exposed
+  // nothing and is not a resource.
+  const payloadKeys = keys.filter((key) => {
+    const lower = key.toLowerCase();
+    if (ERROR_ENVELOPE_KEYS.has(lower)) return false;
+    if (PAGINATION_METADATA_KEYS.has(lower)) return false;
+    if (STATUS_HEALTH_KEYS.has(lower)) return false;
+    if (DATA_WRAPPER_KEYS.includes(lower) && isEmptyValue(parsed[key])) return false;
+    return true;
+  });
+  return payloadKeys.length > 0;
+}
+
+// Affirmative resource-shape check (rejects the false-positive class: soft-404 /
+// generic-200 JSON, empty collections, and SPA/app-shell HTML). Returns true only
+// when the target genuinely returned resource-like content — never on "not
+// 401/403" alone, and never on HEAD/OPTIONS (no body to inspect). Ambiguous /
+// unparseable bodies fail CLOSED (return false). Used purely as a diagnostic by
+// the negative-only classifyDifferential; it never gates a signed row.
+function isResourceShapedResponse(response) {
+  if (!response || response.status < 200 || response.status >= 300) return false;
+  if (isLoginRedirect(response)) return false;
+  if (response.headers && response.headers.get && response.headers.get("www-authenticate")) return false;
+  if (!Buffer.isBuffer(response.bodyBytes) || response.bodyBytes.length === 0) return false;
+  if (responseLooksLikeLoginPage(response)) return false;
+  const text = bodyTextOf(response);
+  if (!text.trim()) return false;
+  if (NON_RESOURCE_TEXT_RE.test(text)) return false;
+  const contentType = contentTypeOf(response);
+  const trimmed = text.trim();
+  const looksJson = /json/i.test(contentType) || trimmed.startsWith("{") || trimmed.startsWith("[");
+  if (looksJson) {
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      // Unparseable JSON is malformed (fail closed) UNLESS the body was
+      // truncated at safe-fetch's 1 MB cap — a genuine large resource — which we
+      // keep via a structural key:value heuristic so the finding is not dropped.
+      return response.bodyTruncated === true && looksStructurallyLikeJsonResource(trimmed);
+    }
+    return jsonIsGenuineResource(parsed);
+  }
+  if (/xml/i.test(contentType)) {
+    // Genuine XML resource: count DATA leaf elements (<tag>text</tag>) that are
+    // NOT status/error envelope tags. >=1 data leaf (e.g. <account><balance>5000
+    // </balance></account>) is a resource; a pure status/error envelope
+    // (<response><status>ok</status><code>0</code></response>) has 0.
+    const leaves = trimmed.match(/<([a-z][\w-]*)\b[^>]*>[^<]+<\/\1\s*>/gi) || [];
+    const dataLeaves = leaves.filter((leaf) => {
+      const tag = (leaf.match(/^<([a-z][\w-]*)/i) || [])[1] || "";
+      return !/^(?:status|code|error|errors|message|msg|reason|detail|title|success|fault|result)$/i.test(tag);
+    });
+    return dataLeaves.length >= 1;
+  }
+  if (/html|text/i.test(contentType)) {
+    const stripped = text.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+    if (/<(?:div|main|app-root)[^>]*\bid=["']?(?:root|app|__next)["']?/i.test(text) && stripped.length < 200) {
+      return false;
+    }
+    return stripped.length >= 64;
+  }
+  // Unrecognized / missing content-type: fail CLOSED. A 200 with no content-type
+  // (catch-all / health / default handler) is a manufacture vector, not proof of
+  // a leaked resource; genuine binary/download resources are a deferred oracle.
+  return false;
+}
+
+// Record each offensive probe in http-audit.jsonl so the session request budget
+// and circuit-breaker summary (built from http-audit records) count the live
+// traffic — an offensive tool makes multiple live requests per call and must not
+// be invisible to the breaker. `toolId` is parameterized so each offensive tool
+// (bob_http_confirm, bob_http_idor_confirm) is attributed correctly in the audit
+// record's `tool` field; the confirmer passes its own TOOL_ID for byte-identical
+// behavior.
+function auditConfirmRequest({ domain, surfaceId, method, url, egressProfile, status, scopeDecision, error, startedAt, toolId }) {
+  if (!domain) return;
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch {}
+  const auditUrl = redactUrlSensitiveValues(url);
+  let auditParsed = parsed;
+  try {
+    auditParsed = new URL(auditUrl);
+  } catch {}
+  try {
+    appendHttpAuditRecord({
+      version: 1,
+      ts: new Date().toISOString(),
+      target_domain: domain,
+      method,
+      url: auditUrl,
+      host: parsed ? parsed.hostname.toLowerCase() : null,
+      path: auditParsed ? `${auditParsed.pathname}${auditParsed.search}` : null,
+      surface_id: surfaceId || null,
+      tool: toolId,
+      egress_profile: egressProfile || null,
+      status: status == null ? null : status,
+      // normalizeHttpAuditRecord REQUIRES a non-empty scope_decision; a null here
+      // throws and is swallowed by the catch below, dropping the record entirely
+      // (and with it the circuit-breaker/budget visibility). Default a normal
+      // probe to "allowed" and a non-scope transport failure to "request_error",
+      // matching bob_http_scan's audit convention.
+      scope_decision: scopeDecision || (error ? "request_error" : "allowed"),
+      error: error || null,
+      duration_ms: startedAt ? Date.now() - startedAt : null,
+    });
+  } catch (auditError) {
+    // A swallowed audit-write failure makes this probe invisible to the circuit
+    // breaker / request budget — a control-plane gap. We still must not let an
+    // audit failure abort the confirm, but surface it to stderr so it is
+    // detectable outside the control plane.
+    try {
+      process.stderr.write(`${toolId}: http-audit write failed: ${auditError && auditError.message ? auditError.message : String(auditError)}\n`);
+    } catch {}
+  }
+}
+
+// The base set of fields no offensive confirmer accepts as caller input: the
+// request is derived server-side from surface_id + path_template, never from a
+// raw URL/body/headers or an asserted severity/finding id. `extraFields` lets a
+// specific tool forbid additional inputs (e.g. the IDOR producer also forbids the
+// server-minted object ids and canary). `toolName` is interpolated into the
+// rejection message so each tool reports under its own id.
+const FORBIDDEN_INPUT_FIELDS = Object.freeze([
+  "url", "body", "headers", "severity", "demonstrated_severity", "finding_id", "resource_id", "id",
+]);
+
+function assertNoForbiddenInputs(args, toolName, extraFields = []) {
+  for (const field of [...FORBIDDEN_INPUT_FIELDS, ...extraFields]) {
+    if (Object.prototype.hasOwnProperty.call(args || {}, field)) {
+      rejectInvalidArguments(`${toolName} does not accept ${field}; the request is derived server-side from surface_id and path_template`);
+    }
+  }
+}
+
+module.exports = {
+  rejectInvalidArguments,
+  decodePathSegments,
+  escapeRegExp,
+  capturedIdSegmentIsSafe,
+  pathTemplateMatchesEndpoint,
+  assertReadOnlyPath,
+  normalizePathTemplate,
+  findRoutedSurface,
+  candidateSurfaceEndpoints,
+  resolveSurfaceOrigins,
+  originFromState,
+  urlFromEndpoint,
+  resolveBaselineFromSurface,
+  isAuthChallenge,
+  isLoginRedirect,
+  responseLooksLikeLoginPage,
+  isResourceShapedResponse,
+  auditConfirmRequest,
+  assertNoForbiddenInputs,
+  SCOPE_VALIDATION_OPTS,
+};

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -154,6 +154,7 @@
   "test/technique-attempt-lead-surface.test.js",
   "test/claim-secret-evidence-bypass.test.js",
   "test/offensive-confirmer.test.js",
+  "test/offensive-http-common.test.js",
   "test/lifecycle-state-drift.test.js",
   "test/evidence-gate-lifecycle.test.js"
 ]

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -1,0 +1,344 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  rejectInvalidArguments,
+  decodePathSegments,
+  escapeRegExp,
+  capturedIdSegmentIsSafe,
+  pathTemplateMatchesEndpoint,
+  assertReadOnlyPath,
+  normalizePathTemplate,
+  findRoutedSurface,
+  candidateSurfaceEndpoints,
+  resolveSurfaceOrigins,
+  originFromState,
+  urlFromEndpoint,
+  resolveBaselineFromSurface,
+  isAuthChallenge,
+  isLoginRedirect,
+  responseLooksLikeLoginPage,
+  isResourceShapedResponse,
+  assertNoForbiddenInputs,
+  SCOPE_VALIDATION_OPTS,
+} = require("../mcp/lib/offensive-http-common.js");
+const { ERROR_CODES } = require("../mcp/lib/envelope.js");
+const { routeSurfaces } = require("../mcp/lib/surface-router.js");
+const { initSession } = require("../mcp/lib/session-state.js");
+const { readSessionStateStrict } = require("../mcp/lib/session-state-store.js");
+const { attackSurfacePath } = require("../mcp/lib/paths.js");
+const {
+  resetForTests: resetMaterializationDebounce,
+} = require("../mcp/lib/frontier-materialize-debounce.js");
+
+function withTempHome(fn) {
+  const previousHome = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-offensive-http-common-"));
+  process.env.HOME = home;
+  return Promise.resolve()
+    .then(() => fn(home))
+    .finally(() => {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      resetMaterializationDebounce();
+      fs.rmSync(home, { recursive: true, force: true });
+    });
+}
+
+function seedRoutedSurface(domain, surfaceId, endpoint) {
+  fs.mkdirSync(path.dirname(attackSurfacePath(domain)), { recursive: true });
+  fs.writeFileSync(attackSurfacePath(domain), `${JSON.stringify({
+    surfaces: [{
+      id: surfaceId,
+      title: "Synthetic API account surface",
+      surface_type: "web",
+      hosts: [domain],
+      endpoints: [endpoint],
+      tech_stack: ["fixture"],
+      priority: "HIGH",
+    }],
+  }, null, 2)}\n`, "utf8");
+  JSON.parse(routeSurfaces({ target_domain: domain }));
+}
+
+// Minimal response mock matching the {status, headers.get, bodyBytes} shape the
+// classifier helpers read (mirrors test/offensive-confirmer.test.js).
+function mockResponse(status, body = "", headers = {}, extra = {}) {
+  const lower = {};
+  for (const [k, v] of Object.entries(headers)) lower[String(k).toLowerCase()] = v;
+  return {
+    status,
+    headers: { get(name) { return lower[String(name).toLowerCase()] ?? null; } },
+    bodyBytes: Buffer.isBuffer(body) ? body : Buffer.from(body),
+    bodyTruncated: false,
+    ...extra,
+  };
+}
+
+// --- assertNoForbiddenInputs: the parameterization payoff (the whole point of PR-B) ---
+
+test("assertNoForbiddenInputs is parameterized: a different toolName + extraFields drive the rejection", () => {
+  // The forthcoming bob_http_idor_confirm reuses this guard with its own tool
+  // name and its own server-minted-only extra fields. Assert on the concrete
+  // message + code so the parameterization (toolName AND the field set) is proven.
+  let caught;
+  try {
+    assertNoForbiddenInputs({ canary: "x" }, "bob_http_idor_confirm", ["canary"]);
+  } catch (error) { caught = error; }
+  assert.ok(caught, "must throw on an extra field");
+  assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+  assert.equal(
+    caught.message,
+    "bob_http_idor_confirm does not accept canary; the request is derived server-side from surface_id and path_template",
+  );
+  // a base field is still rejected even when the caller only supplies extras
+  let baseCaught;
+  try {
+    assertNoForbiddenInputs({ url: "https://x" }, "bob_http_idor_confirm", ["canary"]);
+  } catch (error) { baseCaught = error; }
+  assert.ok(baseCaught);
+  assert.equal(baseCaught.message, "bob_http_idor_confirm does not accept url; the request is derived server-side from surface_id and path_template");
+});
+
+test("assertNoForbiddenInputs back-compat: bob_http_confirm message is byte-identical for every base field", () => {
+  const base = ["url", "body", "headers", "severity", "demonstrated_severity", "finding_id", "resource_id", "id"];
+  for (const field of base) {
+    let caught;
+    try {
+      assertNoForbiddenInputs({ [field]: "x" }, "bob_http_confirm");
+    } catch (error) { caught = error; }
+    assert.ok(caught, `${field} must be rejected`);
+    assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+    assert.equal(
+      caught.message,
+      `bob_http_confirm does not accept ${field}; the request is derived server-side from surface_id and path_template`,
+    );
+  }
+  // a clean confirmer args object does not throw
+  assert.doesNotThrow(() => assertNoForbiddenInputs(
+    { target_domain: "x.test", surface_id: "s", oracle_kind: "differential_response", path_template: "/api/accounts/{id}" },
+    "bob_http_confirm",
+  ));
+});
+
+test("assertNoForbiddenInputs guard semantics: nullish args are safe, hasOwnProperty (not truthiness) gates", () => {
+  assert.doesNotThrow(() => assertNoForbiddenInputs(null, "bob_http_confirm"));
+  assert.doesNotThrow(() => assertNoForbiddenInputs(undefined, "bob_http_confirm"));
+  assert.doesNotThrow(() => assertNoForbiddenInputs({}, "bob_http_confirm"));
+  // a present-but-empty forbidden field still throws (hasOwnProperty, not truthiness)
+  assert.throws(() => assertNoForbiddenInputs({ url: "" }, "bob_http_confirm"), /does not accept url/);
+  // extraFields defaults to [] — only the base list applies when omitted
+  assert.doesNotThrow(() => assertNoForbiddenInputs({ object_id: "x" }, "bob_http_confirm"));
+});
+
+// --- rejectInvalidArguments ---
+
+test("rejectInvalidArguments throws a ToolError(INVALID_ARGUMENTS) carrying details", () => {
+  let caught;
+  try {
+    rejectInvalidArguments("boom", { code: "x", path: "/p" });
+  } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+  assert.equal(caught.message, "boom");
+  assert.equal(caught.details.path, "/p");
+});
+
+// --- escapeRegExp / decodePathSegments ---
+
+test("escapeRegExp escapes regex metacharacters", () => {
+  assert.equal(escapeRegExp("a.b+c"), "a\\.b\\+c");
+  assert.equal(escapeRegExp("/api/x"), "/api/x");
+});
+
+test("decodePathSegments recursively decodes each segment to a fixed point (<=8 passes)", () => {
+  assert.equal(decodePathSegments("/api/%2564elete/1"), "/api/delete/1"); // %2564 -> %64 -> d
+  assert.equal(decodePathSegments("/api/accounts/known"), "/api/accounts/known"); // no-op
+});
+
+// --- capturedIdSegmentIsSafe ---
+
+test("capturedIdSegmentIsSafe accepts clean ids (incl. dotted) and rejects separators/punctuation at any depth", () => {
+  for (const ok of ["known", "user.name", "1.2.3", "file.bin", "550e8400-e29b-41d4-a716-446655440000"]) {
+    assert.equal(capturedIdSegmentIsSafe(ok), true, `${ok} should be safe`);
+  }
+  for (const bad of [
+    "a/b", "a\\b", "a:b", "a;b", "a,b",
+    "known%2Fdelete", "known%252Fdelete", "known%2525252Fdelete", "known%25%32%46delete",
+    "known%5Cdelete", "known%3Acapture",
+  ]) {
+    assert.equal(capturedIdSegmentIsSafe(bad), false, `${bad} should be unsafe`);
+  }
+  assert.equal(capturedIdSegmentIsSafe(""), false);
+  // DOCUMENTED RESIDUAL (see capturedIdSegmentIsSafe comment): a dot-action suffix
+  // in a RECORDED id is treated SAFE because real ids legitimately contain dots.
+  // Pinned here so a future tightening is a deliberate, test-visible change.
+  assert.equal(capturedIdSegmentIsSafe("pay_123.capture"), true);
+});
+
+// --- pathTemplateMatchesEndpoint ---
+
+test("pathTemplateMatchesEndpoint matches single-{id} templates and rejects shape/segment mismatches", () => {
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}", "/api/accounts/known"), true);
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}", "/api/users/known"), false);
+  // captured segment routes to a sub-resource/action -> unsafe -> no match
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}", "/api/accounts/known%2Fdelete"), false);
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}", "/api/accounts/known:capture"), false);
+  // {id} that matched a multi-segment span is rejected by the [^/]+ capture
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}", "/api/accounts/a/b"), false);
+  // a template without exactly one {id} slot never matches
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/{id}/{id}", "/api/accounts/a/b"), false);
+  assert.equal(pathTemplateMatchesEndpoint("/api/accounts/x", "/api/accounts/x"), false);
+});
+
+// --- assertReadOnlyPath / normalizePathTemplate relocation guards ---
+
+test("assertReadOnlyPath (from common) rejects destructive verb collections, allows noun reads", () => {
+  assert.doesNotThrow(() => assertReadOnlyPath("https://t.example.test/api/order/123"));
+  assert.throws(() => assertReadOnlyPath("https://t.example.test/api/delete/123"), /state-changing path segment/);
+  assert.throws(() => assertReadOnlyPath("https://t.example.test/api/%2564elete/123"), /state-changing path segment/);
+});
+
+test("normalizePathTemplate (from common) enforces the {id}-final-segment structural boundary", () => {
+  assert.equal(normalizePathTemplate("/api/accounts/{id}"), "/api/accounts/{id}");
+  assert.doesNotThrow(() => normalizePathTemplate("/api/accounts/{id}.json"));
+  assert.throws(() => normalizePathTemplate("/api/accounts/{id}/transfer"), /final path segment/);
+  assert.throws(() => normalizePathTemplate("/api/accounts/{id}.capture"), /final path segment/);
+  assert.throws(() => normalizePathTemplate("/api/accounts/{id}?fields=all"), /query string/);
+});
+
+// --- candidateSurfaceEndpoints ---
+
+test("candidateSurfaceEndpoints yields uri then string endpoints in order, skipping blank/non-string", () => {
+  assert.deepEqual(
+    candidateSurfaceEndpoints({ uri: "https://x/api", endpoints: ["https://x/a", "", 7, "https://x/b"] }),
+    [
+      { value: "https://x/api", field: "surface.uri" },
+      { value: "https://x/a", field: "surface.endpoints[0]" },
+      { value: "https://x/b", field: "surface.endpoints[3]" },
+    ],
+  );
+  assert.deepEqual(candidateSurfaceEndpoints({ endpoints: [] }), []);
+  assert.deepEqual(candidateSurfaceEndpoints(null), []);
+  assert.deepEqual(candidateSurfaceEndpoints({}), []);
+});
+
+// --- resolveSurfaceOrigins ---
+
+test("resolveSurfaceOrigins dedupes stateOrigin + endpoint origins + host-derived origins", () => {
+  const origins = resolveSurfaceOrigins({
+    uri: "https://api.example.test/v1",
+    endpoints: ["https://api.example.test/v1/x", "mailto:a@b.test", "::: not a url"],
+    hosts: ["edge.example.test", "https://api.example.test"],
+  }, "https://api.example.test");
+  assert.equal(origins[0], "https://api.example.test"); // stateOrigin first
+  assert.ok(origins.includes("https://edge.example.test")); // bare host, https from stateOrigin protocol
+  // dedupe: api.example.test appears via stateOrigin, uri, endpoint, and host -> once
+  assert.equal(origins.filter((o) => o === "https://api.example.test").length, 1);
+  // mailto / garbage endpoints contribute no origin
+  assert.equal(origins.some((o) => o.startsWith("mailto")), false);
+});
+
+test("resolveSurfaceOrigins derives host origins with http when stateOrigin is http", () => {
+  const origins = resolveSurfaceOrigins({ hosts: ["edge.example.test"] }, "http://api.example.test:8080");
+  assert.ok(origins.includes("http://edge.example.test"));
+});
+
+// --- isAuthChallenge / isLoginRedirect / responseLooksLikeLoginPage ---
+
+test("isAuthChallenge is true only for 401/403", () => {
+  assert.equal(isAuthChallenge({ status: 401 }), true);
+  assert.equal(isAuthChallenge({ status: 403 }), true);
+  assert.equal(isAuthChallenge({ status: 200 }), false);
+  assert.ok(!isAuthChallenge(null));
+  assert.ok(!isAuthChallenge(undefined));
+});
+
+test("isLoginRedirect matches auth-shaped 3xx Location only", () => {
+  assert.equal(isLoginRedirect(mockResponse(302, "", { location: "/login?next=/x" })), true);
+  assert.equal(isLoginRedirect(mockResponse(303, "", { location: "https://sso.example.test/" })), true);
+  assert.equal(isLoginRedirect(mockResponse(302, "", { location: "/dashboard" })), false);
+  assert.equal(isLoginRedirect(mockResponse(200, "", { location: "/login" })), false);
+  assert.equal(isLoginRedirect(null), false);
+  assert.equal(isLoginRedirect({ status: 302 }), false); // no headers.get
+});
+
+test("responseLooksLikeLoginPage needs html/text + a form + a login keyword", () => {
+  assert.equal(responseLooksLikeLoginPage(mockResponse(200, "<form><input name=password></form>", { "content-type": "text/html" })), true);
+  assert.equal(responseLooksLikeLoginPage(mockResponse(200, "<form><input name=q></form>", { "content-type": "text/html" })), false);
+  assert.equal(responseLooksLikeLoginPage(mockResponse(200, "<form>password</form>", { "content-type": "application/json" })), false);
+  assert.equal(responseLooksLikeLoginPage({ status: 200, headers: { get: () => "text/html" }, bodyBytes: "not a buffer" }), false);
+});
+
+// --- isResourceShapedResponse relocation smoke ---
+
+test("isResourceShapedResponse smoke: recognizes a genuine JSON resource, rejects soft-404 + empty collection", () => {
+  assert.equal(isResourceShapedResponse(mockResponse(200, "{\"id\":7,\"email\":\"a@b.test\"}", { "content-type": "application/json" })), true);
+  assert.equal(isResourceShapedResponse(mockResponse(200, "{\"error\":\"not found\"}", { "content-type": "application/json" })), false);
+  assert.equal(isResourceShapedResponse(mockResponse(200, "{\"items\":[],\"total\":0,\"page\":1}", { "content-type": "application/json" })), false);
+  assert.equal(isResourceShapedResponse(mockResponse(401, "{\"id\":7}", { "content-type": "application/json" })), false);
+});
+
+// --- findRoutedSurface (I/O) ---
+
+test("findRoutedSurface returns the routed surface and throws on an unknown id", () => withTempHome(() => {
+  const domain = "common-find.example.test";
+  const surfaceId = "surface:accounts";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedRoutedSurface(domain, surfaceId, `https://${domain}/api/accounts/known`);
+
+  const { route, surface } = findRoutedSurface(domain, surfaceId);
+  assert.equal(route.surface_id, surfaceId);
+  assert.equal(surface.id, surfaceId);
+
+  let caught;
+  try { findRoutedSurface(domain, "surface:does-not-exist"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+  assert.match(caught.message, /unknown or unrouted surface_id surface:does-not-exist/);
+}));
+
+// --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---
+
+test("originFromState returns the in-scope origin and rejects a missing/invalid target_url", () => withTempHome(() => {
+  const domain = "common-origin.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  assert.equal(originFromState(domain, { target_url: `https://${domain}/app` }), `https://${domain}`);
+  assert.throws(() => originFromState(domain, {}), /requires a web session with target_url/);
+  assert.throws(() => originFromState(domain, { target_url: "not a url" }), /not a valid URL/);
+}));
+
+test("urlFromEndpoint resolves absolute URLs and absolute paths, rejects bare tokens", () => {
+  assert.equal(urlFromEndpoint("https://x.test/api", "https://x.test", "f").toString(), "https://x.test/api");
+  assert.equal(urlFromEndpoint("/api/y", "https://x.test", "f").toString(), "https://x.test/api/y");
+  assert.throws(() => urlFromEndpoint("api/y", "https://x.test", "f"), /must be an absolute http\(s\) URL or an absolute path/);
+});
+
+test("resolveBaselineFromSurface resolves a query-free baseline that matches the template, else throws", () => withTempHome(() => {
+  const domain = "common-baseline.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  const { state } = readSessionStateStrict(domain);
+  const surface = { id: "s", hosts: [domain], endpoints: [`https://${domain}/api/accounts/known?fields=all`] };
+
+  const baseline = resolveBaselineFromSurface({ domain, surface, pathTemplate: "/api/accounts/{id}", state });
+  // recorded query is dropped for baseline/target symmetry
+  assert.equal(baseline.toString(), `https://${domain}/api/accounts/known`);
+  assert.equal(baseline.search, "");
+
+  assert.throws(
+    () => resolveBaselineFromSurface({ domain, surface, pathTemplate: "/api/users/{id}", state }),
+    /path shape does not match any recorded endpoint for surface_id/,
+  );
+}));
+
+// --- SCOPE_VALIDATION_OPTS export contract ---
+
+test("SCOPE_VALIDATION_OPTS is the frozen intentional-no-internal-host-block sentinel", () => {
+  assert.deepEqual(SCOPE_VALIDATION_OPTS, { blockInternalHosts: false });
+  assert.equal(Object.isFrozen(SCOPE_VALIDATION_OPTS), true);
+});

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -24,10 +24,12 @@ const {
   isLoginRedirect,
   responseLooksLikeLoginPage,
   isResourceShapedResponse,
+  auditConfirmRequest,
   assertNoForbiddenInputs,
   SCOPE_VALIDATION_OPTS,
 } = require("../mcp/lib/offensive-http-common.js");
 const { ERROR_CODES } = require("../mcp/lib/envelope.js");
+const { readHttpAuditRecordsFromJsonl } = require("../mcp/lib/http-records.js");
 const { routeSurfaces } = require("../mcp/lib/surface-router.js");
 const { initSession } = require("../mcp/lib/session-state.js");
 const { readSessionStateStrict } = require("../mcp/lib/session-state-store.js");
@@ -134,6 +136,13 @@ test("assertNoForbiddenInputs guard semantics: nullish args are safe, hasOwnProp
   assert.throws(() => assertNoForbiddenInputs({ url: "" }, "bob_http_confirm"), /does not accept url/);
   // extraFields defaults to [] — only the base list applies when omitted
   assert.doesNotThrow(() => assertNoForbiddenInputs({ object_id: "x" }, "bob_http_confirm"));
+  // a non-array extraFields is a mis-wiring that would silently weaken the guard
+  // (a string spreads into single chars, dropping the intended extra field) — it
+  // must fail fast, not degrade security quietly.
+  assert.throws(
+    () => assertNoForbiddenInputs({}, "bob_http_idor_confirm", "object_id"),
+    /forbidden-input guard misconfigured: extraFields must be an array/,
+  );
 });
 
 // --- rejectInvalidArguments ---
@@ -334,6 +343,40 @@ test("resolveBaselineFromSurface resolves a query-free baseline that matches the
     () => resolveBaselineFromSurface({ domain, surface, pathTemplate: "/api/users/{id}", state }),
     /path shape does not match any recorded endpoint for surface_id/,
   );
+}));
+
+// --- auditConfirmRequest (parameterized toolId attribution) ---
+
+test("auditConfirmRequest writes a breaker-visible record under any toolId and never throws", () => withTempHome(() => {
+  const domain = "common-audit.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  // The point of the parameterized toolId is per-tool attribution; note that
+  // normalizeHttpAuditRecord does NOT persist a `tool` field, so a future producer
+  // passing a different toolId (or omitting it) yields a BYTE-IDENTICAL persisted
+  // record — circuit-breaker / request-budget visibility comes from the record's
+  // existence + surface_id/status/url, never from `tool`. The toolId's only
+  // observable effect is the stderr diagnostic on an audit-write failure.
+  auditConfirmRequest({
+    domain,
+    surfaceId: "surface:accounts",
+    method: "GET",
+    url: `https://${domain}/api/accounts/known`,
+    egressProfile: "default",
+    status: 200,
+    startedAt: 1,
+    toolId: "bob_http_idor_confirm",
+  });
+  const records = readHttpAuditRecordsFromJsonl(domain).filter((r) => r.surface_id === "surface:accounts");
+  assert.equal(records.length, 1, "the probe must be recorded for circuit-breaker visibility");
+  assert.equal(records[0].method, "GET");
+  assert.equal(records[0].status, 200);
+  // a successful probe records scope_decision "allowed" (a null would make
+  // normalizeHttpAuditRecord throw and silently drop the breaker-visibility record)
+  assert.equal(records[0].scope_decision, "allowed");
+  // `tool` is normalized out — a missing toolId cannot make a probe invisible
+  assert.equal(Object.prototype.hasOwnProperty.call(records[0], "tool"), false);
+  // defensive audit contract: never throws even with no domain / no toolId
+  assert.doesNotThrow(() => auditConfirmRequest({ domain: null }));
 }));
 
 // --- SCOPE_VALIDATION_OPTS export contract ---


### PR DESCRIPTION
## What

PR-B of the offensive build sequence: extract the reusable HTTP/surface primitives out of `mcp/lib/offensive-confirmer.js` into a new shared module **`mcp/lib/offensive-http-common.js`**, so the forthcoming `bob_http_idor_confirm` second-identity IDOR producer (PR-C) reuses the same security-reviewed logic rather than forking it.

**Inert refactor.** No new tool, no generator/registry change, no live-mint path, no behavior change.

## Scope

Follows the authoritative §11 PR-B extraction table in `docs/OFFENSIVE_IDOR_PRODUCER_PLAN.md` / `docs/IDOR_PRODUCER_DESIGN_V2.md` (which is broader than a literal "6 helpers" — it includes the `resolveBaselineFromSurface`, response-classification, and `assertReadOnlyPath`/`normalizePathTemplate`/`auditConfirmRequest` clusters, because PR-C is sequenced to *import* them and under-extracting now forces a second refactor of the same file).

**Moved (verbatim, comments included):** `rejectInvalidArguments`, `decodePathSegments`, `escapeRegExp`, `capturedIdSegmentIsSafe`, `pathTemplateMatchesEndpoint`, `assertReadOnlyPath`, `normalizePathTemplate`, `findRoutedSurface`, `candidateSurfaceEndpoints`, `resolveSurfaceOrigins`, `originFromState`, `urlFromEndpoint`, `resolveBaselineFromSurface`, `isAuthChallenge`, `isLoginRedirect`, `responseLooksLikeLoginPage`, `isResourceShapedResponse` (+ its private classification cluster), `auditConfirmRequest`, `assertNoForbiddenInputs`, and the regex/keyset consts.

**Two intended parameterizations (the only non-verbatim changes):**
- `assertNoForbiddenInputs(args, toolName, extraFields=[])` — shared 8-field base denylist + per-tool extras; `${toolName}` in the message. Confirmer passes `"bob_http_confirm"` + no extras → **byte-identical message**.
- `auditConfirmRequest({…, toolId})` — `tool: toolId` and `${toolId}: http-audit write failed:`. Confirmer passes `toolId: TOOL_ID` at all 3 sites → **byte-identical audit record**.

**Stays in the confirmer:** `resolveConfirmSurface`, `classifyDifferential` (negative-only), `httpConfirm`, `syntheticResourceId`, method/oracle normalizers, the top consts. `module.exports` is **byte-identical** (`assertReadOnlyPath`/`normalizePathTemplate`/`isResourceShapedResponse` re-exported from common), so the test imports + tool wrapper are unaffected.

## Deferred to PR-C (flagged)

The §11 table also lists a **net-new** `responseIsSharedCacheable`. It is intentionally **not** added here — it is new cache-discrimination logic with no confirmer caller and no confirmer test, so it belongs with its consumer + the §3.4 cache tests in the producer PR. Adding it now would violate PR-B's "extraction, no behavior change" contract.

## Why no cycle

`offensive-http-common.js` imports only `envelope`, `surface-router`, `frontier-projections`, `safe-fetch`, `validation`, `http-records`, `../redaction` — none of which transitively require the offensive layer (confirmed: `offensive-confirmer.js` is required only by its tool wrapper + test). The edge `offensive-confirmer → offensive-http-common` is one-way.

## Tests

- New `test/offensive-http-common.test.js` (22 cases): unit-tests every moved helper directly, including the **parameterization payoff** (a different `toolName` + `extraFields` drive the rejection) and **byte-identical back-compat** (`bob_http_confirm` message for each base field), plus the documented dot-action `capturedIdSegmentIsSafe` residual.
- Registered in `test/mcp-test-manifest.json`.
- Green: `check:syntax`, `test:mcp` (2508/0), `check:authority-inventory`, `test:prompts` (181/0), `test:package` (clean checkout 20/0), `test:install`/`update`/`cli`/`adapter-detection`/`policy-replay`/`hooks` (55/55). The existing confirmer suite is unchanged and green (proves behavior-identity end-to-end via `executeTool`).

Verified byte-identity with an adversarial multi-agent diff of every moved/retained symbol against `HEAD`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP probing safety, surface targeting, and response-shaping heuristics into a shared module used by the offensive confirmer flow for consistent behavior.

* **Tests**
  * Added comprehensive automated tests for argument guarding, URL/path safety checks, surface/origin resolution, login/redirect detection, resource-shaped response classification, and audit logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->