### PR TITLE
refactor(offense): extract hardened offensive-runs capture/sign writer into shared module

### DIFF
--- a/mcp/lib/offensive-capture-writer.js
+++ b/mcp/lib/offensive-capture-writer.js
@@ -1,0 +1,235 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const {
+  ERROR_CODES,
+  ToolError,
+} = require("./envelope.js");
+const {
+  readOffensiveRunRecords,
+} = require("./claims.js");
+const {
+  signOffensiveRunRow,
+} = require("./offensive-row-mac.js");
+const {
+  readHandoffSigningKey,
+} = require("./handoff-signing-key.js");
+const {
+  offensiveRunsDir,
+  offensiveRunsJsonlPath,
+  sessionsRoot,
+  assertSafeDomain,
+} = require("./paths.js");
+const {
+  canonicalJson,
+} = require("./verification-contracts.js");
+
+// run_id is a single clean [A-Za-z0-9-] segment so sha256OffensiveCaptureSecure
+// (claim-freeze.js) accepts it as a direct child leaf of offensive-runs/.
+function newRunId(prefix) {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function commandHashOf(method, canonicalTarget, identityTag) {
+  return crypto
+    .createHash("sha256")
+    .update(canonicalJson({ method, canonical_target: canonicalTarget, identity_tag: identityTag }))
+    .digest("hex");
+}
+
+function sha256OfFileFd(realLeaf) {
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  if (!noFollow) {
+    const lst = fs.lstatSync(realLeaf);
+    if (lst.isSymbolicLink()) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must not be a symlink: ${realLeaf}`);
+    }
+  }
+  let fd = null;
+  try {
+    fd = fs.openSync(realLeaf, fs.constants.O_RDONLY | noFollow);
+    const stats = fs.fstatSync(fd);
+    if (!stats.isFile()) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must be a regular file: ${realLeaf}`);
+    }
+    if (stats.nlink !== 1) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must not be hard-linked: ${realLeaf}`);
+    }
+    return crypto.createHash("sha256").update(fs.readFileSync(fd)).digest("hex");
+  } finally {
+    if (fd != null) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+}
+
+// Securely realpath-resolve the capture dir the way readOffensiveRunRecords /
+// sha256OffensiveCaptureSecure do (anchored to the real sessions root + safe
+// domain), so a symlinked offensive-runs/ or session dir is rejected, not
+// followed. Returns the real capture dir; creates it under the nominal dir first.
+function resolveCaptureDirSecure(domain) {
+  const nominalDir = offensiveRunsDir(domain);
+  const nominalParent = path.dirname(nominalDir);
+  const realRoot = fs.realpathSync(sessionsRoot());
+  const expectedParent = path.join(realRoot, assertSafeDomain(domain));
+  // Create + verify the SESSION dir BEFORE creating offensive-runs/ under it: a
+  // recursive mkdir would otherwise FOLLOW a symlinked session dir and plant the
+  // capture dir at the link target. Checking the parent first means children are
+  // never created under a symlinked parent (the post-mkdir realpath check below is
+  // kept as a second line for a symlinked offensive-runs/ leaf itself).
+  fs.mkdirSync(nominalParent, { recursive: true });
+  if (fs.realpathSync(nominalParent) !== expectedParent) {
+    throw new ToolError(
+      ERROR_CODES.STATE_CONFLICT,
+      `offensive-runs session dir must stay inside its session root without symlinks: ${nominalParent}`,
+    );
+  }
+  fs.mkdirSync(nominalDir, { recursive: true });
+  const expectedDir = path.join(expectedParent, "offensive-runs");
+  const realDir = fs.realpathSync(nominalDir);
+  if (realDir !== expectedDir) {
+    throw new ToolError(
+      ERROR_CODES.STATE_CONFLICT,
+      `offensive-runs capture dir must stay inside its session root without symlinks: ${nominalDir}`,
+    );
+  }
+  return realDir;
+}
+
+// Write a capture leaf exclusively (O_NOFOLLOW via wx on a fresh path), then
+// realpath/O_NOFOLLOW/nlink-recompute its on-disk sha256 — the recomputed hash
+// (NOT an in-memory string) is what binds into the row, byte-identical to what
+// projectExploitRunObservedRef re-hashes at freeze.
+function writeCaptureAndHash(captureDir, runId, suffix, contentBytes) {
+  const leaf = path.join(captureDir, `${runId}.${suffix}`);
+  // Exclusive create defeats a pre-planted symlink at the leaf path.
+  const fd = fs.openSync(leaf, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+  try {
+    fs.writeFileSync(fd, contentBytes);
+    fs.fsyncSync(fd);
+  } finally {
+    try { fs.closeSync(fd); } catch {}
+  }
+  return sha256OfFileFd(leaf);
+}
+
+// Append one complete JSON line atomically. Single O_APPEND write of `${line}\n`
+// so readOffensiveRunRecords (fail-closed on a partial line) never sees a torn
+// record. Realpath/O_NOFOLLOW/nlink discipline on the ledger leaf.
+function appendSignedRowHardened(domain, row) {
+  const nominalPath = offensiveRunsJsonlPath(domain);
+  const nominalDir = path.dirname(nominalPath);
+  fs.mkdirSync(nominalDir, { recursive: true });
+  const realRoot = fs.realpathSync(sessionsRoot());
+  const expectedDir = path.join(realRoot, assertSafeDomain(domain));
+  const realDir = fs.realpathSync(nominalDir);
+  if (realDir !== expectedDir) {
+    throw new ToolError(
+      ERROR_CODES.STATE_CONFLICT,
+      `offensive-runs.jsonl directory must stay inside its session root without domain-directory symlinks: ${nominalDir}`,
+    );
+  }
+  const realLeaf = path.join(realDir, "offensive-runs.jsonl");
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  if (!noFollow && fs.existsSync(realLeaf)) {
+    const lst = fs.lstatSync(realLeaf);
+    if (lst.isSymbolicLink()) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must not be a symlink: ${realLeaf}`);
+    }
+  }
+  const line = `${JSON.stringify(row)}\n`;
+  let fd = null;
+  try {
+    fd = fs.openSync(realLeaf, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | noFollow, 0o600);
+    const stats = fs.fstatSync(fd);
+    if (!stats.isFile()) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must be a regular file: ${realLeaf}`);
+    }
+    if (stats.nlink !== 1) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must not be hard-linked: ${realLeaf}`);
+    }
+    fs.writeSync(fd, line);
+    fs.fsyncSync(fd);
+  } finally {
+    if (fd != null) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+}
+
+// Build + sign + persist the offensive row. Captures FIRST, recompute the THREE
+// hashes from on-disk bytes, build the 14-field row, sign LAST, atomic append.
+// Returns the persisted row (signed). Caller wraps in withSessionLock.
+function buildAndSignOffensiveRow(domain, {
+  runIdPrefix,
+  toolId,
+  demonstratedSeverity,
+  method,
+  canonicalTarget,
+  surfaceId,
+  identityTag,
+  stdoutContent,
+  stderrContent,
+  relationBooleans = {},
+}) {
+  const runId = newRunId(runIdPrefix);
+
+  // run_id single-use guard (mint condition #25): refuse to re-emit a run_id
+  // already present in offensive-runs.jsonl this session.
+  const existing = readOffensiveRunRecords(domain);
+  for (const r of existing) {
+    if (r && r.run_id === runId) {
+      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive run_id collision (refusing to re-emit): ${runId}`);
+    }
+  }
+
+  const captureDir = resolveCaptureDirSecure(domain);
+  // STEP 1 — write captures FIRST (audit-graded #115; MCP-owned, agents cannot Write here).
+  const stdoutBytes = Buffer.from(stdoutContent, "utf8");
+  const stderrBytes = Buffer.from(stderrContent, "utf8");
+  // STEP 2 — recompute the THREE hashes FROM THE ON-DISK CAPTURE BYTES.
+  const stdoutHash = writeCaptureAndHash(captureDir, runId, "stdout", stdoutBytes);
+  const stderrHash = writeCaptureAndHash(captureDir, runId, "stderr", stderrBytes);
+  const commandHash = commandHashOf(method, canonicalTarget, identityTag);
+
+  // STEP 3 — build the 14-field row + optional MAC-covered relation booleans
+  // (honest self-documentation, NOT a soundness control). demonstrated_severity
+  // is HARDCODED from the producer ceiling, never agent-supplied/content-derived.
+  const row = {
+    version: 1,
+    target_domain: domain,
+    run_id: runId,
+    tool_id: toolId,
+    target: canonicalTarget,
+    offensive_outcome: "exploited_safely",
+    dry_run: false,
+    timed_out: false,
+    command_hash: commandHash,
+    exit_code: 0,
+    stdout_hash: stdoutHash,
+    stderr_hash: stderrHash,
+    demonstrated_severity: demonstratedSeverity,
+    surface_id: surfaceId,
+    ...relationBooleans,
+  };
+
+  // STEP 4 — sign LAST (whole-row MAC auto-binds the relation booleans).
+  signOffensiveRunRow(row, readHandoffSigningKey(domain));
+
+  // APPEND — MCP-owned hardened writer.
+  appendSignedRowHardened(domain, row);
+
+  return row;
+}
+
+module.exports = {
+  newRunId,
+  commandHashOf,
+  resolveCaptureDirSecure,
+  writeCaptureAndHash,
+  appendSignedRowHardened,
+  buildAndSignOffensiveRow,
+};

--- a/mcp/lib/offensive-capture-writer.js
+++ b/mcp/lib/offensive-capture-writer.js
@@ -10,6 +10,7 @@ const {
 } = require("./envelope.js");
 const {
   readOffensiveRunRecords,
+  OFFENSIVE_TOOL_DEMONSTRATED_CEILING,
 } = require("./claims.js");
 const {
   signOffensiveRunRow,
@@ -176,11 +177,16 @@ function appendSignedRowHardened(domain, row) {
 
 // Build + sign + persist the offensive row. Captures FIRST, recompute the THREE
 // hashes from on-disk bytes, build the 14-field row, sign LAST, atomic append.
-// Returns the persisted row (signed). Caller wraps in withSessionLock.
+// Returns the persisted row (signed).
+//
+// CONCURRENCY CONTRACT: the run_id single-use guard (read-then-append) is only
+// race-safe under the per-session lock, so the caller MUST invoke this inside
+// withSessionLock(domain) (the IDOR producer does). Moving the lock into this
+// primitive is the planned hardening for the next producer (it needs a re-entrancy
+// check across both call sites); until then the contract is stated.
 function buildAndSignOffensiveRow(domain, {
   runIdPrefix,
   toolId,
-  demonstratedSeverity,
   method,
   canonicalTarget,
   surfaceId,
@@ -200,15 +206,33 @@ function buildAndSignOffensiveRow(domain, {
       `runIdPrefix must be a lowercase [a-z][a-z0-9]* token: ${runIdPrefix}`,
     );
   }
-  // relationBooleans is spread into the row LAST (to document extra legs), so it
-  // must not be able to override a reserved proof-contract field before signing —
-  // otherwise a caller could clobber demonstrated_severity / *_hash / outcome on
-  // the MAC-signed row.
-  for (const key of Object.keys(relationBooleans)) {
+  // demonstrated_severity is DERIVED from the per-tool registry, NEVER accepted from
+  // the caller — a producer cannot drift its signed severity by convention, and an
+  // unregistered tool_id cannot mint a row at all (fail-closed; stronger than the
+  // record gate's ?? "info" cap, which still applies downstream).
+  const demonstratedSeverity = OFFENSIVE_TOOL_DEMONSTRATED_CEILING[toolId];
+  if (typeof demonstratedSeverity !== "string" || !demonstratedSeverity) {
+    throw new ToolError(
+      ERROR_CODES.INVALID_ARGUMENTS,
+      `unknown offensive tool_id (absent from the demonstrated-severity registry): ${toolId}`,
+    );
+  }
+  // relationBooleans is spread into the row LAST (to document extra legs). It is
+  // MAC-covered proof material, not a free-form bag, so it must neither override a
+  // reserved proof-contract field NOR carry a non-boolean value — otherwise a caller
+  // could clobber demonstrated_severity / *_hash / outcome, or smuggle arbitrary
+  // signed data, before the MAC.
+  for (const [key, value] of Object.entries(relationBooleans)) {
     if (RESERVED_ROW_KEYS.has(key)) {
       throw new ToolError(
         ERROR_CODES.INVALID_ARGUMENTS,
         `relationBooleans may not override reserved offensive-row field: ${key}`,
+      );
+    }
+    if (typeof value !== "boolean") {
+      throw new ToolError(
+        ERROR_CODES.INVALID_ARGUMENTS,
+        `relationBooleans.${key} must be a boolean (MAC-covered proof material), got ${typeof value}`,
       );
     }
   }

--- a/mcp/lib/offensive-capture-writer.js
+++ b/mcp/lib/offensive-capture-writer.js
@@ -27,6 +27,14 @@ const {
   canonicalJson,
 } = require("./verification-contracts.js");
 
+// The proof-contract fields buildAndSignOffensiveRow controls; relationBooleans
+// may never override any of these before the row is signed.
+const RESERVED_ROW_KEYS = new Set([
+  "version", "target_domain", "run_id", "tool_id", "target", "offensive_outcome",
+  "dry_run", "timed_out", "command_hash", "exit_code", "stdout_hash", "stderr_hash",
+  "demonstrated_severity", "surface_id", "row_mac",
+]);
+
 // run_id is a single clean [A-Za-z0-9-] segment so sha256OffensiveCaptureSecure
 // (claim-freeze.js) accepts it as a direct child leaf of offensive-runs/.
 function newRunId(prefix) {
@@ -105,8 +113,14 @@ function resolveCaptureDirSecure(domain) {
 // projectExploitRunObservedRef re-hashes at freeze.
 function writeCaptureAndHash(captureDir, runId, suffix, contentBytes) {
   const leaf = path.join(captureDir, `${runId}.${suffix}`);
-  // Exclusive create defeats a pre-planted symlink at the leaf path.
-  const fd = fs.openSync(leaf, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+  // Exclusive create + O_NOFOLLOW defeats a pre-planted symlink at the leaf path
+  // (O_EXCL already fails on an existing link; O_NOFOLLOW makes the intent explicit
+  // and matches sha256OfFileFd / appendSignedRowHardened).
+  const fd = fs.openSync(
+    leaf,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0),
+    0o600,
+  );
   try {
     fs.writeFileSync(fd, contentBytes);
     fs.fsyncSync(fd);
@@ -175,6 +189,30 @@ function buildAndSignOffensiveRow(domain, {
   stderrContent,
   relationBooleans = {},
 }) {
+  // runIdPrefix flows into the capture-file path (newRunId -> path.join), so a
+  // generic caller must not be able to smuggle a traversal segment into the
+  // capture/ledger write. The IDOR producer hardcoded "idor-"; re-impose that
+  // single-clean-segment guarantee here for EVERY producer. (suffix is internal —
+  // only "stdout"/"stderr" — and the low-level helpers are no longer exported.)
+  if (typeof runIdPrefix !== "string" || !/^[a-z][a-z0-9]*$/.test(runIdPrefix)) {
+    throw new ToolError(
+      ERROR_CODES.INVALID_ARGUMENTS,
+      `runIdPrefix must be a lowercase [a-z][a-z0-9]* token: ${runIdPrefix}`,
+    );
+  }
+  // relationBooleans is spread into the row LAST (to document extra legs), so it
+  // must not be able to override a reserved proof-contract field before signing —
+  // otherwise a caller could clobber demonstrated_severity / *_hash / outcome on
+  // the MAC-signed row.
+  for (const key of Object.keys(relationBooleans)) {
+    if (RESERVED_ROW_KEYS.has(key)) {
+      throw new ToolError(
+        ERROR_CODES.INVALID_ARGUMENTS,
+        `relationBooleans may not override reserved offensive-row field: ${key}`,
+      );
+    }
+  }
+
   const runId = newRunId(runIdPrefix);
 
   // run_id single-use guard (mint condition #25): refuse to re-emit a run_id
@@ -225,11 +263,11 @@ function buildAndSignOffensiveRow(domain, {
   return row;
 }
 
+// Only the high-level build+sign+append entry point is public. The low-level
+// capture/hash/append helpers stay module-internal so a producer mints a signed
+// offensive-runs row ONLY through the disciplined build path — and a row is still
+// not a finding until a candidate claim cites it through the record-time proof
+// gate + per-tool demonstrated-severity ceiling + #111 surface binding.
 module.exports = {
-  newRunId,
-  commandHashOf,
-  resolveCaptureDirSecure,
-  writeCaptureAndHash,
-  appendSignedRowHardened,
   buildAndSignOffensiveRow,
 };

--- a/mcp/lib/offensive-idor-producer.js
+++ b/mcp/lib/offensive-idor-producer.js
@@ -90,20 +90,10 @@ const {
 } = require("./offensive-http-common.js");
 const {
   canonicalizeExploitTarget,
-  readOffensiveRunRecords,
 } = require("./claims.js");
 const {
-  signOffensiveRunRow,
-} = require("./offensive-row-mac.js");
-const {
-  readHandoffSigningKey,
-} = require("./handoff-signing-key.js");
-const {
-  offensiveRunsDir,
-  offensiveRunsJsonlPath,
-  sessionsRoot,
-  assertSafeDomain,
-} = require("./paths.js");
+  buildAndSignOffensiveRow,
+} = require("./offensive-capture-writer.js");
 const {
   resolveAuthProfile,
   buildHeaderProfile,
@@ -501,202 +491,6 @@ function assertSingleEndpointSingleHost(surface, stateOrigin) {
     );
   }
   return { endpoint: endpoints[0], origin: [...origins][0] };
-}
-
-// ── the signed-row builder + hardened capture writer ─────────────────────────
-
-// run_id is a single clean [A-Za-z0-9-] segment so sha256OffensiveCaptureSecure
-// (claim-freeze.js) accepts it as a direct child leaf of offensive-runs/.
-function newRunId() {
-  return `idor-${crypto.randomUUID()}`;
-}
-
-function commandHashOf(method, canonicalTarget, identityTag) {
-  return crypto
-    .createHash("sha256")
-    .update(canonicalJson({ method, canonical_target: canonicalTarget, identity_tag: identityTag }))
-    .digest("hex");
-}
-
-function sha256OfFileFd(realLeaf) {
-  const noFollow = fs.constants.O_NOFOLLOW || 0;
-  if (!noFollow) {
-    const lst = fs.lstatSync(realLeaf);
-    if (lst.isSymbolicLink()) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must not be a symlink: ${realLeaf}`);
-    }
-  }
-  let fd = null;
-  try {
-    fd = fs.openSync(realLeaf, fs.constants.O_RDONLY | noFollow);
-    const stats = fs.fstatSync(fd);
-    if (!stats.isFile()) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must be a regular file: ${realLeaf}`);
-    }
-    if (stats.nlink !== 1) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive capture must not be hard-linked: ${realLeaf}`);
-    }
-    return crypto.createHash("sha256").update(fs.readFileSync(fd)).digest("hex");
-  } finally {
-    if (fd != null) {
-      try { fs.closeSync(fd); } catch {}
-    }
-  }
-}
-
-// Securely realpath-resolve the capture dir the way readOffensiveRunRecords /
-// sha256OffensiveCaptureSecure do (anchored to the real sessions root + safe
-// domain), so a symlinked offensive-runs/ or session dir is rejected, not
-// followed. Returns the real capture dir; creates it under the nominal dir first.
-function resolveCaptureDirSecure(domain) {
-  const nominalDir = offensiveRunsDir(domain);
-  const nominalParent = path.dirname(nominalDir);
-  const realRoot = fs.realpathSync(sessionsRoot());
-  const expectedParent = path.join(realRoot, assertSafeDomain(domain));
-  // Create + verify the SESSION dir BEFORE creating offensive-runs/ under it: a
-  // recursive mkdir would otherwise FOLLOW a symlinked session dir and plant the
-  // capture dir at the link target. Checking the parent first means children are
-  // never created under a symlinked parent (the post-mkdir realpath check below is
-  // kept as a second line for a symlinked offensive-runs/ leaf itself).
-  fs.mkdirSync(nominalParent, { recursive: true });
-  if (fs.realpathSync(nominalParent) !== expectedParent) {
-    throw new ToolError(
-      ERROR_CODES.STATE_CONFLICT,
-      `offensive-runs session dir must stay inside its session root without symlinks: ${nominalParent}`,
-    );
-  }
-  fs.mkdirSync(nominalDir, { recursive: true });
-  const expectedDir = path.join(expectedParent, "offensive-runs");
-  const realDir = fs.realpathSync(nominalDir);
-  if (realDir !== expectedDir) {
-    throw new ToolError(
-      ERROR_CODES.STATE_CONFLICT,
-      `offensive-runs capture dir must stay inside its session root without symlinks: ${nominalDir}`,
-    );
-  }
-  return realDir;
-}
-
-// Write a capture leaf exclusively (O_NOFOLLOW via wx on a fresh path), then
-// realpath/O_NOFOLLOW/nlink-recompute its on-disk sha256 — the recomputed hash
-// (NOT an in-memory string) is what binds into the row, byte-identical to what
-// projectExploitRunObservedRef re-hashes at freeze.
-function writeCaptureAndHash(captureDir, runId, suffix, contentBytes) {
-  const leaf = path.join(captureDir, `${runId}.${suffix}`);
-  // Exclusive create defeats a pre-planted symlink at the leaf path.
-  const fd = fs.openSync(leaf, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
-  try {
-    fs.writeFileSync(fd, contentBytes);
-    fs.fsyncSync(fd);
-  } finally {
-    try { fs.closeSync(fd); } catch {}
-  }
-  return sha256OfFileFd(leaf);
-}
-
-// Append one complete JSON line atomically. Single O_APPEND write of `${line}\n`
-// so readOffensiveRunRecords (fail-closed on a partial line) never sees a torn
-// record. Realpath/O_NOFOLLOW/nlink discipline on the ledger leaf.
-function appendSignedRowHardened(domain, row) {
-  const nominalPath = offensiveRunsJsonlPath(domain);
-  const nominalDir = path.dirname(nominalPath);
-  fs.mkdirSync(nominalDir, { recursive: true });
-  const realRoot = fs.realpathSync(sessionsRoot());
-  const expectedDir = path.join(realRoot, assertSafeDomain(domain));
-  const realDir = fs.realpathSync(nominalDir);
-  if (realDir !== expectedDir) {
-    throw new ToolError(
-      ERROR_CODES.STATE_CONFLICT,
-      `offensive-runs.jsonl directory must stay inside its session root without domain-directory symlinks: ${nominalDir}`,
-    );
-  }
-  const realLeaf = path.join(realDir, "offensive-runs.jsonl");
-  const noFollow = fs.constants.O_NOFOLLOW || 0;
-  if (!noFollow && fs.existsSync(realLeaf)) {
-    const lst = fs.lstatSync(realLeaf);
-    if (lst.isSymbolicLink()) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must not be a symlink: ${realLeaf}`);
-    }
-  }
-  const line = `${JSON.stringify(row)}\n`;
-  let fd = null;
-  try {
-    fd = fs.openSync(realLeaf, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | noFollow, 0o600);
-    const stats = fs.fstatSync(fd);
-    if (!stats.isFile()) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must be a regular file: ${realLeaf}`);
-    }
-    if (stats.nlink !== 1) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive-runs.jsonl must not be hard-linked: ${realLeaf}`);
-    }
-    fs.writeSync(fd, line);
-    fs.fsyncSync(fd);
-  } finally {
-    if (fd != null) {
-      try { fs.closeSync(fd); } catch {}
-    }
-  }
-}
-
-// Build + sign + persist the offensive row. Captures FIRST, recompute the THREE
-// hashes from on-disk bytes, build the 14-field row, sign LAST, atomic append.
-// Returns the persisted row (signed). Caller wraps in withSessionLock.
-function buildSignedOffensiveRunRow(domain, {
-  method,
-  canonicalTarget,
-  surfaceId,
-  p2BodyForCapture,
-  diagnosticBundle,
-  relationBooleans,
-}) {
-  const runId = newRunId();
-
-  // run_id single-use guard (mint condition #25): refuse to re-emit a run_id
-  // already present in offensive-runs.jsonl this session.
-  const existing = readOffensiveRunRecords(domain);
-  for (const r of existing) {
-    if (r && r.run_id === runId) {
-      throw new ToolError(ERROR_CODES.STATE_CONFLICT, `offensive run_id collision (refusing to re-emit): ${runId}`);
-    }
-  }
-
-  const captureDir = resolveCaptureDirSecure(domain);
-  // STEP 1 — write captures FIRST (audit-graded #115; MCP-owned, agents cannot Write here).
-  const stdoutBytes = Buffer.from(p2BodyForCapture, "utf8");
-  const stderrBytes = Buffer.from(diagnosticBundle, "utf8");
-  // STEP 2 — recompute the THREE hashes FROM THE ON-DISK CAPTURE BYTES.
-  const stdoutHash = writeCaptureAndHash(captureDir, runId, "stdout", stdoutBytes);
-  const stderrHash = writeCaptureAndHash(captureDir, runId, "stderr", stderrBytes);
-  const commandHash = commandHashOf(method, canonicalTarget, "B-as-A");
-
-  // STEP 3 — build the 14-field row + optional MAC-covered relation booleans
-  // (honest self-documentation, NOT a soundness control). demonstrated_severity
-  // is HARDCODED from the producer ceiling, never agent-supplied/content-derived.
-  const row = {
-    version: 1,
-    target_domain: domain,
-    run_id: runId,
-    tool_id: TOOL_ID,
-    target: canonicalTarget,
-    offensive_outcome: "exploited_safely",
-    dry_run: false,
-    timed_out: false,
-    command_hash: commandHash,
-    exit_code: 0,
-    stdout_hash: stdoutHash,
-    stderr_hash: stderrHash,
-    demonstrated_severity: IDOR_ORACLE_DEMONSTRATED_CEILING.differential_response,
-    surface_id: surfaceId,
-    ...relationBooleans,
-  };
-
-  // STEP 4 — sign LAST (whole-row MAC auto-binds the relation booleans).
-  signOffensiveRunRow(row, readHandoffSigningKey(domain));
-
-  // APPEND — MCP-owned hardened writer.
-  appendSignedRowHardened(domain, row);
-
-  return row;
 }
 
 // ── the P0–P6 canary runner ──────────────────────────────────────────────────
@@ -1319,12 +1113,14 @@ async function idorConfirm(args = {}, { fetch_fn = null, provision = null } = {}
     tenant_key: tenantB.key,
   });
 
-  const row = withSessionLock(domain, () => buildSignedOffensiveRunRow(domain, {
-    method,
-    canonicalTarget,
-    surfaceId,
-    p2BodyForCapture,
-    diagnosticBundle,
+  const row = withSessionLock(domain, () => buildAndSignOffensiveRow(domain, {
+    runIdPrefix: "idor",
+    toolId: TOOL_ID,
+    demonstratedSeverity: IDOR_ORACLE_DEMONSTRATED_CEILING.differential_response,
+    method, canonicalTarget, surfaceId,
+    identityTag: "B-as-A",
+    stdoutContent: p2BodyForCapture,
+    stderrContent: diagnosticBundle,
     relationBooleans,
   }));
 
@@ -1372,9 +1168,9 @@ module.exports = {
   tenantDiscriminator,
   piiScan,
   profileHasProvenance,
-  // NOTE: buildSignedOffensiveRunRow + assertSingleEndpointSingleHost are NOT
-  // exported. buildSignedOffensiveRunRow signs+writes a row WITHOUT running the
-  // mint-condition gates (those live in idorConfirm), so exporting it would give an
-  // internal caller a gate-bypassing signed-row path. Keep the row builder private;
-  // tests drive the full oracle through idorConfirm.
+  // NOTE: buildAndSignOffensiveRow (in offensive-capture-writer.js) + assertSingleEndpointSingleHost
+  // are NOT re-exported here. buildAndSignOffensiveRow signs+writes a row WITHOUT running the
+  // mint-condition gates (those live in idorConfirm), so re-exporting it would give an
+  // internal caller a gate-bypassing signed-row path. Keep the row builder private to the
+  // tool layer; tests drive the full oracle through idorConfirm.
 };

--- a/mcp/lib/offensive-idor-producer.js
+++ b/mcp/lib/offensive-idor-producer.js
@@ -1116,7 +1116,6 @@ async function idorConfirm(args = {}, { fetch_fn = null, provision = null } = {}
   const row = withSessionLock(domain, () => buildAndSignOffensiveRow(domain, {
     runIdPrefix: "idor",
     toolId: TOOL_ID,
-    demonstratedSeverity: IDOR_ORACLE_DEMONSTRATED_CEILING.differential_response,
     method, canonicalTarget, surfaceId,
     identityTag: "B-as-A",
     stdoutContent: p2BodyForCapture,

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -156,6 +156,7 @@
   "test/claim-secret-evidence-bypass.test.js",
   "test/offensive-confirmer.test.js",
   "test/offensive-http-common.test.js",
+  "test/offensive-capture-writer.test.js",
   "test/lifecycle-state-drift.test.js",
   "test/evidence-gate-lifecycle.test.js"
 ]

--- a/test/offensive-capture-writer.test.js
+++ b/test/offensive-capture-writer.test.js
@@ -1,0 +1,75 @@
+"use strict";
+
+// Guard tests for the SHARED offensive capture/sign writer
+// (mcp/lib/offensive-capture-writer.js), extracted from the IDOR producer. These
+// lock the hardening added in response to the PR #120 review:
+//   - path traversal via an unvalidated runIdPrefix (the prefix flows into the
+//     capture-file path),
+//   - relationBooleans clobbering a reserved proof-contract field before signing,
+//   - an over-wide export surface (only the disciplined build+sign entry is public).
+// The happy-path build+sign+append is already exercised byte-identically through
+// the IDOR producer suite (test/offensive-idor-producer.test.js), so these focus on
+// the new guards, which all reject BEFORE any filesystem/session work.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const writer = require("../mcp/lib/offensive-capture-writer.js");
+
+function buildArgs(over = {}) {
+  return {
+    runIdPrefix: "reflect",
+    toolId: "bob_http_xss_reflect",
+    demonstratedSeverity: "medium",
+    method: "GET",
+    canonicalTarget: "https://app.example.test/api/x",
+    surfaceId: "surface:x",
+    identityTag: "probe",
+    stdoutContent: "{}",
+    stderrContent: "{}",
+    relationBooleans: {},
+    ...over,
+  };
+}
+
+test("offensive-capture-writer exports ONLY the high-level build+sign entry", () => {
+  assert.equal(typeof writer.buildAndSignOffensiveRow, "function");
+  for (const internal of [
+    "newRunId", "commandHashOf", "resolveCaptureDirSecure",
+    "writeCaptureAndHash", "appendSignedRowHardened", "sha256OfFileFd",
+  ]) {
+    assert.equal(writer[internal], undefined, `${internal} must stay module-internal`);
+  }
+  assert.deepEqual(Object.keys(writer), ["buildAndSignOffensiveRow"]);
+});
+
+test("buildAndSignOffensiveRow rejects a runIdPrefix that is not a clean lowercase token (path-traversal guard)", () => {
+  for (const bad of ["../etc", "a/b", "idor-x", "Idor", "1foo", "foo_bar", "", "foo.bar", "..", "a/../b", "x ", "a\tb"]) {
+    assert.throws(
+      () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ runIdPrefix: bad })),
+      /runIdPrefix/,
+      `must reject runIdPrefix ${JSON.stringify(bad)}`,
+    );
+  }
+  for (const bad of [123, null, undefined, {}, ["reflect"]]) {
+    assert.throws(
+      () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ runIdPrefix: bad })),
+      /runIdPrefix/,
+      `must reject non-string runIdPrefix ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test("buildAndSignOffensiveRow refuses relationBooleans that override a reserved proof-contract field", () => {
+  for (const reserved of [
+    "version", "target_domain", "run_id", "tool_id", "target", "offensive_outcome",
+    "dry_run", "timed_out", "command_hash", "exit_code", "stdout_hash", "stderr_hash",
+    "demonstrated_severity", "surface_id", "row_mac",
+  ]) {
+    assert.throws(
+      () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ relationBooleans: { [reserved]: "x" } })),
+      /reserved offensive-row field/,
+      `must reject relationBooleans override of ${reserved}`,
+    );
+  }
+});

