### PR TITLE
feat(offense): PR-IMAGE — digest-pinned offensive arsenal image + fail-closed preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ test/act-run.log
 test/act-mock-api.log
 # offensive arsenal image build staging (host-fetched binaries; never committed)
 docker/offensive-context/
+# operator-minted image digest — deployment-specific (points at the operator's registry push), so it is
+# NOT committed/shipped; install.js copies the local file into the runtime. Each operator mints their own.
+mcp/lib/offensive-image.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ __pycache__/
 .secrets
 test/act-run.log
 test/act-mock-api.log
+# offensive arsenal image build staging (host-fetched binaries; never committed)
+docker/offensive-context/

--- a/docker/offensive.Dockerfile
+++ b/docker/offensive.Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# offensive.Dockerfile — the digest-pinned image for Hacker Bob's wide-open offensive
+# container runner (mcp/lib/offensive-runner.js + offensive-sandbox.js). It carries the
+# arsenal binaries the find-axis tools invoke (httpx for the smoke; dalfox for the first
+# real prover tool in PR5b-tool).
+#
+# HERMETIC BUILD: the arsenal binaries are fetched + sha256-verified ON THE HOST by
+# scripts/build-offensive-image.sh (where egress is verified clean) and COPIED in. There is
+# NO network fetch during this build and NO builder toolchain in the final image — the only
+# registry pull is the base image.
+#
+# PROVENANCE: the OFFENSIVE image's own sha256 digest is what's pinned in
+# mcp/lib/offensive-image.json and enforced at run time by the sandbox (--pull=never +
+# name@sha256). This Dockerfile only has to produce that image reproducibly. The base is
+# overridable + digest-pinnable via BASE_IMAGE.
+#
+# RUNTIME POSTURE (enforced by offensive-sandbox.js, NOT here): --user 1000:1000,
+# --cap-drop ALL, --read-only, no host mounts, /tmp + /work tmpfs, per-run throwaway network.
+# This image only needs to (a) hold the static binaries world-executable and (b) point HOME at
+# a writable tmpfs path so the tools never write a read-only $HOME.
+
+# distroless/base carries glibc (safer than :static for PD release binaries that may use the
+# cgo resolver). Pin to a digest in BASE_IMAGE for a fully reproducible rebuild.
+ARG BASE_IMAGE=gcr.io/distroless/base-debian12:nonroot
+
+FROM ${BASE_IMAGE}
+
+# Arsenal binaries staged under ./bin by scripts/build-offensive-image.sh. World read+exec so
+# the runner's forced --user 1000:1000 (not the image's default nonroot uid) can execute them.
+COPY --chmod=0755 bin/ /usr/local/bin/
+
+# The fs is read-only at run time except /tmp + /work (tmpfs). Point HOME + the XDG dirs at /work
+# so httpx/dalfox never try to write a read-only $HOME. (-disable-update-check / -silent are forced
+# per-tool in the offensive-tools.js spec, so no tool reaches out to update at run time.)
+ENV HOME=/work \
+    XDG_CONFIG_HOME=/work/.config \
+    XDG_CACHE_HOME=/work/.cache
+
+# No entrypoint: the runner supplies the full tool argv as the container command. CMD is only the
+# default smoke — a no-network, read-only invocation proving the image+digest+--pull=never plumbing.
+ENTRYPOINT []
+CMD ["httpx", "-version"]

--- a/docker/offensive.Dockerfile
+++ b/docker/offensive.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-#
 # offensive.Dockerfile — the digest-pinned image for Hacker Bob's wide-open offensive
 # container runner (mcp/lib/offensive-runner.js + offensive-sandbox.js). It carries the
 # arsenal binaries the find-axis tools invoke (httpx for the smoke; dalfox for the first
@@ -20,15 +18,18 @@
 # This image only needs to (a) hold the static binaries world-executable and (b) point HOME at
 # a writable tmpfs path so the tools never write a read-only $HOME.
 
-# distroless/base carries glibc (safer than :static for PD release binaries that may use the
-# cgo resolver). Pin to a digest in BASE_IMAGE for a fully reproducible rebuild.
+# distroless/base carries glibc (safer than :static for release binaries that may use the cgo resolver).
+# The DEFAULT below is a mutable tag; scripts/build-offensive-image.sh resolves it to an immutable
+# @sha256: digest and passes --build-arg BASE_IMAGE=...@sha256:. A direct `docker build` WITHOUT that arg
+# is NOT digest-pinned — override BASE_IMAGE with a @sha256: ref to pin a standalone build.
 ARG BASE_IMAGE=gcr.io/distroless/base-debian12:nonroot
 
 FROM ${BASE_IMAGE}
 
-# Arsenal binaries staged under ./bin by scripts/build-offensive-image.sh. World read+exec so
-# the runner's forced --user 1000:1000 (not the image's default nonroot uid) can execute them.
-COPY --chmod=0755 bin/ /usr/local/bin/
+# Arsenal binaries staged under ./bin by scripts/build-offensive-image.sh as 0755; COPY preserves the host
+# mode (world read+exec) so the runner's forced --user 1000:1000 (not the image's default nonroot uid) can
+# execute them. No `--chmod` => no BuildKit external-frontend pull from Docker Hub.
+COPY bin/ /usr/local/bin/
 
 # The fs is read-only at run time except /tmp + /work (tmpfs). Point HOME + the XDG dirs at /work
 # so httpx/dalfox never try to write a read-only $HOME. (-disable-update-check / -silent are forced
@@ -36,6 +37,10 @@ COPY --chmod=0755 bin/ /usr/local/bin/
 ENV HOME=/work \
     XDG_CONFIG_HOME=/work/.config \
     XDG_CACHE_HOME=/work/.cache
+
+# Start in the writable /work tmpfs (the rootfs is --read-only at runtime) so tools that write to their CWD
+# (temp files, crash dumps, relative output) don't hit a read-only /.
+WORKDIR /work
 
 # Fixed non-root uid so the image stays non-root even when run directly (the manual smoke, or any use
 # outside the sandbox's forced --user 1000:1000) — defense-in-depth, independent of which BASE_IMAGE is used.

--- a/docker/offensive.Dockerfile
+++ b/docker/offensive.Dockerfile
@@ -37,6 +37,10 @@ ENV HOME=/work \
     XDG_CONFIG_HOME=/work/.config \
     XDG_CACHE_HOME=/work/.cache
 
+# Fixed non-root uid so the image stays non-root even when run directly (the manual smoke, or any use
+# outside the sandbox's forced --user 1000:1000) — defense-in-depth, independent of which BASE_IMAGE is used.
+USER 1000:1000
+
 # No entrypoint: the runner supplies the full tool argv as the container command. CMD is only the
 # default smoke — a no-network, read-only invocation proving the image+digest+--pull=never plumbing.
 ENTRYPOINT []

--- a/docs/OFFENSIVE_IMAGE.md
+++ b/docs/OFFENSIVE_IMAGE.md
@@ -20,8 +20,8 @@ is registry-specific, which is also why the base image is pulled from `gcr.io`, 
 # 2. Authenticate to ghcr.io with a PAT carrying the write:packages scope:
 docker login ghcr.io                       # username = your GitHub handle; password = the PAT
 
-# 3. Build + push + pull-by-digest + write the lockfile:
-./scripts/build-offensive-image.sh         # add --stage-only to fetch+verify binaries without docker
+# 3. Build + push + pull-by-digest + write the lockfile (pin the CURRENT release versions — required):
+HTTPX_VERSION=<current> DALFOX_VERSION=<current> ./scripts/build-offensive-image.sh   # --stage-only skips docker
 
 # 4. Commit the generated lockfile:
 git add mcp/lib/offensive-image.json && git commit -m "chore(offense): pin offensive arsenal image digest"
@@ -34,15 +34,18 @@ and writes the digest to `mcp/lib/offensive-image.json` (the **sole source** of 
 `imageDigest`). The lockfile is JSON **data** — read fresh with `fs.readFileSync` + `JSON.parse`, never
 executed — and `install.js` copies it explicitly (the `mcp/lib` copy is `.js`-only).
 