--- a/test/offensive-capture-writer.test.js
+++ b/test/offensive-capture-writer.test.js
@@ -19,8 +19,10 @@ const writer = require("../mcp/lib/offensive-capture-writer.js");
 function buildArgs(over = {}) {
   return {
     runIdPrefix: "reflect",
-    toolId: "bob_http_xss_reflect",
-    demonstratedSeverity: "medium",
+    // a tool_id that IS in OFFENSIVE_TOOL_DEMONSTRATED_CEILING, so the prefix /
+    // reserved-key / boolean guards (which run after the registry check) are reached
+    // by the tests that exercise them.
+    toolId: "bob_http_idor_confirm",
     method: "GET",
     canonicalTarget: "https://app.example.test/api/x",
     surfaceId: "surface:x",
@@ -70,6 +72,26 @@ test("buildAndSignOffensiveRow refuses relationBooleans that override a reserved
       () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ relationBooleans: { [reserved]: "x" } })),
       /reserved offensive-row field/,
       `must reject relationBooleans override of ${reserved}`,
+    );
+  }
+});
+
+test("buildAndSignOffensiveRow rejects a tool_id absent from the demonstrated-severity registry (registry-bound signer)", () => {
+  for (const bad of ["bob_http_xss_reflect", "bob_unknown", "", "BOB_HTTP_IDOR_CONFIRM", "bob_http_idor_confirm "]) {
+    assert.throws(
+      () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ toolId: bad })),
+      /unknown offensive tool_id/,
+      `must reject unregistered tool_id ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test("buildAndSignOffensiveRow refuses a non-boolean relationBooleans value (MAC-covered proof material)", () => {
+  for (const value of ["true", 1, 0, null, {}, ["x"], "../etc"]) {
+    assert.throws(
+      () => writer.buildAndSignOffensiveRow("d.test", buildArgs({ relationBooleans: { p0_stable: value } })),
+      /must be a boolean/,
+      `must reject non-boolean relation value ${JSON.stringify(value)}`,
     );
   }
 });


### PR DESCRIPTION
## What

Extract the signed-row capture/append/hash machinery out of `offensive-idor-producer.js` into a new shared `mcp/lib/offensive-capture-writer.js`, so the upcoming reflected-XSS finder (the find-axis MVP) reuses the same security-reviewed write path instead of forking it. This is the PR-B move (shared-helper extraction) applied to the capture writer — the precursor to the reflect-finder PR, exactly as PR-B (#118) preceded PR-C (#119).

## Why

The find-axis MVP (`bob_http_xss_reflect`, a reflected-canary metachar-survival **finder**) needs the same hardened capture/append/sign path the IDOR producer uses: exclusive-create captures, realpath/`O_NOFOLLOW`/`nlink` discipline, atomic `O_APPEND`, run_id single-use, sign-last MAC. Under-extracting would force the new producer to fork the security-critical writer (the exact anti-pattern PR-B exists to prevent).

## Changes

- **New `mcp/lib/offensive-capture-writer.js`** — `newRunId(prefix)`, `commandHashOf`, `resolveCaptureDirSecure`, `writeCaptureAndHash`, `appendSignedRowHardened` (all moved **verbatim**), `sha256OfFileFd` (internal, not exported), and `buildAndSignOffensiveRow` — the **parameterized** `buildSignedOffensiveRunRow` (now takes `runIdPrefix` / `toolId` / `demonstratedSeverity` / `identityTag` / `stdoutContent` / `stderrContent` instead of hardcoding the IDOR specifics).
- **`offensive-idor-producer.js`** — imports `buildAndSignOffensiveRow`, drops the now-dead requires (`readOffensiveRunRecords`, `signOffensiveRunRow`, `readHandoffSigningKey`, `offensiveRunsDir` / `offensiveRunsJsonlPath` / `sessionsRoot` / `assertSafeDomain`), and calls the shared builder with `runIdPrefix:"idor"`, the IDOR tool ceiling, and `identityTag:"B-as-A"`.

## Behavior: byte-identical

Same 14-field row in the same order, same `idor-<uuid>` run_id format, same sign-last + hardened append. No tool/schema/registry/generator change (pure `mcp/lib` refactor). The existing IDOR producer tests + the offensive-proof-contract + severity-rise-guard suites pass **unchanged** — that is the correctness gate for a byte-identical extraction.

`npm test`: **2605 pass / 0 fail / 2 skip** (pre-existing skips). The local working tree's `package.test` size check trips only on untracked scratch docs in `docs/` + a local measurement script; verified **green (20/0) on the committed-only tree** (untracked stashed).

Precursor to the reflected-XSS finder (`PR_REFLECT_XSS_MVP_HANDOFF_PLAN`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the offensive capture artifact creation and signed, append-only ledger row persistence into a dedicated shared utility.
  * Updated the IDOR confirmation flow to reuse the shared builder for final row persistence.

* **Bug Fixes**
  * Added stricter input validation for run ID prefixes, tool identifiers, and relation boolean values.
  * Prevented any attempt to override reserved proof-contract fields during row creation.

* **Tests**
  * Added automated coverage for hardened export surface, run ID prefix validation, reserved field override rejection, toolId validation, and relation boolean type enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->