-> **Verify the pinned tool versions** (`HTTPX_VERSION` / `DALFOX_VERSION` at the top of the script) against
-> the current upstream releases before a real run — a stale version 404s at download; a tampered asset fails
-> the checksum gate. Override per-run with env vars, e.g. `HTTPX_VERSION=1.6.10 ./scripts/build-offensive-image.sh`.
+> **Tool versions are required** (`HTTPX_VERSION` / `DALFOX_VERSION`) — there is no shipped default (a
+> hardcoded guess can 404). Pin the current release tags from
+> [httpx](https://github.com/projectdiscovery/httpx/releases) /
+> [dalfox](https://github.com/hahwul/dalfox/releases); the script fails closed if they're unset, and a
+> tampered asset fails the checksum gate.
 >
 > **Pin the binary SHA256s in-repo for release-tamper protection.** The first mint is TOFU — the asset is
 > verified against the release's *own* checksums file (same channel) and the computed SHA is printed. Set
 > `HTTPX_SHA256` / `DALFOX_SHA256` (env or at the top of the script) to those values so a later compromised
-> upstream release fails against the in-repo reference. For full base provenance, also set `BASE_IMAGE` to a
-> `gcr.io/distroless/...@sha256:` digest (recorded in the lockfile's `base_image`).
+> upstream release fails against the in-repo reference. (The base image is auto-resolved to an immutable
+> `@sha256:` digest at mint time and recorded in the lockfile's `base_image`; override `BASE_IMAGE` to pin a
+> different base.)
 
 ## Runtime behavior (fail-closed)
 
@@ -57,8 +60,9 @@ Until the lockfile is minted, both fail closed — an offensive container run is
 
 ## Design notes
 
-- **Hermetic build:** binaries are fetched + checksum-verified on the host (clean egress) and `COPY`-ed into a
-  shell-less `gcr.io/distroless/base-debian12:nonroot` base. No builder toolchain, no in-build network.
+- **Hermetic + reproducible build:** binaries are fetched + checksum-verified on the host (clean egress) and
+  `COPY`-ed into a shell-less `gcr.io/distroless/base-debian12` base that the script resolves to an immutable
+  `@sha256:` digest before building (recorded in `base_image`). No builder toolchain, no in-build network.
 - **Runtime posture** is enforced by `offensive-sandbox.js`, not the image: `--user 1000:1000`, `--cap-drop ALL`,
   `--read-only`, no host mounts, `/tmp`+`/work` tmpfs, a per-run throwaway network. The image only holds the
   static binaries world-executable and points `HOME`/XDG at the writable `/work` tmpfs.

--- a/docs/OFFENSIVE_IMAGE.md
+++ b/docs/OFFENSIVE_IMAGE.md
@@ -24,25 +24,31 @@ docker login ghcr.io                       # username = your GitHub handle; pass
 ./scripts/build-offensive-image.sh         # add --stage-only to fetch+verify binaries without docker
 
 # 4. Commit the generated lockfile:
-git add mcp/lib/offensive-image-lock.js && git commit -m "chore(offense): pin offensive arsenal image digest"
+git add mcp/lib/offensive-image.json && git commit -m "chore(offense): pin offensive arsenal image digest"
 ```
 
 The script fetches `httpx` + `dalfox` release binaries **on the host**, verifies each against its official
 GitHub release checksums file, stages them, builds a hermetic image (no in-build network), pushes to
 `ghcr.io/bobnetsec/bob-offense`, pulls the result **by digest** so the local store can resolve `--pull=never`,
-and writes the digest to `mcp/lib/offensive-image-lock.js` (the **sole source** of `runOffensiveTool`'s
-`imageDigest`). It is a generated `.js` module so `install.js`'s `mcp/lib` `.js` copy carries it to the
-operational runtime (a `.json` data file would be silently dropped by that copy).
+and writes the digest to `mcp/lib/offensive-image.json` (the **sole source** of `runOffensiveTool`'s
+`imageDigest`). The lockfile is JSON **data** — read fresh with `fs.readFileSync` + `JSON.parse`, never
+executed — and `install.js` copies it explicitly (the `mcp/lib` copy is `.js`-only).
 
 > **Verify the pinned tool versions** (`HTTPX_VERSION` / `DALFOX_VERSION` at the top of the script) against
 > the current upstream releases before a real run — a stale version 404s at download; a tampered asset fails
 > the checksum gate. Override per-run with env vars, e.g. `HTTPX_VERSION=1.6.10 ./scripts/build-offensive-image.sh`.
+>
+> **Pin the binary SHA256s in-repo for release-tamper protection.** The first mint is TOFU — the asset is
+> verified against the release's *own* checksums file (same channel) and the computed SHA is printed. Set
+> `HTTPX_SHA256` / `DALFOX_SHA256` (env or at the top of the script) to those values so a later compromised
+> upstream release fails against the in-repo reference. For full base provenance, also set `BASE_IMAGE` to a
+> `gcr.io/distroless/...@sha256:` digest (recorded in the lockfile's `base_image`).
 
 ## Runtime behavior (fail-closed)
 
 `mcp/lib/offensive-image.js`:
-- `resolveOffensiveImageDigest()` loads + validates the lockfile; **throws** if absent (not yet minted),
-  unloadable, or carrying a non-`name@sha256` digest.
+- `resolveOffensiveImageDigest()` reads + validates the lockfile fresh each call; **throws** if absent (not
+  yet minted), unparseable, or carrying a non-`name@sha256` digest.
 - `assertOffensiveImagePresent(digest, docker)` runs `docker image inspect <digest>` before a run; **throws**
   with a clear "run `scripts/build-offensive-image.sh`" message if the image is not in the local store, so
   `--pull=never` never fails cryptically.
@@ -63,5 +69,5 @@ Until the lockfile is minted, both fail closed — an offensive container run is
 ## Bumping the image
 
 Edit the pinned versions in `scripts/build-offensive-image.sh`, re-run it, commit the regenerated
-`mcp/lib/offensive-image-lock.js`, and re-run `./install.sh <runtime>` so the operational runtime picks up the
+`mcp/lib/offensive-image.json`, and re-run `./install.sh <runtime>` so the operational runtime picks up the
 new digest.

--- a/docs/OFFENSIVE_IMAGE.md
+++ b/docs/OFFENSIVE_IMAGE.md
@@ -25,16 +25,16 @@ docker login ghcr.io                       # username = your GitHub handle; pass
 HTTPX_URL=... HTTPX_SHA256=... DALFOX_URL=... DALFOX_SHA256=... ./scripts/build-offensive-image.sh
 #    (add --stage-only to fetch+verify+stage the binaries without Docker)
 
-# 4. Commit the generated lockfile:
-git add mcp/lib/offensive-image.json && git commit -m "chore(offense): pin offensive arsenal image digest"
+# 4. The lockfile is operator-local (gitignored) — DON'T commit it. Refresh your runtime so it's picked up:
+./install.sh <your-runtime>          # install copies the local mcp/lib/offensive-image.json into the runtime
 ```
 
-The script fetches `httpx` + `dalfox` release binaries **on the host**, verifies each against its official
-GitHub release checksums file, stages them, builds a hermetic image (no in-build network), pushes to
-`ghcr.io/bobnetsec/bob-offense`, pulls the result **by digest** so the local store can resolve `--pull=never`,
-and writes the digest to `mcp/lib/offensive-image.json` (the **sole source** of `runOffensiveTool`'s
-`imageDigest`). The lockfile is JSON **data** — read fresh with `fs.readFileSync` + `JSON.parse`, never
-executed — and `install.js` copies it explicitly (the `mcp/lib` copy is `.js`-only).
+The script fetches the `httpx` + `dalfox` archives **on the host** from the URLs you supply, verifies each
+against the sha256 you supply, stages them, builds a hermetic image (no in-build network), pushes to your
+`OFFENSIVE_REGISTRY` (default `ghcr.io/bobnetsec/bob-offense`), pulls the result **by digest** so the local
+store can resolve `--pull=never`, and writes the digest to `mcp/lib/offensive-image.json` (the **sole source**
+of `runOffensiveTool`'s `imageDigest`). The lockfile is JSON **data** — read fresh with `fs.readFileSync` +
+`JSON.parse`, never executed — operator-local (gitignored); `install.js` copies it into the runtime if present.
 
 > **You supply the exact archive URL + sha256 per tool** (`HTTPX_URL`+`HTTPX_SHA256`,
 > `DALFOX_URL`+`DALFOX_SHA256`) — all required, no defaults. Copy the linux archive URL for your arch and
@@ -72,6 +72,5 @@ Until the lockfile is minted, both fail closed — an offensive container run is
 
 ## Bumping the image
 
-Edit the pinned versions in `scripts/build-offensive-image.sh`, re-run it, commit the regenerated
-`mcp/lib/offensive-image.json`, and re-run `./install.sh <runtime>` so the operational runtime picks up the
-new digest.
+Re-run the mint (step 3) with the new release URLs + sha256s, then re-run `./install.sh <runtime>` so your
+runtime picks up the regenerated `mcp/lib/offensive-image.json`. The lockfile stays operator-local — don't commit it.

--- a/docs/OFFENSIVE_IMAGE.md
+++ b/docs/OFFENSIVE_IMAGE.md
@@ -20,8 +20,10 @@ is registry-specific, which is also why the base image is pulled from `gcr.io`, 
 # 2. Authenticate to ghcr.io with a PAT carrying the write:packages scope:
 docker login ghcr.io                       # username = your GitHub handle; password = the PAT
 
-# 3. Build + push + pull-by-digest + write the lockfile (pin the CURRENT release versions — required):
-HTTPX_VERSION=<current> DALFOX_VERSION=<current> ./scripts/build-offensive-image.sh   # --stage-only skips docker
+# 3. Build + push + pull-by-digest + write the lockfile. Copy each tool's linux release ARCHIVE URL for
+#    your arch + its published sha256 from the releases page, and pass all four (required):
+HTTPX_URL=... HTTPX_SHA256=... DALFOX_URL=... DALFOX_SHA256=... ./scripts/build-offensive-image.sh
+#    (add --stage-only to fetch+verify+stage the binaries without Docker)
 
 # 4. Commit the generated lockfile:
 git add mcp/lib/offensive-image.json && git commit -m "chore(offense): pin offensive arsenal image digest"
@@ -34,18 +36,16 @@ and writes the digest to `mcp/lib/offensive-image.json` (the **sole source** of 
 `imageDigest`). The lockfile is JSON **data** — read fresh with `fs.readFileSync` + `JSON.parse`, never
 executed — and `install.js` copies it explicitly (the `mcp/lib` copy is `.js`-only).
 
-> **Tool versions are required** (`HTTPX_VERSION` / `DALFOX_VERSION`) — there is no shipped default (a
-> hardcoded guess can 404). Pin the current release tags from
-> [httpx](https://github.com/projectdiscovery/httpx/releases) /
-> [dalfox](https://github.com/hahwul/dalfox/releases); the script fails closed if they're unset, and a
-> tampered asset fails the checksum gate.
+> **You supply the exact archive URL + sha256 per tool** (`HTTPX_URL`+`HTTPX_SHA256`,
+> `DALFOX_URL`+`DALFOX_SHA256`) — all required, no defaults. Copy the linux archive URL for your arch and
+> its published sha256 from the releases pages
+> ([httpx](https://github.com/projectdiscovery/httpx/releases) /
+> [dalfox](https://github.com/hahwul/dalfox/releases)). This avoids guessing release asset names (which
+> differ per tool/version) and pins each binary to the published hash — no trust-on-first-use; a mismatch
+> fails the checksum gate.
 >
-> **Pin the binary SHA256s in-repo for release-tamper protection.** The first mint is TOFU — the asset is
-> verified against the release's *own* checksums file (same channel) and the computed SHA is printed. Set
-> `HTTPX_SHA256` / `DALFOX_SHA256` (env or at the top of the script) to those values so a later compromised
-> upstream release fails against the in-repo reference. (The base image is auto-resolved to an immutable
-> `@sha256:` digest at mint time and recorded in the lockfile's `base_image`; override `BASE_IMAGE` to pin a
-> different base.)
+> The base image is auto-resolved to an immutable `@sha256:` digest at mint time and recorded in the
+> lockfile's `base_image`; override `BASE_IMAGE` with a `@sha256:` ref to pin a different base.
 
 ## Runtime behavior (fail-closed)
 

--- a/docs/OFFENSIVE_IMAGE.md
+++ b/docs/OFFENSIVE_IMAGE.md
@@ -1,0 +1,67 @@
+# Offensive arsenal image (`bob-offense`)
+
+The wide-open offensive container runner (`mcp/lib/offensive-runner.js` + `offensive-sandbox.js`) runs
+each arsenal tool inside a **digest-pinned** image with `--pull=never`. This doc is the one-time build +
+pin procedure and the design rationale. It is **`PR-IMAGE`**: image infrastructure only — no MCP tool is
+wired here (that is `PR5b-tool`).
+
+## Why a registry push is required (not just a local build)
+
+`offensive-sandbox.js` enforces `--pull=never` + `name@sha256:<digest>` (`IMAGE_DIGEST_RE`). A purely-local
+`docker build`/retag has **no `RepoDigest`**, so `docker run --pull=never name@sha256:…` cannot resolve it.
+The only sound way to mint a resolvable digest is **build → push to a registry → pull-by-digest**. We use
+`ghcr.io` (its TLS is clean on the build host; verified 2026-06-18 — the documented Docker-Hub TLS-intercept
+is registry-specific, which is also why the base image is pulled from `gcr.io`, not Docker Hub).
+
+## One-time operator steps (mint the digest)
+
+```sh
+# 1. Start Docker Desktop (the daemon must be running).
+# 2. Authenticate to ghcr.io with a PAT carrying the write:packages scope:
+docker login ghcr.io                       # username = your GitHub handle; password = the PAT
+
+# 3. Build + push + pull-by-digest + write the lockfile:
+./scripts/build-offensive-image.sh         # add --stage-only to fetch+verify binaries without docker
+
+# 4. Commit the generated lockfile:
+git add mcp/lib/offensive-image-lock.js && git commit -m "chore(offense): pin offensive arsenal image digest"
+```
+
+The script fetches `httpx` + `dalfox` release binaries **on the host**, verifies each against its official
+GitHub release checksums file, stages them, builds a hermetic image (no in-build network), pushes to
+`ghcr.io/bobnetsec/bob-offense`, pulls the result **by digest** so the local store can resolve `--pull=never`,
+and writes the digest to `mcp/lib/offensive-image-lock.js` (the **sole source** of `runOffensiveTool`'s
+`imageDigest`). It is a generated `.js` module so `install.js`'s `mcp/lib` `.js` copy carries it to the
+operational runtime (a `.json` data file would be silently dropped by that copy).
+
+> **Verify the pinned tool versions** (`HTTPX_VERSION` / `DALFOX_VERSION` at the top of the script) against
+> the current upstream releases before a real run — a stale version 404s at download; a tampered asset fails
+> the checksum gate. Override per-run with env vars, e.g. `HTTPX_VERSION=1.6.10 ./scripts/build-offensive-image.sh`.
+
+## Runtime behavior (fail-closed)
+
+`mcp/lib/offensive-image.js`:
+- `resolveOffensiveImageDigest()` loads + validates the lockfile; **throws** if absent (not yet minted),
+  unloadable, or carrying a non-`name@sha256` digest.
+- `assertOffensiveImagePresent(digest, docker)` runs `docker image inspect <digest>` before a run; **throws**
+  with a clear "run `scripts/build-offensive-image.sh`" message if the image is not in the local store, so
+  `--pull=never` never fails cryptically.
+
+Until the lockfile is minted, both fail closed — an offensive container run is impossible, by design.
+
+## Design notes
+
+- **Hermetic build:** binaries are fetched + checksum-verified on the host (clean egress) and `COPY`-ed into a
+  shell-less `gcr.io/distroless/base-debian12:nonroot` base. No builder toolchain, no in-build network.
+- **Runtime posture** is enforced by `offensive-sandbox.js`, not the image: `--user 1000:1000`, `--cap-drop ALL`,
+  `--read-only`, no host mounts, `/tmp`+`/work` tmpfs, a per-run throwaway network. The image only holds the
+  static binaries world-executable and points `HOME`/XDG at the writable `/work` tmpfs.
+- **Accepted residual** (operator-locked): wide-open OUTBOUND egress once a container runs. Mitigations live in
+  the runner (redaction-before-agent, count/boolean oracle default) and the build plan — see
+  `docs/OFFENSIVE_BOB_BUILD_PLAN.md`.
+
+## Bumping the image
+
+Edit the pinned versions in `scripts/build-offensive-image.sh`, re-run it, commit the regenerated
+`mcp/lib/offensive-image-lock.js`, and re-run `./install.sh <runtime>` so the operational runtime picks up the
+new digest.

--- a/mcp/lib/offensive-image.js
+++ b/mcp/lib/offensive-image.js
@@ -1,0 +1,82 @@
+"use strict";
+
+// offensive-image.js — the SOLE source of the offensive container image digest, and the
+// fail-closed preflight that the image is present locally before a wide-open offensive run.
+//
+// The sandbox (offensive-sandbox.js) runs with `--pull=never` + `name@sha256:<digest>`, so the
+// arsenal image MUST be (1) digest-pinned and (2) already in the local docker store. A purely-local
+// `docker build` has no RepoDigest, so the digest is minted by scripts/build-offensive-image.sh
+// (build -> push to ghcr.io -> pull-by-digest) which writes the lockfile mcp/lib/offensive-image-lock.js
+// (a generated `.js` module so install.js's mcp/lib `.js` copy picks it up automatically; a `.json`
+// data file would be silently dropped by that copy). This module loads that lockfile and fail-closes
+// when it is absent/unloadable (the image hasn't been minted yet), when the pinned digest is not a
+// valid name@sha256, or when it is not in the local store (so `--pull=never` would otherwise fail
+// cryptically).
+//
+// PR-IMAGE lands + unit-tests these functions; no production code calls them yet (no tool is wired in
+// this PR). PR5b-tool's handler resolves the digest via resolveOffensiveImageDigest() and gates the run
+// via assertOffensiveImagePresent().
+
+const path = require("path");
+const { IMAGE_DIGEST_RE } = require("./offensive-sandbox.js");
+
+// Generated lockfile, committed next to this module so it travels with mcp/lib on install. It is
+// operator-minted (scripts/build-offensive-image.sh) and ABSENT until then.
+const LOCK_BASENAME = "offensive-image-lock.js";
+
+function offensiveImageLockPath() {
+  return path.join(__dirname, LOCK_BASENAME);
+}
+
+// Load + validate the pinned digest. Fail-closed: a missing lockfile, an unloadable lockfile, or a
+// non-digest image_digest throws — the image has not been minted, or the lockfile was tampered.
+function resolveOffensiveImageDigest({ lockPath = offensiveImageLockPath() } = {}) {
+  let lock;
+  try {
+    lock = require(lockPath);
+  } catch (err) {
+    if (err && err.code === "MODULE_NOT_FOUND") {
+      throw new Error(
+        `offensive image not pinned: ${lockPath} is absent. Run scripts/build-offensive-image.sh ` +
+          `(start Docker + 'docker login ghcr.io') to build, push, and pin the arsenal image.`
+      );
+    }
+    throw new Error(`offensive image lockfile is not loadable (${lockPath}): ${err && err.message}`);
+  }
+  const digest = lock && typeof lock.image_digest === "string" ? lock.image_digest : "";
+  if (!IMAGE_DIGEST_RE.test(digest)) {
+    throw new Error(`offensive image lockfile has no valid name@sha256:<digest> image_digest: ${lockPath}`);
+  }
+  return digest;
+}
+
+// Fail-closed preflight: with `--pull=never` the digest MUST already be in the local image store.
+// `docker.inspectImage(digest) -> Promise<boolean>` is injectable so tests drive it without docker.
+// Any non-true result (absent, or inspect error) blocks the run with a clear remediation message.
+async function assertOffensiveImagePresent(imageDigest, docker) {
+  if (typeof imageDigest !== "string" || !IMAGE_DIGEST_RE.test(imageDigest)) {
+    throw new Error("assertOffensiveImagePresent requires a digest-pinned image (name@sha256:<64 hex>)");
+  }
+  if (!docker || typeof docker.inspectImage !== "function") {
+    throw new Error("assertOffensiveImagePresent requires a docker.inspectImage(digest) function");
+  }
+  let present = false;
+  try {
+    present = await docker.inspectImage(imageDigest);
+  } catch {
+    present = false;
+  }
+  if (present !== true) {
+    throw new Error(
+      `offensive image ${imageDigest} is not present in the local docker store. ` +
+        `Run scripts/build-offensive-image.sh to build/push/pull-by-digest before an offensive run.`
+    );
+  }
+}
+
+module.exports = {
+  offensiveImageLockPath,
+  resolveOffensiveImageDigest,
+  assertOffensiveImagePresent,
+  OFFENSIVE_IMAGE_LOCK_BASENAME: LOCK_BASENAME,
+};

--- a/mcp/lib/offensive-image.js
+++ b/mcp/lib/offensive-image.js
@@ -6,44 +6,55 @@
 // The sandbox (offensive-sandbox.js) runs with `--pull=never` + `name@sha256:<digest>`, so the
 // arsenal image MUST be (1) digest-pinned and (2) already in the local docker store. A purely-local
 // `docker build` has no RepoDigest, so the digest is minted by scripts/build-offensive-image.sh
-// (build -> push to ghcr.io -> pull-by-digest) which writes the lockfile mcp/lib/offensive-image-lock.js
-// (a generated `.js` module so install.js's mcp/lib `.js` copy picks it up automatically; a `.json`
-// data file would be silently dropped by that copy). This module loads that lockfile and fail-closes
-// when it is absent/unloadable (the image hasn't been minted yet), when the pinned digest is not a
-// valid name@sha256, or when it is not in the local store (so `--pull=never` would otherwise fail
-// cryptically).
+// (build -> push to ghcr.io -> pull-by-digest) which writes the lockfile mcp/lib/offensive-image.json.
+//
+// The lockfile is JSON read FRESH with fs.readFileSync + JSON.parse on every call — it is DATA, never
+// executed. (An earlier `.js` + require() form was rejected in review: require() caches by resolved path,
+// so a live MCP process would keep serving a stale digest after an image bump; and a generated `.js`
+// lockfile executes arbitrary code before any validation — a broken trust boundary. JSON closes both.)
+// Because install.js's mcp/lib copy is `.js`-only, install.js copies this `.json` lockfile explicitly.
+//
+// Fail-closed when the lockfile is absent (not minted yet), unparseable, or carries a non-name@sha256
+// digest; and when the pinned digest is not in the local store (so `--pull=never` won't fail cryptically).
 //
 // PR-IMAGE lands + unit-tests these functions; no production code calls them yet (no tool is wired in
 // this PR). PR5b-tool's handler resolves the digest via resolveOffensiveImageDigest() and gates the run
 // via assertOffensiveImagePresent().
 
+const fs = require("fs");
 const path = require("path");
 const { IMAGE_DIGEST_RE } = require("./offensive-sandbox.js");
 
-// Generated lockfile, committed next to this module so it travels with mcp/lib on install. It is
-// operator-minted (scripts/build-offensive-image.sh) and ABSENT until then.
-const LOCK_BASENAME = "offensive-image-lock.js";
+const LOCK_BASENAME = "offensive-image.json";
 
+// Operator-minted lockfile committed next to this module; install.js copies it. ABSENT until minted.
 function offensiveImageLockPath() {
   return path.join(__dirname, LOCK_BASENAME);
 }
 
-// Load + validate the pinned digest. Fail-closed: a missing lockfile, an unloadable lockfile, or a
-// non-digest image_digest throws — the image has not been minted, or the lockfile was tampered.
+// Load + validate the pinned digest, reading the lockfile FRESH each call (no module cache, so an image
+// bump is picked up by a live process). Fail-closed on absent / unparseable / non-object / non-digest.
 function resolveOffensiveImageDigest({ lockPath = offensiveImageLockPath() } = {}) {
-  let lock;
+  let raw;
   try {
-    lock = require(lockPath);
+    raw = fs.readFileSync(lockPath, "utf8");
   } catch (err) {
-    if (err && err.code === "MODULE_NOT_FOUND") {
+    if (err && err.code === "ENOENT") {
       throw new Error(
         `offensive image not pinned: ${lockPath} is absent. Run scripts/build-offensive-image.sh ` +
           `(start Docker + 'docker login ghcr.io') to build, push, and pin the arsenal image.`
       );
     }
-    throw new Error(`offensive image lockfile is not loadable (${lockPath}): ${err && err.message}`);
+    throw err;
   }
-  const digest = lock && typeof lock.image_digest === "string" ? lock.image_digest : "";
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`offensive image lockfile is not valid JSON: ${lockPath}`);
+  }
+  const digest =
+    parsed && typeof parsed === "object" && typeof parsed.image_digest === "string" ? parsed.image_digest : "";
   if (!IMAGE_DIGEST_RE.test(digest)) {
     throw new Error(`offensive image lockfile has no valid name@sha256:<digest> image_digest: ${lockPath}`);
   }
@@ -52,7 +63,8 @@ function resolveOffensiveImageDigest({ lockPath = offensiveImageLockPath() } = {
 
 // Fail-closed preflight: with `--pull=never` the digest MUST already be in the local image store.
 // `docker.inspectImage(digest) -> Promise<boolean>` is injectable so tests drive it without docker.
-// Any non-true result (absent, or inspect error) blocks the run with a clear remediation message.
+// On a false/error result the run is blocked; the underlying docker error (e.g. daemon down vs image
+// absent) is surfaced in the message for diagnosis while still failing closed.
 async function assertOffensiveImagePresent(imageDigest, docker) {
   if (typeof imageDigest !== "string" || !IMAGE_DIGEST_RE.test(imageDigest)) {
     throw new Error("assertOffensiveImagePresent requires a digest-pinned image (name@sha256:<64 hex>)");
@@ -61,14 +73,17 @@ async function assertOffensiveImagePresent(imageDigest, docker) {
     throw new Error("assertOffensiveImagePresent requires a docker.inspectImage(digest) function");
   }
   let present = false;
+  let inspectError = null;
   try {
     present = await docker.inspectImage(imageDigest);
-  } catch {
+  } catch (err) {
+    inspectError = err;
     present = false;
   }
   if (present !== true) {
+    const why = inspectError ? ` (docker inspect failed: ${inspectError.message})` : "";
     throw new Error(
-      `offensive image ${imageDigest} is not present in the local docker store. ` +
+      `offensive image ${imageDigest} is not present in the local docker store${why}. ` +
         `Run scripts/build-offensive-image.sh to build/push/pull-by-digest before an offensive run.`
     );
   }

--- a/mcp/lib/offensive-image.js
+++ b/mcp/lib/offensive-image.js
@@ -27,7 +27,8 @@ const { IMAGE_DIGEST_RE } = require("./offensive-sandbox.js");
 
 const LOCK_BASENAME = "offensive-image.json";
 
-// Operator-minted lockfile committed next to this module; install.js copies it. ABSENT until minted.
+// Operator-minted lockfile next to this module — OPERATOR-LOCAL (gitignored; the digest is deployment-specific,
+// so it is NOT committed/shipped). install.js copies it into the runtime if present; ABSENT until minted.
 function offensiveImageLockPath() {
   return path.join(__dirname, LOCK_BASENAME);
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ".hacker-bob/knowledge/**/*",
     "adapters/**/*",
     "bin/**/*.js",
+    "docker/**/*.Dockerfile",
     "docs/**/*.md",
     "!docs/refactor-*.md",
     "!docs/plane-delta/detail/**/*",

--- a/scripts/build-offensive-image.sh
+++ b/scripts/build-offensive-image.sh
@@ -12,28 +12,28 @@
 # clean) and sha256-verified. PREFER an IN-REPO pinned SHA (HTTPX_SHA256/DALFOX_SHA256 below) so a
 # compromised upstream release fails against an in-repo reference; otherwise the FIRST mint is TOFU
 # (verified against the release's own checksums file — same channel — with a loud warning + the
-# computed SHA printed for you to pin).
+# computed SHA printed for you to pin). The base image is resolved to a digest before the build so the
+# build is reproducible, and the final image digest is bound to ${REGISTRY} (never RepoDigests[0]).
 #
 # ONE-TIME OPERATOR PREREQS (the script refuses to push without them):
 #   1. Docker Desktop running.
 #   2. docker login ghcr.io   (Personal Access Token with the write:packages scope)
 #
 # Usage:
-#   scripts/build-offensive-image.sh                # full: fetch+verify+stage -> build -> push -> pin
-#   scripts/build-offensive-image.sh --stage-only   # fetch+verify+stage binaries only (no docker)
+#   HTTPX_VERSION=x.y.z DALFOX_VERSION=x.y.z scripts/build-offensive-image.sh                # full mint
+#   HTTPX_VERSION=x.y.z DALFOX_VERSION=x.y.z scripts/build-offensive-image.sh --stage-only   # no docker
 #
-# Override knobs (env): HTTPX_VERSION, DALFOX_VERSION, HTTPX_SHA256, DALFOX_SHA256,
-#                       OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
+# Override knobs (env): HTTPX_SHA256, DALFOX_SHA256, OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
 set -euo pipefail
 
-# --- pinned arsenal versions — VERIFY against the current GitHub releases before a real run ---
-# A wrong version fails loudly at download (404); a tampered asset fails at the checksum gate.
-HTTPX_VERSION="${HTTPX_VERSION:-1.6.10}"
-DALFOX_VERSION="${DALFOX_VERSION:-2.9.6}"
+# --- pinned arsenal versions (REQUIRED — no default: a hardcoded guess can 404, and there is no
+#     'current' version that stays valid). Look up + pin the exact release tags:
+#       httpx:  https://github.com/projectdiscovery/httpx/releases
+#       dalfox: https://github.com/hahwul/dalfox/releases
+HTTPX_VERSION="${HTTPX_VERSION:?set HTTPX_VERSION to a current httpx release (see github.com/projectdiscovery/httpx/releases)}"
+DALFOX_VERSION="${DALFOX_VERSION:?set DALFOX_VERSION to a current dalfox release (see github.com/hahwul/dalfox/releases)}"
 
-# --- in-repo pinned SHA256 of each downloaded asset (release-tamper protection) ---
-# Leave empty for the FIRST mint (TOFU). Then pin the printed value here (or via env) so a later
-# compromised upstream release fails against this in-repo reference, not a same-channel checksums file.
+# --- in-repo pinned SHA256 of each downloaded asset (release-tamper protection); empty => TOFU 1st mint ---
 HTTPX_SHA256="${HTTPX_SHA256:-}"
 DALFOX_SHA256="${DALFOX_SHA256:-}"
 
@@ -76,6 +76,16 @@ fi
 
 upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }
 
+# strip a tag/digest off an image ref -> bare repo (handles an optional registry :port)
+bare_repo() { local r="${1%@*}"; printf '%s' "${r%:*}"; }
+
+# pick the RepoDigest bound to a given repo (never blindly index 0 across registries).
+# args: image_ref repo_prefix -> echoes repo@sha256:<64hex> (empty if none match)
+repo_digest_for() {
+  docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$1" |
+    awk -v p="$2@sha256:" 'index($0,p)==1 && length($0)==length(p)+64 && substr($0,length(p)+1) ~ /^[0-9a-f]{64}$/ {print; exit}'
+}
+
 # clean up all temp dirs on exit
 TMPDIRS=()
 cleanup() { local d; for d in "${TMPDIRS[@]:-}"; do [ -n "${d}" ] && rm -rf "${d}"; done; }
@@ -106,7 +116,9 @@ fetch_verify() {
   echo "${tmp}/${asset}"
 }
 
-rm -rf "${BIN_DIR:?}"     # atomic reset — clears dotfiles too so nothing stale sneaks into `COPY bin/`
+# reset the WHOLE build context — `docker build "${CONTEXT_DIR}"` uploads the entire dir to the daemon,
+# so nothing stale/secret elsewhere under the gitignored context should ever be sent. Only bin/ remains.
+rm -rf "${CONTEXT_DIR:?}"
 mkdir -p "${BIN_DIR}"
 
 # httpx (projectdiscovery) — .zip containing the bare `httpx` binary
@@ -124,25 +136,28 @@ if [ "${STAGE_ONLY}" = "1" ]; then echo "stage-only: skipping docker build/push/
 
 docker version >/dev/null 2>&1 || { echo "Docker daemon not running — start Docker Desktop" >&2; exit 4; }
 
+# resolve the base image to an immutable digest so the build is reproducible (recorded in the lockfile)
+echo ">> resolving base image digest for ${BASE_IMAGE}"
+docker pull "${BASE_IMAGE}" >/dev/null
+BASE_DIGEST="$(repo_digest_for "${BASE_IMAGE}" "$(bare_repo "${BASE_IMAGE}")")"
+[ -n "${BASE_DIGEST}" ] || { echo "could not resolve a digest for base image ${BASE_IMAGE}" >&2; exit 5; }
+echo ">> base pinned: ${BASE_DIGEST}"
+
 TAG="${REGISTRY}:$(date -u +%Y%m%d)-${ARCH}-httpx${HTTPX_VERSION}-dalfox${DALFOX_VERSION}"
-echo ">> building ${TAG} (${PLATFORM}, base ${BASE_IMAGE})"
-docker build --platform "${PLATFORM}" --build-arg "BASE_IMAGE=${BASE_IMAGE}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
+echo ">> building ${TAG} (${PLATFORM}, base ${BASE_DIGEST})"
+docker build --platform "${PLATFORM}" --build-arg "BASE_IMAGE=${BASE_DIGEST}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
 
 echo ">> pushing ${TAG}  (needs: docker login ghcr.io with write:packages)"
 docker push "${TAG}"
 
-DIGEST="$(docker inspect --format '{{index .RepoDigests 0}}' "${TAG}")"
-[ -n "${DIGEST}" ] || { echo "could not resolve RepoDigest after push" >&2; exit 5; }
-# validate the digest shape before writing it into the lockfile (offensive-image.js also fail-closes on read)
-case "${DIGEST}" in
-  *@sha256:*) : ;;
-  *) echo "resolved digest is not name@sha256:<digest>: ${DIGEST}" >&2; exit 5 ;;
-esac
+# bind the pinned digest to the registry we just pushed to (never blindly take RepoDigests[0])
+DIGEST="$(repo_digest_for "${TAG}" "$(bare_repo "${REGISTRY}")")"
+[ -n "${DIGEST}" ] || { echo "could not resolve ${REGISTRY}@sha256:<digest> after push" >&2; docker inspect --format '{{json .RepoDigests}}' "${TAG}" >&2; exit 5; }
 echo ">> pulling by digest so --pull=never can resolve it locally: ${DIGEST}"
 docker pull "${DIGEST}" >/dev/null
 
 # write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as JSON DATA — commit it.
 printf '{\n  "image_digest": "%s",\n  "base_image": "%s",\n  "built_platform": "%s",\n  "tools": { "httpx": "%s", "dalfox": "%s" }\n}\n' \
-  "${DIGEST}" "${BASE_IMAGE}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
+  "${DIGEST}" "${BASE_DIGEST}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
 echo ">> wrote ${LOCKFILE}:"; cat "${LOCKFILE}"
 echo ">> DONE. Commit mcp/lib/offensive-image.json."

--- a/scripts/build-offensive-image.sh
+++ b/scripts/build-offensive-image.sh
@@ -2,40 +2,31 @@
 #
 # build-offensive-image.sh — build + push + DIGEST-PIN the Hacker Bob offensive arsenal image.
 #
-# WHY THIS EXISTS: offensive-sandbox.js runs the offensive container with `--pull=never` +
-# `name@sha256:<digest>` (IMAGE_DIGEST_RE). A purely-local `docker build` has NO RepoDigest, so it
-# cannot be run by digest. The only sound way to mint a resolvable digest is: build -> push to a
-# registry -> pull-by-digest. This script does exactly that against ghcr.io and writes the resulting
-# digest to mcp/lib/offensive-image.json (the SOLE source of runOffensiveTool's imageDigest).
+# WHY: offensive-sandbox.js runs the container with `--pull=never` + `name@sha256:<digest>`. A local
+# `docker build` has NO RepoDigest, so the only way to mint a resolvable digest is build -> push to a
+# registry -> pull-by-digest. This does that against ghcr.io and writes mcp/lib/offensive-image.json
+# (the SOLE source of runOffensiveTool's imageDigest).
 #
-# PROVENANCE: the arsenal binaries are fetched on THIS host (where ghcr/github egress is verified
-# clean) and sha256-verified. PREFER an IN-REPO pinned SHA (HTTPX_SHA256/DALFOX_SHA256 below) so a
-# compromised upstream release fails against an in-repo reference; otherwise the FIRST mint is TOFU
-# (verified against the release's own checksums file — same channel — with a loud warning + the
-# computed SHA printed for you to pin). The base image is resolved to a digest before the build so the
-# build is reproducible, and the final image digest is bound to ${REGISTRY} (never RepoDigests[0]).
+# PROVENANCE: you supply each tool's exact release archive URL + its published sha256 (both REQUIRED).
+# The script verifies the download against your pin — no upstream asset-name guessing (release naming
+# differs per tool/version) and no trust-on-first-use. The base image is resolved to an immutable
+# @sha256: digest before the build (reproducible); the final image digest is bound to ${REGISTRY}.
 #
-# ONE-TIME OPERATOR PREREQS (the script refuses to push without them):
-#   1. Docker Desktop running.
-#   2. docker login ghcr.io   (Personal Access Token with the write:packages scope)
+# ONE-TIME PREREQS: Docker running + `docker login ghcr.io` (PAT with the write:packages scope).
 #
-# Usage:
-#   HTTPX_VERSION=x.y.z DALFOX_VERSION=x.y.z scripts/build-offensive-image.sh                # full mint
-#   HTTPX_VERSION=x.y.z DALFOX_VERSION=x.y.z scripts/build-offensive-image.sh --stage-only   # no docker
+# Usage — from each project's releases page, copy the linux archive URL for your arch + its sha256:
+#   HTTPX_URL=...  HTTPX_SHA256=...  DALFOX_URL=...  DALFOX_SHA256=...  scripts/build-offensive-image.sh
+#   ... same env ... scripts/build-offensive-image.sh --stage-only     # fetch+verify+stage, no docker
 #
-# Override knobs (env): HTTPX_SHA256, DALFOX_SHA256, OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
+# Override knobs (env): OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
 set -euo pipefail
 
-# --- pinned arsenal versions (REQUIRED — no default: a hardcoded guess can 404, and there is no
-#     'current' version that stays valid). Look up + pin the exact release tags:
-#       httpx:  https://github.com/projectdiscovery/httpx/releases
-#       dalfox: https://github.com/hahwul/dalfox/releases
-HTTPX_VERSION="${HTTPX_VERSION:?set HTTPX_VERSION to a current httpx release (see github.com/projectdiscovery/httpx/releases)}"
-DALFOX_VERSION="${DALFOX_VERSION:?set DALFOX_VERSION to a current dalfox release (see github.com/hahwul/dalfox/releases)}"
-
-# --- in-repo pinned SHA256 of each downloaded asset (release-tamper protection); empty => TOFU 1st mint ---
-HTTPX_SHA256="${HTTPX_SHA256:-}"
-DALFOX_SHA256="${DALFOX_SHA256:-}"
+# REQUIRED per-tool inputs — the exact release ARCHIVE URL + its published sha256 (no defaults). Supplying
+# the URL avoids guessing release asset names; supplying the sha pins the binary to the published hash.
+HTTPX_URL="${HTTPX_URL:?set HTTPX_URL to the httpx linux release archive (github.com/projectdiscovery/httpx/releases)}"
+HTTPX_SHA256="${HTTPX_SHA256:?set HTTPX_SHA256 to the published sha256 of HTTPX_URL}"
+DALFOX_URL="${DALFOX_URL:?set DALFOX_URL to the dalfox linux release archive (github.com/hahwul/dalfox/releases)}"
+DALFOX_SHA256="${DALFOX_SHA256:?set DALFOX_SHA256 to the published sha256 of DALFOX_URL}"
 
 REGISTRY="${OFFENSIVE_REGISTRY:-ghcr.io/bobnetsec/bob-offense}"
 BASE_IMAGE="${BASE_IMAGE:-gcr.io/distroless/base-debian12:nonroot}"
@@ -48,11 +39,6 @@ LOCKFILE="${REPO_ROOT}/mcp/lib/offensive-image.json"
 STAGE_ONLY=0
 [ "${1:-}" = "--stage-only" ] && STAGE_ONLY=1
 
-# version-format guard — keep the version env vars from injecting path/URL segments into the curl URL
-valid_ver() { case "$1" in *[!0-9.]* | "" ) return 1 ;; *.*.* ) return 0 ;; * ) return 1 ;; esac; }
-valid_ver "${HTTPX_VERSION}"  || { echo "bad HTTPX_VERSION (want N.N.N): ${HTTPX_VERSION}" >&2; exit 2; }
-valid_ver "${DALFOX_VERSION}" || { echo "bad DALFOX_VERSION (want N.N.N): ${DALFOX_VERSION}" >&2; exit 2; }
-
 # target platform: linux + host arch (override with OFFENSIVE_ARCH=amd64|arm64)
 host_arch="$(uname -m)"
 case "${OFFENSIVE_ARCH:-${host_arch}}" in
@@ -63,7 +49,7 @@ esac
 PLATFORM="linux/${ARCH}"
 
 need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 2; }; }
-need curl; need unzip; need tar; need awk
+need curl; need unzip; need tar; need awk; need find
 
 # sha256 helper — prefer sha256sum (Linux), fall back to shasum (macOS)
 if command -v sha256sum >/dev/null 2>&1; then
@@ -74,13 +60,16 @@ else
   echo "need sha256sum or shasum" >&2; exit 2
 fi
 
-upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }
-
-# strip a tag/digest off an image ref -> bare repo (handles an optional registry :port)
-bare_repo() { local r="${1%@*}"; printf '%s' "${r%:*}"; }
+# strip a tag/digest off an image ref -> bare repo, PORT-AWARE (a registry host:port colon is not a tag).
+bare_repo() {
+  local r="${1%@*}"                # strip @digest
+  case "${r##*/}" in               # only the part after the last '/' can hold a :tag
+    *:*) printf '%s' "${r%:*}" ;;  # has a tag -> strip it
+    *)   printf '%s' "${r}" ;;     # no tag (a host:port colon lives before the last '/')
+  esac
+}
 
 # pick the RepoDigest bound to a given repo (never blindly index 0 across registries).
-# args: image_ref repo_prefix -> echoes repo@sha256:<64hex> (empty if none match)
 repo_digest_for() {
   docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$1" |
     awk -v p="$2@sha256:" 'index($0,p)==1 && length($0)==length(p)+64 && substr($0,length(p)+1) ~ /^[0-9a-f]{64}$/ {print; exit}'
@@ -91,29 +80,25 @@ TMPDIRS=()
 cleanup() { local d; for d in "${TMPDIRS[@]:-}"; do [ -n "${d}" ] && rm -rf "${d}"; done; }
 trap cleanup EXIT
 
-# fetch a release asset and verify it against an IN-REPO pinned sha if provided, else (TOFU) against the
-# release's own checksums file with a loud warning. args: tool version asset checks slug pinned_sha
-# echoes the verified asset path on stdout.
-fetch_verify() {
-  local tool="$1" ver="$2" asset="$3" checks="$4" slug="$5" pinned="$6"
-  local tmp base got want
+# download an archive, verify its sha256 against the REQUIRED pin, extract a named binary into BIN_DIR.
+# args: binary_name url expected_sha
+fetch_bin() {
+  local name="$1" url="$2" want="$3" tmp got found
   tmp="$(mktemp -d)"; TMPDIRS+=("${tmp}")
-  base="https://github.com/${slug}/releases/download/v${ver}"
-  echo ">> ${tool} v${ver} (${ARCH}): downloading ${asset}" >&2
-  curl -fsSL "${base}/${asset}" -o "${tmp}/${asset}"
-  got="$(sha256_of "${tmp}/${asset}")"
-  if [ -n "${pinned}" ]; then
-    [ "${pinned}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: in-repo pinned ${pinned} got ${got}" >&2; exit 3; }
-    echo ">> ${tool}: verified against in-repo pinned SHA (${got})" >&2
-  else
-    curl -fsSL "${base}/${checks}" -o "${tmp}/${checks}"
-    want="$(awk -v f="${asset}" '$2 == f || $2 == "*" f {print $1; exit}' "${tmp}/${checks}")"
-    [ -n "${want}" ] || { echo "no checksum for ${asset} in ${checks}" >&2; exit 3; }
-    [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: release-checksums ${want} got ${got}" >&2; exit 3; }
-    echo "!! ${tool}: TOFU — verified against the release's OWN checksums (same channel; NOT release-tamper-proof)." >&2
-    echo "!! Pin in-repo to harden: $(upper "${tool}")_SHA256=${got}" >&2
-  fi
-  echo "${tmp}/${asset}"
+  echo ">> ${name}: downloading ${url}" >&2
+  curl -fsSL "${url}" -o "${tmp}/archive"
+  got="$(sha256_of "${tmp}/archive")"
+  [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${name}: expected ${want} got ${got}" >&2; exit 3; }
+  echo ">> ${name}: sha256 OK (${got})" >&2
+  case "${url}" in
+    *.zip)          ( cd "${tmp}" && unzip -oq archive ) ;;
+    *.tar.gz|*.tgz) tar -xzf "${tmp}/archive" -C "${tmp}" ;;
+    *.tar.xz)       tar -xJf "${tmp}/archive" -C "${tmp}" ;;
+    *) echo "unsupported archive type for ${url} (want .zip / .tar.gz / .tgz / .tar.xz)" >&2; exit 3 ;;
+  esac
+  found="$(find "${tmp}" -type f -name "${name}" | head -1)"
+  [ -n "${found}" ] || { echo "binary '${name}' not found inside ${url}" >&2; exit 3; }
+  cp "${found}" "${BIN_DIR}/${name}"
 }
 
 # reset the WHOLE build context — `docker build "${CONTEXT_DIR}"` uploads the entire dir to the daemon,
@@ -121,14 +106,8 @@ fetch_verify() {
 rm -rf "${CONTEXT_DIR:?}"
 mkdir -p "${BIN_DIR}"
 
-# httpx (projectdiscovery) — .zip containing the bare `httpx` binary
-hx="$(fetch_verify httpx "${HTTPX_VERSION}" "httpx_${HTTPX_VERSION}_linux_${ARCH}.zip" "httpx_${HTTPX_VERSION}_checksums.txt" projectdiscovery/httpx "${HTTPX_SHA256}")"
-unzip -o -j "${hx}" httpx -d "${BIN_DIR}" >/dev/null
-
-# dalfox (hahwul) — .tar.gz containing the bare `dalfox` binary (flat layout)
-dx="$(fetch_verify dalfox "${DALFOX_VERSION}" "dalfox_${DALFOX_VERSION}_linux_${ARCH}.tar.gz" "dalfox_${DALFOX_VERSION}_checksums.txt" hahwul/dalfox "${DALFOX_SHA256}")"
-tar -xzf "${dx}" -C "${BIN_DIR}" dalfox
-
+fetch_bin httpx  "${HTTPX_URL}"  "${HTTPX_SHA256}"
+fetch_bin dalfox "${DALFOX_URL}" "${DALFOX_SHA256}"
 chmod 0755 "${BIN_DIR}"/*
 echo ">> staged binaries:"; ls -l "${BIN_DIR}"
 
@@ -143,7 +122,7 @@ BASE_DIGEST="$(repo_digest_for "${BASE_IMAGE}" "$(bare_repo "${BASE_IMAGE}")")"
 [ -n "${BASE_DIGEST}" ] || { echo "could not resolve a digest for base image ${BASE_IMAGE}" >&2; exit 5; }
 echo ">> base pinned: ${BASE_DIGEST}"
 
-TAG="${REGISTRY}:$(date -u +%Y%m%d)-${ARCH}-httpx${HTTPX_VERSION}-dalfox${DALFOX_VERSION}"
+TAG="${REGISTRY}:$(date -u +%Y%m%d%H%M%S)-${ARCH}"
 echo ">> building ${TAG} (${PLATFORM}, base ${BASE_DIGEST})"
 docker build --platform "${PLATFORM}" --build-arg "BASE_IMAGE=${BASE_DIGEST}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
 
@@ -157,7 +136,7 @@ echo ">> pulling by digest so --pull=never can resolve it locally: ${DIGEST}"
 docker pull "${DIGEST}" >/dev/null
 
 # write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as JSON DATA — commit it.
-printf '{\n  "image_digest": "%s",\n  "base_image": "%s",\n  "built_platform": "%s",\n  "tools": { "httpx": "%s", "dalfox": "%s" }\n}\n' \
-  "${DIGEST}" "${BASE_DIGEST}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
+printf '{\n  "image_digest": "%s",\n  "base_image": "%s",\n  "built_platform": "%s",\n  "tools": { "httpx_sha256": "%s", "dalfox_sha256": "%s" }\n}\n' \
+  "${DIGEST}" "${BASE_DIGEST}" "${PLATFORM}" "${HTTPX_SHA256}" "${DALFOX_SHA256}" > "${LOCKFILE}"
 echo ">> wrote ${LOCKFILE}:"; cat "${LOCKFILE}"
 echo ">> DONE. Commit mcp/lib/offensive-image.json."

--- a/scripts/build-offensive-image.sh
+++ b/scripts/build-offensive-image.sh
@@ -91,12 +91,12 @@ fetch_bin() {
   [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${name}: expected ${want} got ${got}" >&2; exit 3; }
   echo ">> ${name}: sha256 OK (${got})" >&2
   case "${url}" in
-    *.zip)          ( cd "${tmp}" && unzip -oq archive ) ;;
+    *.zip)          unzip -ojq "${tmp}/archive" -d "${tmp}" ;;  # -j junks paths (no zip-slip traversal)
     *.tar.gz|*.tgz) tar -xzf "${tmp}/archive" -C "${tmp}" ;;
     *.tar.xz)       tar -xJf "${tmp}/archive" -C "${tmp}" ;;
     *) echo "unsupported archive type for ${url} (want .zip / .tar.gz / .tgz / .tar.xz)" >&2; exit 3 ;;
   esac
-  found="$(find "${tmp}" -type f -name "${name}" | head -1)"
+  found="$(find "${tmp}" -type f -name "${name}" | sort | head -1)"  # sort => deterministic pick
   [ -n "${found}" ] || { echo "binary '${name}' not found inside ${url}" >&2; exit 3; }
   cp "${found}" "${BIN_DIR}/${name}"
 }
@@ -117,7 +117,7 @@ docker version >/dev/null 2>&1 || { echo "Docker daemon not running — start Do
 
 # resolve the base image to an immutable digest so the build is reproducible (recorded in the lockfile)
 echo ">> resolving base image digest for ${BASE_IMAGE}"
-docker pull "${BASE_IMAGE}" >/dev/null
+docker pull --platform "${PLATFORM}" "${BASE_IMAGE}" >/dev/null
 BASE_DIGEST="$(repo_digest_for "${BASE_IMAGE}" "$(bare_repo "${BASE_IMAGE}")")"
 [ -n "${BASE_DIGEST}" ] || { echo "could not resolve a digest for base image ${BASE_IMAGE}" >&2; exit 5; }
 echo ">> base pinned: ${BASE_DIGEST}"
@@ -132,11 +132,14 @@ docker push "${TAG}"
 # bind the pinned digest to the registry we just pushed to (never blindly take RepoDigests[0])
 DIGEST="$(repo_digest_for "${TAG}" "$(bare_repo "${REGISTRY}")")"
 [ -n "${DIGEST}" ] || { echo "could not resolve ${REGISTRY}@sha256:<digest> after push" >&2; docker inspect --format '{{json .RepoDigests}}' "${TAG}" >&2; exit 5; }
+# the runtime sandbox (offensive-sandbox.js IMAGE_DIGEST_RE) rejects any colon before @sha256 — fail loud
+# here rather than write a lockfile the runner can't load (e.g. a ported OFFENSIVE_REGISTRY host:port/...).
+[[ "${DIGEST}" =~ ^[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$ ]] || { echo "resolved digest ${DIGEST} is not accepted by the runtime image pin (e.g. a registry port) — use a colon-free OFFENSIVE_REGISTRY" >&2; exit 5; }
 echo ">> pulling by digest so --pull=never can resolve it locally: ${DIGEST}"
 docker pull "${DIGEST}" >/dev/null
 
-# write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as JSON DATA — commit it.
+# write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as JSON DATA (operator-local; gitignored).
 printf '{\n  "image_digest": "%s",\n  "base_image": "%s",\n  "built_platform": "%s",\n  "tools": { "httpx_sha256": "%s", "dalfox_sha256": "%s" }\n}\n' \
   "${DIGEST}" "${BASE_DIGEST}" "${PLATFORM}" "${HTTPX_SHA256}" "${DALFOX_SHA256}" > "${LOCKFILE}"
 echo ">> wrote ${LOCKFILE}:"; cat "${LOCKFILE}"
-echo ">> DONE. Commit mcp/lib/offensive-image.json."
+echo ">> DONE. The lockfile is operator-local (gitignored) — pick it up with ./install.sh <runtime>; do not commit it."

--- a/scripts/build-offensive-image.sh
+++ b/scripts/build-offensive-image.sh
@@ -9,8 +9,10 @@
 # digest to mcp/lib/offensive-image.json (the SOLE source of runOffensiveTool's imageDigest).
 #
 # PROVENANCE: the arsenal binaries are fetched on THIS host (where ghcr/github egress is verified
-# clean) and sha256-verified against each tool's official GitHub release checksums file, then COPIED
-# into a hermetic image (no in-build network, no builder toolchain).
+# clean) and sha256-verified. PREFER an IN-REPO pinned SHA (HTTPX_SHA256/DALFOX_SHA256 below) so a
+# compromised upstream release fails against an in-repo reference; otherwise the FIRST mint is TOFU
+# (verified against the release's own checksums file — same channel — with a loud warning + the
+# computed SHA printed for you to pin).
 #
 # ONE-TIME OPERATOR PREREQS (the script refuses to push without them):
 #   1. Docker Desktop running.
@@ -20,7 +22,8 @@
 #   scripts/build-offensive-image.sh                # full: fetch+verify+stage -> build -> push -> pin
 #   scripts/build-offensive-image.sh --stage-only   # fetch+verify+stage binaries only (no docker)
 #
-# Override knobs (env): HTTPX_VERSION, DALFOX_VERSION, OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
+# Override knobs (env): HTTPX_VERSION, DALFOX_VERSION, HTTPX_SHA256, DALFOX_SHA256,
+#                       OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
 set -euo pipefail
 
 # --- pinned arsenal versions — VERIFY against the current GitHub releases before a real run ---
@@ -28,15 +31,27 @@ set -euo pipefail
 HTTPX_VERSION="${HTTPX_VERSION:-1.6.10}"
 DALFOX_VERSION="${DALFOX_VERSION:-2.9.6}"
 
+# --- in-repo pinned SHA256 of each downloaded asset (release-tamper protection) ---
+# Leave empty for the FIRST mint (TOFU). Then pin the printed value here (or via env) so a later
+# compromised upstream release fails against this in-repo reference, not a same-channel checksums file.
+HTTPX_SHA256="${HTTPX_SHA256:-}"
+DALFOX_SHA256="${DALFOX_SHA256:-}"
+
 REGISTRY="${OFFENSIVE_REGISTRY:-ghcr.io/bobnetsec/bob-offense}"
+BASE_IMAGE="${BASE_IMAGE:-gcr.io/distroless/base-debian12:nonroot}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTEXT_DIR="${REPO_ROOT}/docker/offensive-context"
 BIN_DIR="${CONTEXT_DIR}/bin"
 DOCKERFILE="${REPO_ROOT}/docker/offensive.Dockerfile"
-LOCKFILE="${REPO_ROOT}/mcp/lib/offensive-image-lock.js"
+LOCKFILE="${REPO_ROOT}/mcp/lib/offensive-image.json"
 
 STAGE_ONLY=0
 [ "${1:-}" = "--stage-only" ] && STAGE_ONLY=1
+
+# version-format guard — keep the version env vars from injecting path/URL segments into the curl URL
+valid_ver() { case "$1" in *[!0-9.]* | "" ) return 1 ;; *.*.* ) return 0 ;; * ) return 1 ;; esac; }
+valid_ver "${HTTPX_VERSION}"  || { echo "bad HTTPX_VERSION (want N.N.N): ${HTTPX_VERSION}" >&2; exit 2; }
+valid_ver "${DALFOX_VERSION}" || { echo "bad DALFOX_VERSION (want N.N.N): ${DALFOX_VERSION}" >&2; exit 2; }
 
 # target platform: linux + host arch (override with OFFENSIVE_ARCH=amd64|arm64)
 host_arch="$(uname -m)"
@@ -48,38 +63,58 @@ esac
 PLATFORM="linux/${ARCH}"
 
 need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 2; }; }
-need curl; need shasum; need unzip; need tar; need awk
+need curl; need unzip; need tar; need awk
 
-sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+# sha256 helper — prefer sha256sum (Linux), fall back to shasum (macOS)
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  echo "need sha256sum or shasum" >&2; exit 2
+fi
 
-# fetch a release asset + verify it against the release's official checksums file.
-# args: tool, version, asset_filename, checksums_filename, github_owner/repo ; echoes the asset path
+upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }
+
+# clean up all temp dirs on exit
+TMPDIRS=()
+cleanup() { local d; for d in "${TMPDIRS[@]:-}"; do [ -n "${d}" ] && rm -rf "${d}"; done; }
+trap cleanup EXIT
+
+# fetch a release asset and verify it against an IN-REPO pinned sha if provided, else (TOFU) against the
+# release's own checksums file with a loud warning. args: tool version asset checks slug pinned_sha
+# echoes the verified asset path on stdout.
 fetch_verify() {
-  local tool="$1" ver="$2" asset="$3" checks="$4" slug="$5"
-  local tmp base want got
-  tmp="$(mktemp -d)"
+  local tool="$1" ver="$2" asset="$3" checks="$4" slug="$5" pinned="$6"
+  local tmp base got want
+  tmp="$(mktemp -d)"; TMPDIRS+=("${tmp}")
   base="https://github.com/${slug}/releases/download/v${ver}"
   echo ">> ${tool} v${ver} (${ARCH}): downloading ${asset}" >&2
-  curl -fsSL "${base}/${asset}"  -o "${tmp}/${asset}"
-  curl -fsSL "${base}/${checks}" -o "${tmp}/${checks}"
-  # checksums lines are "<sha>  <file>" or "<sha> *<file>"
-  want="$(awk -v f="${asset}" '$2 == f || $2 == "*" f {print $1; exit}' "${tmp}/${checks}")"
-  [ -n "${want}" ] || { echo "no checksum for ${asset} in ${checks}" >&2; exit 3; }
+  curl -fsSL "${base}/${asset}" -o "${tmp}/${asset}"
   got="$(sha256_of "${tmp}/${asset}")"
-  [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: want ${want} got ${got}" >&2; exit 3; }
-  echo ">> ${tool}: checksum OK (${got})" >&2
+  if [ -n "${pinned}" ]; then
+    [ "${pinned}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: in-repo pinned ${pinned} got ${got}" >&2; exit 3; }
+    echo ">> ${tool}: verified against in-repo pinned SHA (${got})" >&2
+  else
+    curl -fsSL "${base}/${checks}" -o "${tmp}/${checks}"
+    want="$(awk -v f="${asset}" '$2 == f || $2 == "*" f {print $1; exit}' "${tmp}/${checks}")"
+    [ -n "${want}" ] || { echo "no checksum for ${asset} in ${checks}" >&2; exit 3; }
+    [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: release-checksums ${want} got ${got}" >&2; exit 3; }
+    echo "!! ${tool}: TOFU — verified against the release's OWN checksums (same channel; NOT release-tamper-proof)." >&2
+    echo "!! Pin in-repo to harden: $(upper "${tool}")_SHA256=${got}" >&2
+  fi
   echo "${tmp}/${asset}"
 }
 
+rm -rf "${BIN_DIR:?}"     # atomic reset — clears dotfiles too so nothing stale sneaks into `COPY bin/`
 mkdir -p "${BIN_DIR}"
-rm -f "${BIN_DIR:?}"/*
 
 # httpx (projectdiscovery) — .zip containing the bare `httpx` binary
-hx="$(fetch_verify httpx "${HTTPX_VERSION}" "httpx_${HTTPX_VERSION}_linux_${ARCH}.zip" "httpx_${HTTPX_VERSION}_checksums.txt" projectdiscovery/httpx)"
+hx="$(fetch_verify httpx "${HTTPX_VERSION}" "httpx_${HTTPX_VERSION}_linux_${ARCH}.zip" "httpx_${HTTPX_VERSION}_checksums.txt" projectdiscovery/httpx "${HTTPX_SHA256}")"
 unzip -o -j "${hx}" httpx -d "${BIN_DIR}" >/dev/null
 
 # dalfox (hahwul) — .tar.gz containing the bare `dalfox` binary (flat layout)
-dx="$(fetch_verify dalfox "${DALFOX_VERSION}" "dalfox_${DALFOX_VERSION}_linux_${ARCH}.tar.gz" "dalfox_${DALFOX_VERSION}_checksums.txt" hahwul/dalfox)"
+dx="$(fetch_verify dalfox "${DALFOX_VERSION}" "dalfox_${DALFOX_VERSION}_linux_${ARCH}.tar.gz" "dalfox_${DALFOX_VERSION}_checksums.txt" hahwul/dalfox "${DALFOX_SHA256}")"
 tar -xzf "${dx}" -C "${BIN_DIR}" dalfox
 
 chmod 0755 "${BIN_DIR}"/*
@@ -90,22 +125,24 @@ if [ "${STAGE_ONLY}" = "1" ]; then echo "stage-only: skipping docker build/push/
 docker version >/dev/null 2>&1 || { echo "Docker daemon not running — start Docker Desktop" >&2; exit 4; }
 
 TAG="${REGISTRY}:$(date -u +%Y%m%d)-${ARCH}-httpx${HTTPX_VERSION}-dalfox${DALFOX_VERSION}"
-echo ">> building ${TAG} (${PLATFORM})"
-build_args=()
-[ -n "${BASE_IMAGE:-}" ] && build_args+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
-docker build --platform "${PLATFORM}" "${build_args[@]}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
+echo ">> building ${TAG} (${PLATFORM}, base ${BASE_IMAGE})"
+docker build --platform "${PLATFORM}" --build-arg "BASE_IMAGE=${BASE_IMAGE}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
 
 echo ">> pushing ${TAG}  (needs: docker login ghcr.io with write:packages)"
 docker push "${TAG}"
 
 DIGEST="$(docker inspect --format '{{index .RepoDigests 0}}' "${TAG}")"
 [ -n "${DIGEST}" ] || { echo "could not resolve RepoDigest after push" >&2; exit 5; }
+# validate the digest shape before writing it into the lockfile (offensive-image.js also fail-closes on read)
+case "${DIGEST}" in
+  *@sha256:*) : ;;
+  *) echo "resolved digest is not name@sha256:<digest>: ${DIGEST}" >&2; exit 5 ;;
+esac
 echo ">> pulling by digest so --pull=never can resolve it locally: ${DIGEST}"
 docker pull "${DIGEST}" >/dev/null
 
-# write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as a generated `.js` module,
-# so install.js's mcp/lib `.js` copy picks it up automatically (a `.json` would be silently dropped) — commit it.
-printf '"use strict";\n// Generated by scripts/build-offensive-image.sh — pinned offensive arsenal image digest. Commit this file.\nmodule.exports = {\n  image_digest: "%s",\n  built_platform: "%s",\n  tools: { httpx: "%s", dalfox: "%s" },\n};\n' \
-  "${DIGEST}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
+# write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as JSON DATA — commit it.
+printf '{\n  "image_digest": "%s",\n  "base_image": "%s",\n  "built_platform": "%s",\n  "tools": { "httpx": "%s", "dalfox": "%s" }\n}\n' \
+  "${DIGEST}" "${BASE_IMAGE}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
 echo ">> wrote ${LOCKFILE}:"; cat "${LOCKFILE}"
-echo ">> DONE. Commit mcp/lib/offensive-image-lock.js."
+echo ">> DONE. Commit mcp/lib/offensive-image.json."

--- a/scripts/build-offensive-image.sh
+++ b/scripts/build-offensive-image.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# build-offensive-image.sh — build + push + DIGEST-PIN the Hacker Bob offensive arsenal image.
+#
+# WHY THIS EXISTS: offensive-sandbox.js runs the offensive container with `--pull=never` +
+# `name@sha256:<digest>` (IMAGE_DIGEST_RE). A purely-local `docker build` has NO RepoDigest, so it
+# cannot be run by digest. The only sound way to mint a resolvable digest is: build -> push to a
+# registry -> pull-by-digest. This script does exactly that against ghcr.io and writes the resulting
+# digest to mcp/lib/offensive-image.json (the SOLE source of runOffensiveTool's imageDigest).
+#
+# PROVENANCE: the arsenal binaries are fetched on THIS host (where ghcr/github egress is verified
+# clean) and sha256-verified against each tool's official GitHub release checksums file, then COPIED
+# into a hermetic image (no in-build network, no builder toolchain).
+#
+# ONE-TIME OPERATOR PREREQS (the script refuses to push without them):
+#   1. Docker Desktop running.
+#   2. docker login ghcr.io   (Personal Access Token with the write:packages scope)
+#
+# Usage:
+#   scripts/build-offensive-image.sh                # full: fetch+verify+stage -> build -> push -> pin
+#   scripts/build-offensive-image.sh --stage-only   # fetch+verify+stage binaries only (no docker)
+#
+# Override knobs (env): HTTPX_VERSION, DALFOX_VERSION, OFFENSIVE_REGISTRY, OFFENSIVE_ARCH, BASE_IMAGE
+set -euo pipefail
+
+# --- pinned arsenal versions — VERIFY against the current GitHub releases before a real run ---
+# A wrong version fails loudly at download (404); a tampered asset fails at the checksum gate.
+HTTPX_VERSION="${HTTPX_VERSION:-1.6.10}"
+DALFOX_VERSION="${DALFOX_VERSION:-2.9.6}"
+
+REGISTRY="${OFFENSIVE_REGISTRY:-ghcr.io/bobnetsec/bob-offense}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTEXT_DIR="${REPO_ROOT}/docker/offensive-context"
+BIN_DIR="${CONTEXT_DIR}/bin"
+DOCKERFILE="${REPO_ROOT}/docker/offensive.Dockerfile"
+LOCKFILE="${REPO_ROOT}/mcp/lib/offensive-image-lock.js"
+
+STAGE_ONLY=0
+[ "${1:-}" = "--stage-only" ] && STAGE_ONLY=1
+
+# target platform: linux + host arch (override with OFFENSIVE_ARCH=amd64|arm64)
+host_arch="$(uname -m)"
+case "${OFFENSIVE_ARCH:-${host_arch}}" in
+  arm64|aarch64) ARCH=arm64 ;;
+  x86_64|amd64)  ARCH=amd64 ;;
+  *) echo "unsupported arch: ${OFFENSIVE_ARCH:-${host_arch}}" >&2; exit 2 ;;
+esac
+PLATFORM="linux/${ARCH}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 2; }; }
+need curl; need shasum; need unzip; need tar; need awk
+
+sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+# fetch a release asset + verify it against the release's official checksums file.
+# args: tool, version, asset_filename, checksums_filename, github_owner/repo ; echoes the asset path
+fetch_verify() {
+  local tool="$1" ver="$2" asset="$3" checks="$4" slug="$5"
+  local tmp base want got
+  tmp="$(mktemp -d)"
+  base="https://github.com/${slug}/releases/download/v${ver}"
+  echo ">> ${tool} v${ver} (${ARCH}): downloading ${asset}" >&2
+  curl -fsSL "${base}/${asset}"  -o "${tmp}/${asset}"
+  curl -fsSL "${base}/${checks}" -o "${tmp}/${checks}"
+  # checksums lines are "<sha>  <file>" or "<sha> *<file>"
+  want="$(awk -v f="${asset}" '$2 == f || $2 == "*" f {print $1; exit}' "${tmp}/${checks}")"
+  [ -n "${want}" ] || { echo "no checksum for ${asset} in ${checks}" >&2; exit 3; }
+  got="$(sha256_of "${tmp}/${asset}")"
+  [ "${want}" = "${got}" ] || { echo "CHECKSUM MISMATCH ${tool}: want ${want} got ${got}" >&2; exit 3; }
+  echo ">> ${tool}: checksum OK (${got})" >&2
+  echo "${tmp}/${asset}"
+}
+
+mkdir -p "${BIN_DIR}"
+rm -f "${BIN_DIR:?}"/*
+
+# httpx (projectdiscovery) — .zip containing the bare `httpx` binary
+hx="$(fetch_verify httpx "${HTTPX_VERSION}" "httpx_${HTTPX_VERSION}_linux_${ARCH}.zip" "httpx_${HTTPX_VERSION}_checksums.txt" projectdiscovery/httpx)"
+unzip -o -j "${hx}" httpx -d "${BIN_DIR}" >/dev/null
+
+# dalfox (hahwul) — .tar.gz containing the bare `dalfox` binary (flat layout)
+dx="$(fetch_verify dalfox "${DALFOX_VERSION}" "dalfox_${DALFOX_VERSION}_linux_${ARCH}.tar.gz" "dalfox_${DALFOX_VERSION}_checksums.txt" hahwul/dalfox)"
+tar -xzf "${dx}" -C "${BIN_DIR}" dalfox
+
+chmod 0755 "${BIN_DIR}"/*
+echo ">> staged binaries:"; ls -l "${BIN_DIR}"
+
+if [ "${STAGE_ONLY}" = "1" ]; then echo "stage-only: skipping docker build/push/pin"; exit 0; fi
+
+docker version >/dev/null 2>&1 || { echo "Docker daemon not running — start Docker Desktop" >&2; exit 4; }
+
+TAG="${REGISTRY}:$(date -u +%Y%m%d)-${ARCH}-httpx${HTTPX_VERSION}-dalfox${DALFOX_VERSION}"
+echo ">> building ${TAG} (${PLATFORM})"
+build_args=()
+[ -n "${BASE_IMAGE:-}" ] && build_args+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
+docker build --platform "${PLATFORM}" "${build_args[@]}" -f "${DOCKERFILE}" -t "${TAG}" "${CONTEXT_DIR}"
+
+echo ">> pushing ${TAG}  (needs: docker login ghcr.io with write:packages)"
+docker push "${TAG}"
+
+DIGEST="$(docker inspect --format '{{index .RepoDigests 0}}' "${TAG}")"
+[ -n "${DIGEST}" ] || { echo "could not resolve RepoDigest after push" >&2; exit 5; }
+echo ">> pulling by digest so --pull=never can resolve it locally: ${DIGEST}"
+docker pull "${DIGEST}" >/dev/null
+
+# write the lockfile (the SOLE source of runOffensiveTool's imageDigest) as a generated `.js` module,
+# so install.js's mcp/lib `.js` copy picks it up automatically (a `.json` would be silently dropped) — commit it.
+printf '"use strict";\n// Generated by scripts/build-offensive-image.sh — pinned offensive arsenal image digest. Commit this file.\nmodule.exports = {\n  image_digest: "%s",\n  built_platform: "%s",\n  tools: { httpx: "%s", dalfox: "%s" },\n};\n' \
+  "${DIGEST}" "${PLATFORM}" "${HTTPX_VERSION}" "${DALFOX_VERSION}" > "${LOCKFILE}"
+echo ">> wrote ${LOCKFILE}:"; cat "${LOCKFILE}"
+echo ">> DONE. Commit mcp/lib/offensive-image-lock.js."

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -367,6 +367,12 @@ function installProject(projectDir, options = {}) {
   }
   fs.chmodSync(path.join(mcpDir, "server.js"), 0o755);
   copyDirFiles(path.join(sourceRoot, "mcp", "lib"), path.join(mcpDir, "lib"), (name) => name.endsWith(".js"));
+  // The offensive arsenal image digest lockfile is operator-minted JSON data (scripts/build-offensive-image.sh).
+  // The mcp/lib copy above is .js-only, so copy this .json explicitly. Absent until the image is pinned.
+  const offensiveImageLock = path.join(sourceRoot, "mcp", "lib", "offensive-image.json");
+  if (fs.existsSync(offensiveImageLock)) {
+    copyFile(offensiveImageLock, path.join(mcpDir, "lib", "offensive-image.json"));
+  }
   const sourceToolsDir = path.join(sourceRoot, "mcp", "lib", "tools");
   const targetToolsDir = path.join(mcpDir, "lib", "tools");
   if (path.resolve(sourceToolsDir) !== path.resolve(targetToolsDir)) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -370,8 +370,13 @@ function installProject(projectDir, options = {}) {
   // The offensive arsenal image digest lockfile is operator-minted JSON data (scripts/build-offensive-image.sh).
   // The mcp/lib copy above is .js-only, so copy this .json explicitly. Absent until the image is pinned.
   const offensiveImageLock = path.join(sourceRoot, "mcp", "lib", "offensive-image.json");
+  const targetImageLock = path.join(mcpDir, "lib", "offensive-image.json");
   if (fs.existsSync(offensiveImageLock)) {
-    copyFile(offensiveImageLock, path.join(mcpDir, "lib", "offensive-image.json"));
+    copyFile(offensiveImageLock, targetImageLock);
+  } else {
+    // Unpinned source: remove any stale target lockfile so the runtime fails closed instead of
+    // resolving a previously-installed (now removed) digest.
+    fs.rmSync(targetImageLock, { force: true });
   }
   const sourceToolsDir = path.join(sourceRoot, "mcp", "lib", "tools");
   const targetToolsDir = path.join(mcpDir, "lib", "tools");

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -160,6 +160,7 @@
   "test/offensive-capture-writer.test.js",
   "test/offensive-sandbox.test.js",
   "test/offensive-runner.test.js",
+  "test/offensive-image.test.js",
   "test/lifecycle-state-drift.test.js",
   "test/evidence-gate-lifecycle.test.js"
 ]

--- a/test/offensive-image.test.js
+++ b/test/offensive-image.test.js
@@ -15,19 +15,17 @@ const {
 
 const GOOD = "ghcr.io/bobnetsec/bob-offense@sha256:" + "a".repeat(64);
 
-// create a temp lockfile path; pass `contents` (a `.js` module body) to write the file, omit to
-// leave it absent. Each call uses a fresh temp dir so require()-cache never collides across cases.
+// create a temp lockfile path; pass `contents` (JSON text) to write the file, omit to leave it absent.
 function tmpLock(contents) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bob-offimg-"));
-  const p = path.join(dir, "offensive-image-lock.js");
+  const p = path.join(dir, "offensive-image.json");
   if (contents !== undefined) fs.writeFileSync(p, contents);
   return p;
 }
-const lockModule = (obj) => `module.exports = ${JSON.stringify(obj)};\n`;
 
-test("offensiveImageLockPath resolves to mcp/lib/offensive-image-lock.js", () => {
-  assert.equal(OFFENSIVE_IMAGE_LOCK_BASENAME, "offensive-image-lock.js");
-  assert.ok(offensiveImageLockPath().endsWith(path.join("mcp", "lib", "offensive-image-lock.js")));
+test("offensiveImageLockPath resolves to mcp/lib/offensive-image.json", () => {
+  assert.equal(OFFENSIVE_IMAGE_LOCK_BASENAME, "offensive-image.json");
+  assert.ok(offensiveImageLockPath().endsWith(path.join("mcp", "lib", "offensive-image.json")));
 });
 
 test("resolveOffensiveImageDigest: fail-closed when the lockfile is absent", () => {
@@ -35,24 +33,34 @@ test("resolveOffensiveImageDigest: fail-closed when the lockfile is absent", () 
   assert.throws(() => resolveOffensiveImageDigest({ lockPath: p }), /not pinned/);
 });
 
-test("resolveOffensiveImageDigest: fail-closed on an unloadable lockfile", () => {
-  assert.throws(() => resolveOffensiveImageDigest({ lockPath: tmpLock("this is }{ not js") }), /not loadable/);
+test("resolveOffensiveImageDigest: fail-closed on invalid JSON", () => {
+  assert.throws(() => resolveOffensiveImageDigest({ lockPath: tmpLock("not json{") }), /not valid JSON/);
 });
 
-test("resolveOffensiveImageDigest: rejects a non-digest image_digest (mutable tag, short, empty, missing)", () => {
+test("resolveOffensiveImageDigest: rejects non-object and non-digest lockfiles", () => {
   for (const bad of [
-    lockModule({ image_digest: "ghcr.io/x/bob-offense:latest" }),
-    lockModule({ image_digest: "ghcr.io/x/bob-offense@sha256:short" }),
-    lockModule({ image_digest: "" }),
-    lockModule({ notdigest: GOOD }),
+    "null",
+    "5",
+    JSON.stringify({ image_digest: "ghcr.io/x/bob-offense:latest" }),
+    JSON.stringify({ image_digest: "ghcr.io/x/bob-offense@sha256:short" }),
+    JSON.stringify({ image_digest: "" }),
+    JSON.stringify({ notdigest: GOOD }),
   ]) {
     assert.throws(() => resolveOffensiveImageDigest({ lockPath: tmpLock(bad) }), /no valid name@sha256/);
   }
 });
 
 test("resolveOffensiveImageDigest: returns a valid pinned digest", () => {
-  const p = tmpLock(lockModule({ image_digest: GOOD, tools: { httpx: "1.0.0" } }));
+  const p = tmpLock(JSON.stringify({ image_digest: GOOD, tools: { httpx: "1.0.0" } }));
   assert.equal(resolveOffensiveImageDigest({ lockPath: p }), GOOD);
+});
+
+test("resolveOffensiveImageDigest: reads fresh each call (no require cache — picks up a bump)", () => {
+  const p = tmpLock(JSON.stringify({ image_digest: GOOD }));
+  assert.equal(resolveOffensiveImageDigest({ lockPath: p }), GOOD);
+  const BUMPED = "ghcr.io/bobnetsec/bob-offense@sha256:" + "b".repeat(64);
+  fs.writeFileSync(p, JSON.stringify({ image_digest: BUMPED }));
+  assert.equal(resolveOffensiveImageDigest({ lockPath: p }), BUMPED);
 });
 
 test("assertOffensiveImagePresent: requires a digest-pinned image (rejects a mutable tag)", async () => {
@@ -84,14 +92,14 @@ test("assertOffensiveImagePresent: fail-closed when the image is absent", async 
   );
 });
 
-test("assertOffensiveImagePresent: fail-closed (not a leak) when inspect throws", async () => {
+test("assertOffensiveImagePresent: fail-closed AND surfaces the docker error when inspect throws", async () => {
   await assert.rejects(
     () =>
       assertOffensiveImagePresent(GOOD, {
         inspectImage: async () => {
-          throw new Error("boom");
+          throw new Error("daemon down");
         },
       }),
-    /not present in the local docker store/
+    (e) => /not present in the local docker store/.test(e.message) && /daemon down/.test(e.message)
   );
 });

--- a/test/offensive-image.test.js
+++ b/test/offensive-image.test.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  offensiveImageLockPath,
+  resolveOffensiveImageDigest,
+  assertOffensiveImagePresent,
+  OFFENSIVE_IMAGE_LOCK_BASENAME,
+} = require("../mcp/lib/offensive-image.js");
+
+const GOOD = "ghcr.io/bobnetsec/bob-offense@sha256:" + "a".repeat(64);
+
+// create a temp lockfile path; pass `contents` (a `.js` module body) to write the file, omit to
+// leave it absent. Each call uses a fresh temp dir so require()-cache never collides across cases.
+function tmpLock(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bob-offimg-"));
+  const p = path.join(dir, "offensive-image-lock.js");
+  if (contents !== undefined) fs.writeFileSync(p, contents);
+  return p;
+}
+const lockModule = (obj) => `module.exports = ${JSON.stringify(obj)};\n`;
+
+test("offensiveImageLockPath resolves to mcp/lib/offensive-image-lock.js", () => {
+  assert.equal(OFFENSIVE_IMAGE_LOCK_BASENAME, "offensive-image-lock.js");
+  assert.ok(offensiveImageLockPath().endsWith(path.join("mcp", "lib", "offensive-image-lock.js")));
+});
+
+test("resolveOffensiveImageDigest: fail-closed when the lockfile is absent", () => {
+  const p = tmpLock(undefined); // dir exists, file does not
+  assert.throws(() => resolveOffensiveImageDigest({ lockPath: p }), /not pinned/);
+});
+
+test("resolveOffensiveImageDigest: fail-closed on an unloadable lockfile", () => {
+  assert.throws(() => resolveOffensiveImageDigest({ lockPath: tmpLock("this is }{ not js") }), /not loadable/);
+});
+
+test("resolveOffensiveImageDigest: rejects a non-digest image_digest (mutable tag, short, empty, missing)", () => {
+  for (const bad of [
+    lockModule({ image_digest: "ghcr.io/x/bob-offense:latest" }),
+    lockModule({ image_digest: "ghcr.io/x/bob-offense@sha256:short" }),
+    lockModule({ image_digest: "" }),
+    lockModule({ notdigest: GOOD }),
+  ]) {
+    assert.throws(() => resolveOffensiveImageDigest({ lockPath: tmpLock(bad) }), /no valid name@sha256/);
+  }
+});
+
+test("resolveOffensiveImageDigest: returns a valid pinned digest", () => {
+  const p = tmpLock(lockModule({ image_digest: GOOD, tools: { httpx: "1.0.0" } }));
+  assert.equal(resolveOffensiveImageDigest({ lockPath: p }), GOOD);
+});
+
+test("assertOffensiveImagePresent: requires a digest-pinned image (rejects a mutable tag)", async () => {
+  await assert.rejects(
+    () => assertOffensiveImagePresent("bob-offense:latest", { inspectImage: async () => true }),
+    /digest-pinned image/
+  );
+});
+
+test("assertOffensiveImagePresent: requires a docker.inspectImage function", async () => {
+  await assert.rejects(() => assertOffensiveImagePresent(GOOD, {}), /inspectImage/);
+});
+
+test("assertOffensiveImagePresent: resolves and queries the exact digest when present", async () => {
+  let askedFor = null;
+  await assertOffensiveImagePresent(GOOD, {
+    inspectImage: async (d) => {
+      askedFor = d;
+      return true;
+    },
+  });
+  assert.equal(askedFor, GOOD);
+});
+
+test("assertOffensiveImagePresent: fail-closed when the image is absent", async () => {
+  await assert.rejects(
+    () => assertOffensiveImagePresent(GOOD, { inspectImage: async () => false }),
+    /not present in the local docker store/
+  );
+});
+
+test("assertOffensiveImagePresent: fail-closed (not a leak) when inspect throws", async () => {
+  await assert.rejects(
+    () =>
+      assertOffensiveImagePresent(GOOD, {
+        inspectImage: async () => {
+          throw new Error("boom");
+        },
+      }),
+    /not present in the local docker store/
+  );
+});


### PR DESCRIPTION
## What + why

`PR-IMAGE` — the first of three sequenced PRs that turn the inert PR5a container runner into a live find
capability (`PR-IMAGE → PR-124 → PR5b-tool`, the dalfox `reflected_canary` prover).

PR5a (#123) landed the wide-open container runner + sandbox, but an ultracode exploration found the container
**can't run anything**: there is no offensive image and nothing builds one, and the sandbox's `--pull=never` +
`name@sha256:` pin **cannot resolve a local-only build** (no `RepoDigest` without a registry push/pull). This
PR lands that missing image infrastructure.

**No MCP tool is wired and `offensive-runner.js` is untouched** — that's `PR5b-tool`. `offensive-image.js` is
exercised only by tests until then (the same inert-foundation pattern as PR5a; keeps the review surface off the
concurrency-sensitive runner path).

## Contents

- **`docker/offensive.Dockerfile`** — hermetic image: host-fetched + checksum-verified `httpx` + `dalfox`
  `COPY`'d onto a shell-less `gcr.io` distroless base (gcr avoids the documented Docker-Hub TLS-intercept; no
  in-build network, no builder toolchain).
- **`scripts/build-offensive-image.sh`** — fetch+verify (each tool's official release checksums) → `docker build`
  → push `ghcr.io/bobnetsec/bob-offense` → **pull-by-digest** → write the lockfile.
- **`mcp/lib/offensive-image.js`** — `resolveOffensiveImageDigest()` (fail-closed when unminted/unloadable or the
  digest isn't `name@sha256`) + `assertOffensiveImagePresent()` (`docker image inspect` before a `--pull=never`
  run, fail-closed).
- The lockfile (`mcp/lib/offensive-image-lock.js`) is a **generated `.js` module** so `install.js`'s `mcp/lib`
  `.js` copy carries it to the runtime — a `.json` data file would be silently dropped by that copy.
- `test/offensive-image.test.js` (10) + manifest; `docs/OFFENSIVE_IMAGE.md`; gitignore the build staging dir.

## Operator one-time action (mints the digest + smoke; needed before merge)

The digest is operator-minted — the lockfile is **absent + fail-closed** until then:

```sh
# Docker Desktop running, then:
docker login ghcr.io               # username = GitHub handle; password = a write:packages PAT
./scripts/build-offensive-image.sh # build → push → pull-by-digest → writes mcp/lib/offensive-image-lock.js
```

I'll commit the generated lockfile to this branch once minted. ghcr egress was verified TLS-clean (2026-06-18);
`IMAGE_DIGEST_RE` is unchanged (ghcr has no port colon → strict pin preserved).

## Deferred (not this PR)

The `bob_offensive_*` tool + the classify/sign path + the per-tool ceiling entry + `command_hash` binding
(`PR5b-tool`); the three #124 runner mutations (`PR-124`); the OOB collector + arsenal expansion.

## Gates

`test:mcp` 2686/0 · `test:install` + `test:prompts` + `check:syntax` green · `test:hooks` 55/55.
(`test:package`/`release:check:clean` are clean on a fresh checkout; locally they only flag pre-existing
untracked scratch docs.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a digest-pinned “offensive” container image workflow using a lockfile-driven, fail-closed local preflight check.
  * Introduced a hermetic, non-root runtime container definition for the offensive toolchain.
* **Documentation**
  * Added instructions for minting, checksum-verifying, bumping, and pulling the pinned image by digest (build → push → pull-by-digest).
* **Tests**
  * Added coverage for lockfile parsing, digest validation, and local image presence enforcement; updated the test manifest.
* **Chores**
  * Updated installation to copy/remove the image lockfile, expanded npm packaging to include Dockerfiles, and improved staging ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->