### PR TITLE
feat(offense): PR-124 — runner binary-binding + named egress audit + infra-failure budget

### DIFF
--- a/mcp/lib/offensive-runner.js
+++ b/mcp/lib/offensive-runner.js
@@ -62,11 +62,19 @@ const MAX_TIMEOUT_MS = 600_000;
 const MIN_TIMEOUT_MS = 5_000;
 // Per-session cap on offensive container runs (fail-closed, global across tools).
 const MAX_OFFENSIVE_RUNS = 200;
-// #124-3: cap on infra failures (network-create / spawn errors — the container never
-// ran). These are REFUNDED from the run budget (an infra failure must not burn a
-// genuine-run slot), so they need their own bound, or a daemon/target that fails every
-// spawn could spin unbounded docker attempts. Fail-closed like the run budget.
+// #124-3: cap on infra failures (network-create / spawn errors / docker "couldn't start
+// the container" exits — the container never ran). These are REFUNDED from the run budget
+// (an infra failure must not burn a genuine-run slot), so they need their own bound, or a
+// daemon/target that fails every spawn could spin unbounded docker attempts. Fail-closed
+// like the run budget.
 const MAX_OFFENSIVE_INFRA_FAILURES = 50;
+// A legit monotonic counter is a few digits; a larger leaf is tampered → fail closed (the
+// WHOLE file is validated, never just a prefix that a padded "0…0<junk>" could spoof to 0).
+const OFFENSIVE_COUNTER_MAX_BYTES = 32;
+// docker exit codes meaning the daemon/exec could NOT run the container (the tool never
+// executed): 125 daemon run error (e.g. a --pull=never image miss), 126 not executable,
+// 127 not found. Treated as infra failures (refund + count), NOT genuine runs.
+const OFFENSIVE_CONTAINER_FAILED_EXIT_CODES = Object.freeze([125, 126, 127]);
 // http-audit normalization STRIPS `tool`, so offensive runs are marked + counted by
 // a distinctive `method` token that survives normalization.
 const OFFENSIVE_RUN_AUDIT_METHOD = "CONTAINER_RUN";
@@ -213,27 +221,35 @@ function offensiveInfraFailurePath(domain) {
   return path.join(sessionDir(domain), "offensive-infra-failures");
 }
 
-// Read a fail-closed MONOTONIC counter file with O_NOFOLLOW + regular-file discipline:
-// missing = 0 (fresh session); a SYMLINKED / hardlinked / irregular / unreadable /
-// malformed leaf fails CLOSED (Infinity → blocks). The O_NOFOLLOW open refuses to read
-// THROUGH a symlink a same-UID stale artifact could pre-create to point the counter at an
-// attacker-chosen file (e.g. one containing "0" to silently reset the budget). Strict
-// digits-only — parseInt would accept "7x" / "0x10" / "7\ntrailing" and under-count.
+// Read a fail-closed MONOTONIC counter file with O_NOFOLLOW + O_NONBLOCK + regular-file
+// discipline. missing = 0 (fresh session). A SYMLINKED (O_NOFOLLOW → ELOOP), FIFO/device
+// (O_NONBLOCK so the open can't HANG while we hold the session lock; the fstat then
+// rejects it), hardlinked (nlink≠1), OVERSIZED (a few digits is the only legit shape — a
+// larger leaf is tampered), unreadable, or malformed leaf all fail CLOSED (Infinity →
+// blocks). The WHOLE file is validated (not a 32-byte prefix), so a padded "0…0<junk>"
+// leaf can't be trusted as 0 and silently reset the budget. Strict digits-only — parseInt
+// would accept "7x" / "0x10" / "7\ntrailing" and under-count.
 function readCounterFile(filePath) {
   const noFollow = fs.constants.O_NOFOLLOW || 0;
+  const nonBlock = fs.constants.O_NONBLOCK || 0;
   let fd;
   try {
-    fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow | nonBlock);
   } catch (e) {
     if (e && e.code === "ENOENT") return 0;
-    return Number.POSITIVE_INFINITY; // ELOOP (symlinked leaf) / any open error → fail closed
+    return Number.POSITIVE_INFINITY; // ELOOP (symlink) / ENXIO / any open error → fail closed
   }
   try {
     const st = fs.fstatSync(fd);
-    if (!st.isFile() || st.nlink !== 1) return Number.POSITIVE_INFINITY;
-    const buf = Buffer.alloc(32); // a counter is a few digits; bound the read
-    const n = fs.readSync(fd, buf, 0, buf.length, 0);
-    const trimmed = buf.subarray(0, n).toString("utf8").trim();
+    if (!st.isFile() || st.nlink !== 1 || st.size > OFFENSIVE_COUNTER_MAX_BYTES) return Number.POSITIVE_INFINITY;
+    const buf = Buffer.alloc(st.size);
+    let off = 0;
+    while (off < st.size) {
+      const n = fs.readSync(fd, buf, off, st.size - off, off);
+      if (n <= 0) break;
+      off += n;
+    }
+    const trimmed = buf.subarray(0, off).toString("utf8").trim(); // validates the WHOLE file
     if (!/^\d+$/.test(trimmed)) return Number.POSITIVE_INFINITY;
     const v = Number.parseInt(trimmed, 10);
     return Number.isInteger(v) && v >= 0 ? v : Number.POSITIVE_INFINITY;
@@ -242,20 +258,21 @@ function readCounterFile(filePath) {
   }
 }
 
-// Write a counter with O_NOFOLLOW + regular-file/nlink discipline so the write can never
-// be redirected THROUGH a symlinked or hardlinked leaf to a path outside Bob's session
-// files (a same-UID stale artifact pre-creating the counter as a symlink must not turn a
-// counter write into a write-where primitive). nlink is checked BEFORE truncating so a
-// hardlinked target is never clobbered. Returns false on any failure (caller treats a
-// failed reserve as fail-closed).
+// Write a counter with O_NOFOLLOW + O_NONBLOCK + regular-file/nlink discipline so the write
+// can never be redirected THROUGH a symlinked/FIFO/hardlinked leaf to a path outside Bob's
+// session files (a same-UID stale artifact must not turn a counter write into a write-where
+// primitive, nor hang the open on a FIFO with no reader → ENXIO). nlink is checked BEFORE
+// truncating so a hardlinked target is never clobbered. Returns false on any failure
+// (caller treats a failed reserve as fail-closed).
 function writeCounterFile(domain, filePath, value) {
   const noFollow = fs.constants.O_NOFOLLOW || 0;
+  const nonBlock = fs.constants.O_NONBLOCK || 0;
   let fd;
   try {
     fs.mkdirSync(sessionDir(domain), { recursive: true });
-    fd = fs.openSync(filePath, fs.constants.O_WRONLY | fs.constants.O_CREAT | noFollow, 0o600);
+    fd = fs.openSync(filePath, fs.constants.O_WRONLY | fs.constants.O_CREAT | noFollow | nonBlock, 0o600);
   } catch {
-    return false; // ELOOP (symlinked leaf) / any open error → refuse the write
+    return false; // ELOOP (symlink) / ENXIO (FIFO, no reader) / any open error → refuse
   }
   try {
     const st = fs.fstatSync(fd);
@@ -571,6 +588,15 @@ async function runOffensiveTool({
     // failure (best-effort; fail-fast lock-miss must not mask the spawn error).
     try { withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain)); } catch {}
     return blocked(domain, toolId, "blocked_by_infra", "offensive_spawn_failed", { failure_reason: runResult.spawn_error });
+  }
+  // #124-3: docker CLI ran but the daemon/exec could NOT run the container (exit
+  // 125/126/127 — e.g. a --pull=never image miss, esp. likely before the operator mints
+  // the image). The tool never executed, so this is an infra failure (refund + count),
+  // NOT a genuine run that should burn the 200-run budget. (A non-zero exit OTHER than
+  // these is a real run whose tool exited non-zero — handled as a genuine outcome below.)
+  if (OFFENSIVE_CONTAINER_FAILED_EXIT_CODES.includes(runResult.exit_code)) {
+    try { withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain)); } catch {}
+    return blocked(domain, toolId, "blocked_by_infra", "offensive_container_failed_to_start", { exit_code: runResult.exit_code });
   }
   // A timeout is NOT refunded and NOT an infra failure: the container actually RAN
   // (consumed CPU/net + a real slot) and only failed to FINISH — a genuine run (#124-3).

--- a/mcp/lib/offensive-runner.js
+++ b/mcp/lib/offensive-runner.js
@@ -256,30 +256,36 @@ function offensiveInfraFailureCount(domain) {
   return readCounterFile(offensiveInfraFailurePath(domain));
 }
 
+// Atomically bump a monotonic counter by delta (caller holds the session lock), clamped
+// at >= 0. Fail-closed on a corrupt (non-finite) read: leave the file untouched so it
+// keeps failing CLOSED at the reservation gate rather than being reset to a finite value.
+function bumpCounterFile(domain, filePath, delta) {
+  const cur = readCounterFile(filePath);
+  if (!Number.isFinite(cur)) return false;
+  return writeCounterFile(domain, filePath, Math.max(0, cur + delta));
+}
+
 // Reserve one run by incrementing the monotonic counter (the caller holds the session
 // lock). Returns false (fail closed) if the reservation can't be read or persisted.
 function incrementOffensiveRun(domain) {
-  const next = offensiveRunCount(domain) + 1;
-  if (!Number.isFinite(next)) return false;
-  return writeCounterFile(domain, offensiveRunBudgetPath(domain), next);
+  return bumpCounterFile(domain, offensiveRunBudgetPath(domain), 1);
 }
 
-// #124-3: REFUND a previously-reserved run slot (the container never ran — an infra
-// failure) and record it in the separate infra-failure counter. The caller holds the
-// session lock so the decrement + increment are atomic w.r.t. concurrent reservations.
-// Conservative: if the run counter can't be read as a finite value we leave the slot
-// consumed (never refund MORE than was reserved); if the infra counter is corrupt
-// (non-finite) we leave it — it already fails CLOSED at the reservation gate and must
-// not be silently reset to a finite value.
-function refundOffensiveRunAsInfraFailure(domain) {
-  const runCount = offensiveRunCount(domain);
-  if (Number.isFinite(runCount) && runCount > 0) {
-    writeCounterFile(domain, offensiveRunBudgetPath(domain), runCount - 1);
-  }
-  const infra = offensiveInfraFailureCount(domain);
-  if (Number.isFinite(infra)) {
-    writeCounterFile(domain, offensiveInfraFailurePath(domain), infra + 1);
-  }
+// #124-3: the infra-failure counter is reserved PESSIMISTICALLY at reservation time
+// (every attempt holds an infra slot BEFORE docker is spawned) so the cap is enforced
+// UNDER CONCURRENCY — a burst of N parallel runs each takes a slot under the lock, so at
+// most MAX_OFFENSIVE_INFRA_FAILURES run concurrently and at most that many infra failures
+// are ever recorded (no stale-count overshoot). A GENUINE run (the container started)
+// RELEASES its slot; an infra failure (the container never ran) KEEPS it as the recorded
+// failure. Net per outcome: genuine → run+1/infra+0; infra failure → run+0/infra+1.
+function incrementOffensiveInfra(domain) {
+  return bumpCounterFile(domain, offensiveInfraFailurePath(domain), 1);
+}
+function decrementOffensiveRun(domain) {
+  return bumpCounterFile(domain, offensiveRunBudgetPath(domain), -1);
+}
+function decrementOffensiveInfra(domain) {
+  return bumpCounterFile(domain, offensiveInfraFailurePath(domain), -1);
 }
 
 // A legitimate session dir is a real directory Bob created — never a symlink. A
@@ -474,12 +480,16 @@ async function runOffensiveTool({
   const auditUrl = primaryUrl ? String(primaryUrl.value) : `https://${domain}/`;
   const reservation = withSessionLock(domain, () => {
     if (offensiveRunCount(domain) >= MAX_OFFENSIVE_RUNS) return { ok: false, reason: "offensive_run_budget_exhausted" };
-    // #124-3: infra failures are refunded from the run budget, so cap them separately to
-    // keep the total-attempts bound the reserve-before-spawn used to provide.
+    // #124-3: the infra cap is checked AND reserved under this SAME lock (pessimistically,
+    // before spawn) so it holds under concurrency — a burst of parallel runs can't all
+    // pass a stale count and overshoot the cap. A genuine run releases its infra slot
+    // once docker has started.
     if (offensiveInfraFailureCount(domain) >= MAX_OFFENSIVE_INFRA_FAILURES) return { ok: false, reason: "offensive_infra_failure_budget_exhausted" };
     const auditOk = auditConfirmRequest({ domain, surfaceId: null, method: OFFENSIVE_RUN_AUDIT_METHOD, url: auditUrl, egressProfile: egressProfileName, status: null, scopeDecision: "allowed", error: null, startedAt, toolId });
     if (auditOk === false) return { ok: false, reason: "offensive_run_audit_failed" };
     if (!incrementOffensiveRun(domain)) return { ok: false, reason: "offensive_run_budget_write_failed" };
+    // pessimistically take an infra slot too; roll back the run slot if it can't persist.
+    if (!incrementOffensiveInfra(domain)) { decrementOffensiveRun(domain); return { ok: false, reason: "offensive_infra_budget_write_failed" }; }
     return { ok: true };
   });
   if (!reservation.ok) {
@@ -503,8 +513,9 @@ async function runOffensiveTool({
   } catch (e) {
     try { docker.networkRm(runId, env); } catch {} // tear down a partially-created network
     cleanupScratch();
-    // #124-3: the container never ran — refund the reserved run slot + count it as infra.
-    withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain));
+    // #124-3: the container never ran — refund the run slot; the pessimistically-reserved
+    // infra slot STAYS (it is now the recorded infra failure).
+    withSessionLock(domain, () => decrementOffensiveRun(domain));
     return blocked(domain, toolId, "blocked_by_infra", "offensive_network_create_failed", { failure_reason: e.message || String(e) });
   }
   let stdoutBytes = Buffer.alloc(0);
@@ -523,12 +534,16 @@ async function runOffensiveTool({
   }
 
   if (runResult.spawn_error) {
-    // #124-3: docker never started the container — refund the slot + count it as infra.
-    withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain));
+    // #124-3: docker never started the container — refund the run slot; the pessimistic
+    // infra slot STAYS as the recorded infra failure.
+    withSessionLock(domain, () => decrementOffensiveRun(domain));
     return blocked(domain, toolId, "blocked_by_infra", "offensive_spawn_failed", { failure_reason: runResult.spawn_error });
   }
-  // A timeout is NOT refunded: the container actually RAN (consumed CPU/net + a real
-  // slot) and only failed to FINISH — a genuine run, not an infra failure (#124-3).
+  // #124-3: the container STARTED — every outcome from here on is a GENUINE run (it
+  // consumed a real slot), so RELEASE the pessimistically-reserved infra slot exactly
+  // once. This single release covers ALL genuine returns below, INCLUDING a timeout (the
+  // container ran and only failed to FINISH — not an infra failure).
+  withSessionLock(domain, () => decrementOffensiveInfra(domain));
   if (runResult.timed_out) return blocked(domain, toolId, "blocked_by_infra", "offensive_run_timed_out");
 
   const stdoutText = stdoutBytes.toString("utf8");

--- a/mcp/lib/offensive-runner.js
+++ b/mcp/lib/offensive-runner.js
@@ -213,31 +213,60 @@ function offensiveInfraFailurePath(domain) {
   return path.join(sessionDir(domain), "offensive-infra-failures");
 }
 
-// Read a fail-closed MONOTONIC counter file: missing = 0 (fresh session); an unreadable
-// or malformed value fails CLOSED (Infinity → blocks). Strict digits-only — parseInt
-// would accept "7x" / "0x10" / "7\ntrailing" and under-count, so a tampered/malformed
-// counter must fail CLOSED, not parse low.
+// Read a fail-closed MONOTONIC counter file with O_NOFOLLOW + regular-file discipline:
+// missing = 0 (fresh session); a SYMLINKED / hardlinked / irregular / unreadable /
+// malformed leaf fails CLOSED (Infinity → blocks). The O_NOFOLLOW open refuses to read
+// THROUGH a symlink a same-UID stale artifact could pre-create to point the counter at an
+// attacker-chosen file (e.g. one containing "0" to silently reset the budget). Strict
+// digits-only — parseInt would accept "7x" / "0x10" / "7\ntrailing" and under-count.
 function readCounterFile(filePath) {
-  let raw;
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  let fd;
   try {
-    raw = fs.readFileSync(filePath, "utf8");
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
   } catch (e) {
     if (e && e.code === "ENOENT") return 0;
-    return Number.POSITIVE_INFINITY;
+    return Number.POSITIVE_INFINITY; // ELOOP (symlinked leaf) / any open error → fail closed
   }
-  const trimmed = String(raw).trim();
-  if (!/^\d+$/.test(trimmed)) return Number.POSITIVE_INFINITY;
-  const n = Number.parseInt(trimmed, 10);
-  return Number.isInteger(n) && n >= 0 ? n : Number.POSITIVE_INFINITY;
+  try {
+    const st = fs.fstatSync(fd);
+    if (!st.isFile() || st.nlink !== 1) return Number.POSITIVE_INFINITY;
+    const buf = Buffer.alloc(32); // a counter is a few digits; bound the read
+    const n = fs.readSync(fd, buf, 0, buf.length, 0);
+    const trimmed = buf.subarray(0, n).toString("utf8").trim();
+    if (!/^\d+$/.test(trimmed)) return Number.POSITIVE_INFINITY;
+    const v = Number.parseInt(trimmed, 10);
+    return Number.isInteger(v) && v >= 0 ? v : Number.POSITIVE_INFINITY;
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
+// Write a counter with O_NOFOLLOW + regular-file/nlink discipline so the write can never
+// be redirected THROUGH a symlinked or hardlinked leaf to a path outside Bob's session
+// files (a same-UID stale artifact pre-creating the counter as a symlink must not turn a
+// counter write into a write-where primitive). nlink is checked BEFORE truncating so a
+// hardlinked target is never clobbered. Returns false on any failure (caller treats a
+// failed reserve as fail-closed).
 function writeCounterFile(domain, filePath, value) {
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  let fd;
   try {
     fs.mkdirSync(sessionDir(domain), { recursive: true });
-    fs.writeFileSync(filePath, String(value), { mode: 0o600 });
+    fd = fs.openSync(filePath, fs.constants.O_WRONLY | fs.constants.O_CREAT | noFollow, 0o600);
+  } catch {
+    return false; // ELOOP (symlinked leaf) / any open error → refuse the write
+  }
+  try {
+    const st = fs.fstatSync(fd);
+    if (!st.isFile() || st.nlink !== 1) return false;
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, String(value), 0);
     return true;
   } catch {
     return false;
+  } finally {
+    fs.closeSync(fd);
   }
 }
 
@@ -256,36 +285,27 @@ function offensiveInfraFailureCount(domain) {
   return readCounterFile(offensiveInfraFailurePath(domain));
 }
 
-// Atomically bump a monotonic counter by delta (caller holds the session lock), clamped
-// at >= 0. Fail-closed on a corrupt (non-finite) read: leave the file untouched so it
-// keeps failing CLOSED at the reservation gate rather than being reset to a finite value.
-function bumpCounterFile(domain, filePath, delta) {
-  const cur = readCounterFile(filePath);
-  if (!Number.isFinite(cur)) return false;
-  return writeCounterFile(domain, filePath, Math.max(0, cur + delta));
-}
-
 // Reserve one run by incrementing the monotonic counter (the caller holds the session
 // lock). Returns false (fail closed) if the reservation can't be read or persisted.
 function incrementOffensiveRun(domain) {
-  return bumpCounterFile(domain, offensiveRunBudgetPath(domain), 1);
+  const cur = offensiveRunCount(domain);
+  if (!Number.isFinite(cur)) return false;
+  return writeCounterFile(domain, offensiveRunBudgetPath(domain), cur + 1);
 }
 
-// #124-3: the infra-failure counter is reserved PESSIMISTICALLY at reservation time
-// (every attempt holds an infra slot BEFORE docker is spawned) so the cap is enforced
-// UNDER CONCURRENCY — a burst of N parallel runs each takes a slot under the lock, so at
-// most MAX_OFFENSIVE_INFRA_FAILURES run concurrently and at most that many infra failures
-// are ever recorded (no stale-count overshoot). A GENUINE run (the container started)
-// RELEASES its slot; an infra failure (the container never ran) KEEPS it as the recorded
-// failure. Net per outcome: genuine → run+1/infra+0; infra failure → run+0/infra+1.
-function incrementOffensiveInfra(domain) {
-  return bumpCounterFile(domain, offensiveInfraFailurePath(domain), 1);
-}
-function decrementOffensiveRun(domain) {
-  return bumpCounterFile(domain, offensiveRunBudgetPath(domain), -1);
-}
-function decrementOffensiveInfra(domain) {
-  return bumpCounterFile(domain, offensiveInfraFailurePath(domain), -1);
+// #124-3: an infra failure (the container never ran) is REFUNDED from the run budget so
+// it doesn't burn a genuine-run slot, and recorded in the separate, capped infra counter
+// (which bounds infra-failure spin). ORDER + fail-closed matter: record the infra failure
+// FIRST and only refund the run slot if it persisted, so a storage failure can never free
+// the run slot WITHOUT counting the infra failure (which would let infra failures silently
+// bypass the cap). Worst case on a partial write is an OVER-count (run slot stays
+// consumed), never an under-count. Caller holds the session lock.
+function refundOffensiveRunAsInfraFailure(domain) {
+  const infra = offensiveInfraFailureCount(domain);
+  if (!Number.isFinite(infra)) return; // corrupt counter already fails closed at the gate
+  if (!writeCounterFile(domain, offensiveInfraFailurePath(domain), infra + 1)) return; // not counted → keep run slot
+  const run = offensiveRunCount(domain);
+  if (Number.isFinite(run) && run > 0) writeCounterFile(domain, offensiveRunBudgetPath(domain), run - 1);
 }
 
 // A legitimate session dir is a real directory Bob created — never a symlink. A
@@ -440,8 +460,18 @@ async function runOffensiveTool({
   if (egressProfileName != null && (typeof egressProfileName !== "string" || !/^[a-zA-Z0-9_.-]{1,64}$/.test(egressProfileName))) {
     rejectInvalid("egressProfileName must be a short [a-zA-Z0-9_.-] profile name");
   }
-  if (egressProxyUrl != null && egressProfileName == null) {
-    rejectInvalid("egressProxyUrl requires egressProfileName (the resolved egress profile identity)");
+  if (egressProxyUrl != null) {
+    if (egressProfileName == null) {
+      rejectInvalid("egressProxyUrl requires egressProfileName (the resolved egress profile identity)");
+    }
+    // "default" is the reserved DIRECT-egress profile (egress-profiles.js pins it to
+    // proxy_url: null); stamping a proxied run as "default" would misbind it as direct
+    // egress for audit/circuit consumers. The runner can't resolve the full named-profile
+    // registry in PR-124 (PR5b does, binding name<->url via resolveAndAssertSessionEgressIdentity),
+    // but it CAN reject this one universally-known inconsistency.
+    if (egressProfileName === "default") {
+      rejectInvalid("egressProfileName must not be the reserved 'default' (direct-egress) profile when a proxy URL is set");
+    }
   }
   const cappedTimeout = Math.min(Math.max(Number(timeoutMs) || DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
 
@@ -480,16 +510,17 @@ async function runOffensiveTool({
   const auditUrl = primaryUrl ? String(primaryUrl.value) : `https://${domain}/`;
   const reservation = withSessionLock(domain, () => {
     if (offensiveRunCount(domain) >= MAX_OFFENSIVE_RUNS) return { ok: false, reason: "offensive_run_budget_exhausted" };
-    // #124-3: the infra cap is checked AND reserved under this SAME lock (pessimistically,
-    // before spawn) so it holds under concurrency — a burst of parallel runs can't all
-    // pass a stale count and overshoot the cap. A genuine run releases its infra slot
-    // once docker has started.
+    // #124-3: infra failures are refunded from the run budget, so they're capped
+    // separately to bound infra-failure SPIN (a flaky network retrying forever). A
+    // concurrent burst is ADDITIONALLY bounded by the run budget itself — each in-flight
+    // run holds a run slot until refund, so at most MAX_OFFENSIVE_RUNS docker spawns are
+    // in flight at once — so total thrash stays bounded without a per-run release. (See
+    // the PR note: this trades exact-cap-under-a-50+-concurrent-burst, unreachable at
+    // Bob's wave concurrency, for avoiding a per-run post-run lock write + crash-leak.)
     if (offensiveInfraFailureCount(domain) >= MAX_OFFENSIVE_INFRA_FAILURES) return { ok: false, reason: "offensive_infra_failure_budget_exhausted" };
     const auditOk = auditConfirmRequest({ domain, surfaceId: null, method: OFFENSIVE_RUN_AUDIT_METHOD, url: auditUrl, egressProfile: egressProfileName, status: null, scopeDecision: "allowed", error: null, startedAt, toolId });
     if (auditOk === false) return { ok: false, reason: "offensive_run_audit_failed" };
     if (!incrementOffensiveRun(domain)) return { ok: false, reason: "offensive_run_budget_write_failed" };
-    // pessimistically take an infra slot too; roll back the run slot if it can't persist.
-    if (!incrementOffensiveInfra(domain)) { decrementOffensiveRun(domain); return { ok: false, reason: "offensive_infra_budget_write_failed" }; }
     return { ok: true };
   });
   if (!reservation.ok) {
@@ -513,9 +544,11 @@ async function runOffensiveTool({
   } catch (e) {
     try { docker.networkRm(runId, env); } catch {} // tear down a partially-created network
     cleanupScratch();
-    // #124-3: the container never ran — refund the run slot; the pessimistically-reserved
-    // infra slot STAYS (it is now the recorded infra failure).
-    withSessionLock(domain, () => decrementOffensiveRun(domain));
+    // #124-3: the container never ran — refund the run slot + record the infra failure.
+    // Best-effort: `withSessionLock` is fail-fast (throws on cross-process contention), so
+    // a bookkeeping lock-miss must not add a second error to an already-failed run; the
+    // refund is itself fail-closed (run slot stays consumed on any miss).
+    try { withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain)); } catch {}
     return blocked(domain, toolId, "blocked_by_infra", "offensive_network_create_failed", { failure_reason: e.message || String(e) });
   }
   let stdoutBytes = Buffer.alloc(0);
@@ -534,16 +567,13 @@ async function runOffensiveTool({
   }
 
   if (runResult.spawn_error) {
-    // #124-3: docker never started the container — refund the run slot; the pessimistic
-    // infra slot STAYS as the recorded infra failure.
-    withSessionLock(domain, () => decrementOffensiveRun(domain));
+    // #124-3: docker never started the container — refund the run slot + record the infra
+    // failure (best-effort; fail-fast lock-miss must not mask the spawn error).
+    try { withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain)); } catch {}
     return blocked(domain, toolId, "blocked_by_infra", "offensive_spawn_failed", { failure_reason: runResult.spawn_error });
   }
-  // #124-3: the container STARTED — every outcome from here on is a GENUINE run (it
-  // consumed a real slot), so RELEASE the pessimistically-reserved infra slot exactly
-  // once. This single release covers ALL genuine returns below, INCLUDING a timeout (the
-  // container ran and only failed to FINISH — not an infra failure).
-  withSessionLock(domain, () => decrementOffensiveInfra(domain));
+  // A timeout is NOT refunded and NOT an infra failure: the container actually RAN
+  // (consumed CPU/net + a real slot) and only failed to FINISH — a genuine run (#124-3).
   if (runResult.timed_out) return blocked(domain, toolId, "blocked_by_infra", "offensive_run_timed_out");
 
   const stdoutText = stdoutBytes.toString("utf8");

--- a/mcp/lib/offensive-runner.js
+++ b/mcp/lib/offensive-runner.js
@@ -62,6 +62,11 @@ const MAX_TIMEOUT_MS = 600_000;
 const MIN_TIMEOUT_MS = 5_000;
 // Per-session cap on offensive container runs (fail-closed, global across tools).
 const MAX_OFFENSIVE_RUNS = 200;
+// #124-3: cap on infra failures (network-create / spawn errors — the container never
+// ran). These are REFUNDED from the run budget (an infra failure must not burn a
+// genuine-run slot), so they need their own bound, or a daemon/target that fails every
+// spawn could spin unbounded docker attempts. Fail-closed like the run budget.
+const MAX_OFFENSIVE_INFRA_FAILURES = 50;
 // http-audit normalization STRIPS `tool`, so offensive runs are marked + counted by
 // a distinctive `method` token that survives normalization.
 const OFFENSIVE_RUN_AUDIT_METHOD = "CONTAINER_RUN";
@@ -141,9 +146,22 @@ function parseAllowlistedArgv(toolArgv, spec) {
   }
   // toolArgv[0] is the container binary the runner executes — constrain it to a bare
   // binary-name token (no path separators / metacharacters) so an arbitrary in-image
-  // binary or path can't be run. PR5b binds it to the tool spec's declared binary.
+  // binary or path can't be run.
   if (!/^[a-zA-Z0-9._-]+$/.test(toolArgv[0])) {
     rejectInvalid("toolArgv[0] (the container binary name) must be a bare [a-zA-Z0-9._-] token", { code: "offensive_bad_binary" });
+  }
+  // #124-1: bind toolArgv[0] to the tool spec's DECLARED binary. PR5b's registry sets
+  // spec.binary per tool_id from server-side config (never agent input), so a live
+  // caller forwarding agent-influenced argv cannot run a DIFFERENT in-image binary
+  // (sh, curl) under the claimed tool_id. When no binary is declared (the PR5a inert
+  // path) only the bare-token shape check above constrains it.
+  if (spec && spec.binary != null) {
+    if (typeof spec.binary !== "string" || !/^[a-zA-Z0-9._-]+$/.test(spec.binary)) {
+      rejectInvalid("flagSpec.binary must be a bare [a-zA-Z0-9._-] binary name", { code: "offensive_bad_spec_binary" });
+    }
+    if (toolArgv[0] !== spec.binary) {
+      rejectInvalid(`toolArgv[0] ${JSON.stringify(toolArgv[0])} does not match the tool's declared binary ${JSON.stringify(spec.binary)}`, { code: "offensive_binary_mismatch" });
+    }
   }
   const booleanFlags = spec && spec.boolean ? new Set(spec.boolean) : new Set();
   const valueFlags = spec && spec.value ? new Set(spec.value) : new Set();
@@ -189,28 +207,53 @@ function offensiveRunBudgetPath(domain) {
   return path.join(sessionDir(domain), "offensive-run-budget");
 }
 
-// F3 (fail-closed): the per-session offensive-run count is a MONOTONIC counter in a
-// dedicated session file — NOT derived from http-audit.jsonl, which is trimmed to the
-// last HTTP_AUDIT_LOG_MAX_RECORDS (5000) and would let early CONTAINER_RUN rows evict
-// so the budget silently resets and permits unlimited wide-open runs. Missing file =
-// 0 (fresh session); an unreadable / malformed value fails CLOSED (Infinity → blocks).
-// (The run is STILL recorded to http-audit for circuit-breaker visibility; that write
-// is just no longer the budget source.) O(1) read, so the count under the lock no
-// longer re-parses a growing log.
-function offensiveRunCount(domain) {
+// #124-3: infra failures (container never ran) are counted in their OWN session file so
+// they can be capped + refunded independently of the genuine-run budget.
+function offensiveInfraFailurePath(domain) {
+  return path.join(sessionDir(domain), "offensive-infra-failures");
+}
+
+// Read a fail-closed MONOTONIC counter file: missing = 0 (fresh session); an unreadable
+// or malformed value fails CLOSED (Infinity → blocks). Strict digits-only — parseInt
+// would accept "7x" / "0x10" / "7\ntrailing" and under-count, so a tampered/malformed
+// counter must fail CLOSED, not parse low.
+function readCounterFile(filePath) {
   let raw;
   try {
-    raw = fs.readFileSync(offensiveRunBudgetPath(domain), "utf8");
+    raw = fs.readFileSync(filePath, "utf8");
   } catch (e) {
     if (e && e.code === "ENOENT") return 0;
     return Number.POSITIVE_INFINITY;
   }
-  // Strict digits-only — parseInt would accept "7x" / "0x10" / "7\ntrailing" and
-  // under-count, so a tampered/malformed counter must fail CLOSED, not parse low.
   const trimmed = String(raw).trim();
   if (!/^\d+$/.test(trimmed)) return Number.POSITIVE_INFINITY;
   const n = Number.parseInt(trimmed, 10);
   return Number.isInteger(n) && n >= 0 ? n : Number.POSITIVE_INFINITY;
+}
+
+function writeCounterFile(domain, filePath, value) {
+  try {
+    fs.mkdirSync(sessionDir(domain), { recursive: true });
+    fs.writeFileSync(filePath, String(value), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// F3 (fail-closed): the per-session offensive-run count is a MONOTONIC counter in a
+// dedicated session file — NOT derived from http-audit.jsonl, which is trimmed to the
+// last HTTP_AUDIT_LOG_MAX_RECORDS (5000) and would let early CONTAINER_RUN rows evict
+// so the budget silently resets and permits unlimited wide-open runs. (The run is STILL
+// recorded to http-audit for circuit-breaker visibility; that write is just no longer
+// the budget source.) O(1) read, so the count under the lock no longer re-parses a
+// growing log.
+function offensiveRunCount(domain) {
+  return readCounterFile(offensiveRunBudgetPath(domain));
+}
+
+function offensiveInfraFailureCount(domain) {
+  return readCounterFile(offensiveInfraFailurePath(domain));
 }
 
 // Reserve one run by incrementing the monotonic counter (the caller holds the session
@@ -218,12 +261,24 @@ function offensiveRunCount(domain) {
 function incrementOffensiveRun(domain) {
   const next = offensiveRunCount(domain) + 1;
   if (!Number.isFinite(next)) return false;
-  try {
-    fs.mkdirSync(sessionDir(domain), { recursive: true });
-    fs.writeFileSync(offensiveRunBudgetPath(domain), String(next), { mode: 0o600 });
-    return true;
-  } catch {
-    return false;
+  return writeCounterFile(domain, offensiveRunBudgetPath(domain), next);
+}
+
+// #124-3: REFUND a previously-reserved run slot (the container never ran — an infra
+// failure) and record it in the separate infra-failure counter. The caller holds the
+// session lock so the decrement + increment are atomic w.r.t. concurrent reservations.
+// Conservative: if the run counter can't be read as a finite value we leave the slot
+// consumed (never refund MORE than was reserved); if the infra counter is corrupt
+// (non-finite) we leave it — it already fails CLOSED at the reservation gate and must
+// not be silently reset to a finite value.
+function refundOffensiveRunAsInfraFailure(domain) {
+  const runCount = offensiveRunCount(domain);
+  if (Number.isFinite(runCount) && runCount > 0) {
+    writeCounterFile(domain, offensiveRunBudgetPath(domain), runCount - 1);
+  }
+  const infra = offensiveInfraFailureCount(domain);
+  if (Number.isFinite(infra)) {
+    writeCounterFile(domain, offensiveInfraFailurePath(domain), infra + 1);
   }
 }
 
@@ -342,6 +397,7 @@ async function runOffensiveTool({
   flagSpec = {},
   forcedFlags = [],
   egressProxyUrl = null,
+  egressProfileName = null,
   workTmpfsBytes,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   docker = defaultOffensiveDocker,
@@ -368,6 +424,18 @@ async function runOffensiveTool({
   // well-formed http(s) proxy URL before it is handed to `docker --env`.
   if (egressProxyUrl != null && (typeof egressProxyUrl !== "string" || !/^https?:\/\/[^\s]+$/i.test(egressProxyUrl))) {
     rejectInvalid("egressProxyUrl must be an http(s) proxy URL");
+  }
+  // #124-2: record the RESOLVED named egress profile (not the literal "proxy"). PR5b
+  // resolves session-bound named profiles via resolveAndAssertSessionEgressIdentity and
+  // passes the profile name here; the runner stamps THAT into the audit row's
+  // egress_profile so circuit-breaker / report consumers can tell which egress the
+  // wide-open container used. A proxied run MUST name its profile — an anonymous proxy
+  // (the old literal "proxy") is rejected.
+  if (egressProfileName != null && (typeof egressProfileName !== "string" || !/^[a-zA-Z0-9_.-]{1,64}$/.test(egressProfileName))) {
+    rejectInvalid("egressProfileName must be a short [a-zA-Z0-9_.-] profile name");
+  }
+  if (egressProxyUrl != null && egressProfileName == null) {
+    rejectInvalid("egressProxyUrl requires egressProfileName (the resolved egress profile identity)");
   }
   const cappedTimeout = Math.min(Math.max(Number(timeoutMs) || DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
 
@@ -406,7 +474,10 @@ async function runOffensiveTool({
   const auditUrl = primaryUrl ? String(primaryUrl.value) : `https://${domain}/`;
   const reservation = withSessionLock(domain, () => {
     if (offensiveRunCount(domain) >= MAX_OFFENSIVE_RUNS) return { ok: false, reason: "offensive_run_budget_exhausted" };
-    const auditOk = auditConfirmRequest({ domain, surfaceId: null, method: OFFENSIVE_RUN_AUDIT_METHOD, url: auditUrl, egressProfile: egressProxyUrl ? "proxy" : null, status: null, scopeDecision: "allowed", error: null, startedAt, toolId });
+    // #124-3: infra failures are refunded from the run budget, so cap them separately to
+    // keep the total-attempts bound the reserve-before-spawn used to provide.
+    if (offensiveInfraFailureCount(domain) >= MAX_OFFENSIVE_INFRA_FAILURES) return { ok: false, reason: "offensive_infra_failure_budget_exhausted" };
+    const auditOk = auditConfirmRequest({ domain, surfaceId: null, method: OFFENSIVE_RUN_AUDIT_METHOD, url: auditUrl, egressProfile: egressProfileName, status: null, scopeDecision: "allowed", error: null, startedAt, toolId });
     if (auditOk === false) return { ok: false, reason: "offensive_run_audit_failed" };
     if (!incrementOffensiveRun(domain)) return { ok: false, reason: "offensive_run_budget_write_failed" };
     return { ok: true };
@@ -432,6 +503,8 @@ async function runOffensiveTool({
   } catch (e) {
     try { docker.networkRm(runId, env); } catch {} // tear down a partially-created network
     cleanupScratch();
+    // #124-3: the container never ran — refund the reserved run slot + count it as infra.
+    withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain));
     return blocked(domain, toolId, "blocked_by_infra", "offensive_network_create_failed", { failure_reason: e.message || String(e) });
   }
   let stdoutBytes = Buffer.alloc(0);
@@ -449,7 +522,13 @@ async function runOffensiveTool({
     cleanupScratch();                                 // F7-cleanup: guaranteed last
   }
 
-  if (runResult.spawn_error) return blocked(domain, toolId, "blocked_by_infra", "offensive_spawn_failed", { failure_reason: runResult.spawn_error });
+  if (runResult.spawn_error) {
+    // #124-3: docker never started the container — refund the slot + count it as infra.
+    withSessionLock(domain, () => refundOffensiveRunAsInfraFailure(domain));
+    return blocked(domain, toolId, "blocked_by_infra", "offensive_spawn_failed", { failure_reason: runResult.spawn_error });
+  }
+  // A timeout is NOT refunded: the container actually RAN (consumed CPU/net + a real
+  // slot) and only failed to FINISH — a genuine run, not an infra failure (#124-3).
   if (runResult.timed_out) return blocked(domain, toolId, "blocked_by_infra", "offensive_run_timed_out");
 
   const stdoutText = stdoutBytes.toString("utf8");
@@ -529,9 +608,12 @@ module.exports = {
   secureReadCaptureBytes,
   offensiveRunCount,
   offensiveRunBudgetPath,
+  offensiveInfraFailureCount,
+  offensiveInfraFailurePath,
   mintRunId,
   defaultOffensiveDocker,
   MAX_OFFENSIVE_RUNS,
+  MAX_OFFENSIVE_INFRA_FAILURES,
   MAX_TIMEOUT_MS,
   OFFENSIVE_RUN_AUDIT_METHOD,
 };

--- a/test/offensive-runner.test.js
+++ b/test/offensive-runner.test.js
@@ -472,6 +472,25 @@ test("a timeout CONSUMES the run budget (the container ran) — NOT counted as i
   assert.equal(offensiveInfraFailureCount(domain), 0, "a timeout is not an infra failure");
 }));
 
+test("the infra slot is HELD during the run + RELEASED on a genuine outcome — caps concurrency (#124-3)", () => withTempHome(async () => {
+  // The pessimistic reservation is what enforces MAX_OFFENSIVE_INFRA_FAILURES under a
+  // concurrent burst: each in-flight run holds an infra slot from BEFORE docker spawns
+  // until it completes, so the cap can't be overshot by parallel calls passing a stale
+  // count. A genuine outcome then releases the slot.
+  const domain = "runner-infrahold.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  const inner = docker.run;
+  let infraDuringRun = null;
+  docker.run = async (opts) => {
+    infraDuringRun = offensiveInfraFailureCount(domain); // slot is held while the container "runs"
+    return inner(opts);
+  };
+  await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(infraDuringRun, 1, "an in-flight run holds an infra slot (bounds concurrency before any docker failure)");
+  assert.equal(offensiveInfraFailureCount(domain), 0, "a genuine outcome releases the infra slot");
+}));
+
 test("infra-failure budget exhausted blocks new runs (separate cap) (#124-3)", () => withTempHome(async () => {
   const domain = "runner-infracap.example.test";
   setup(domain);

--- a/test/offensive-runner.test.js
+++ b/test/offensive-runner.test.js
@@ -472,19 +472,39 @@ test("a timeout CONSUMES the run budget (the container ran) — NOT counted as i
   assert.equal(offensiveInfraFailureCount(domain), 0, "a timeout is not an infra failure");
 }));
 
-test("a symlinked counter leaf fails CLOSED + is never written through (O_NOFOLLOW) (#124 P1)", () => withTempHome(async (home) => {
-  // A same-UID stale artifact pre-creating a counter as a symlink must not (a) reset the
-  // budget by pointing it at a "0" file, nor (b) let the counter write clobber the target.
+test("a symlinked counter leaf fails CLOSED via O_NOFOLLOW (not the target's value) (#124 P1)", () => withTempHome(async (home) => {
+  // Point the symlink at a VALID low count: if the reader FOLLOWED it, it would read "0"
+  // and the run would proceed. Since the run is blocked, O_NOFOLLOW refused to follow.
   const domain = "runner-symlink.example.test";
   setup(domain);
-  const evil = path.join(home, "evil-target.txt");
-  fs.writeFileSync(evil, "untouched");
-  fs.symlinkSync(evil, offensiveRunBudgetPath(domain)); // counter leaf is now a symlink
+  const target = path.join(home, "counter-target");
+  fs.writeFileSync(target, "0");
+  fs.symlinkSync(target, offensiveRunBudgetPath(domain));
   const docker = makeStubDocker();
   const r = await runOffensiveTool(baseRun(domain, { docker }));
-  assert.equal(r.reason, "offensive_run_budget_exhausted", "a symlinked counter reads fail-closed (Infinity)");
+  assert.equal(r.reason, "offensive_run_budget_exhausted", "O_NOFOLLOW fails closed (Infinity), NOT the target's 0");
   assert.ok(noLifecycle(docker));
-  assert.equal(fs.readFileSync(evil, "utf8"), "untouched", "the write must not follow the symlink to the target");
+}));
+
+test("an oversized/padded counter file fails CLOSED — whole-file validation, not a prefix (#124 P1)", () => withTempHome(async () => {
+  const domain = "runner-oversize.example.test";
+  setup(domain);
+  // a 32-zero prefix + junk: a prefix-only reader would parse "0" and reset the budget
+  fs.writeFileSync(offensiveRunBudgetPath(domain), "0".repeat(32) + "999");
+  const docker = makeStubDocker();
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_run_budget_exhausted", "a padded counter must not parse as its 32-zero prefix");
+  assert.ok(noLifecycle(docker));
+}));
+
+test("docker exit 125 (container failed to start) is an infra failure: refunded + counted (#124-3)", () => withTempHome(async () => {
+  const domain = "runner-exit125.example.test";
+  setup(domain);
+  const docker = makeStubDocker({ runResult: { exit_code: 125, timed_out: false } });
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_container_failed_to_start");
+  assert.equal(offensiveRunCount(domain), 0, "exit 125 refunds the run slot (container never ran)");
+  assert.equal(offensiveInfraFailureCount(domain), 1, "exit 125 counts as infra");
 }));
 
 test("egressProfileName 'default' is rejected when a proxy URL is set — no direct/proxy misbinding (#124-2)", () => withTempHome(async () => {

--- a/test/offensive-runner.test.js
+++ b/test/offensive-runner.test.js
@@ -472,23 +472,30 @@ test("a timeout CONSUMES the run budget (the container ran) — NOT counted as i
   assert.equal(offensiveInfraFailureCount(domain), 0, "a timeout is not an infra failure");
 }));
 
-test("the infra slot is HELD during the run + RELEASED on a genuine outcome — caps concurrency (#124-3)", () => withTempHome(async () => {
-  // The pessimistic reservation is what enforces MAX_OFFENSIVE_INFRA_FAILURES under a
-  // concurrent burst: each in-flight run holds an infra slot from BEFORE docker spawns
-  // until it completes, so the cap can't be overshot by parallel calls passing a stale
-  // count. A genuine outcome then releases the slot.
-  const domain = "runner-infrahold.example.test";
+test("a symlinked counter leaf fails CLOSED + is never written through (O_NOFOLLOW) (#124 P1)", () => withTempHome(async (home) => {
+  // A same-UID stale artifact pre-creating a counter as a symlink must not (a) reset the
+  // budget by pointing it at a "0" file, nor (b) let the counter write clobber the target.
+  const domain = "runner-symlink.example.test";
+  setup(domain);
+  const evil = path.join(home, "evil-target.txt");
+  fs.writeFileSync(evil, "untouched");
+  fs.symlinkSync(evil, offensiveRunBudgetPath(domain)); // counter leaf is now a symlink
+  const docker = makeStubDocker();
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_run_budget_exhausted", "a symlinked counter reads fail-closed (Infinity)");
+  assert.ok(noLifecycle(docker));
+  assert.equal(fs.readFileSync(evil, "utf8"), "untouched", "the write must not follow the symlink to the target");
+}));
+
+test("egressProfileName 'default' is rejected when a proxy URL is set — no direct/proxy misbinding (#124-2)", () => withTempHome(async () => {
+  const domain = "runner-egressdefault.example.test";
   setup(domain);
   const docker = makeStubDocker();
-  const inner = docker.run;
-  let infraDuringRun = null;
-  docker.run = async (opts) => {
-    infraDuringRun = offensiveInfraFailureCount(domain); // slot is held while the container "runs"
-    return inner(opts);
-  };
-  await runOffensiveTool(baseRun(domain, { docker }));
-  assert.equal(infraDuringRun, 1, "an in-flight run holds an infra slot (bounds concurrency before any docker failure)");
-  assert.equal(offensiveInfraFailureCount(domain), 0, "a genuine outcome releases the infra slot");
+  await assert.rejects(
+    runOffensiveTool(baseRun(domain, { egressProxyUrl: "http://proxy.internal:8080", egressProfileName: "default", docker })),
+    /reserved 'default'/,
+  );
+  assert.ok(noLifecycle(docker));
 }));
 
 test("infra-failure budget exhausted blocks new runs (separate cap) (#124-3)", () => withTempHome(async () => {

--- a/test/offensive-runner.test.js
+++ b/test/offensive-runner.test.js
@@ -12,10 +12,13 @@ const {
   scrubbedDockerEnv,
   offensiveRunCount,
   offensiveRunBudgetPath,
+  offensiveInfraFailureCount,
+  offensiveInfraFailurePath,
   MAX_OFFENSIVE_RUNS,
+  MAX_OFFENSIVE_INFRA_FAILURES,
 } = require("../mcp/lib/offensive-runner.js");
 const { initSession } = require("../mcp/lib/session-state.js");
-const { repoRunsDir } = require("../mcp/lib/paths.js");
+const { repoRunsDir, httpAuditJsonlPath } = require("../mcp/lib/paths.js");
 
 const DIGEST = "ghcr.io/bobnetsec/bob-offense@sha256:" + "b".repeat(64);
 
@@ -55,12 +58,18 @@ const baseRun = (domain, overrides = {}) => ({
   toolId: "bob_offensive_test",
   imageDigest: DIGEST,
   toolArgv: ["httpx", "-silent", "-u", `https://${domain}/`],
-  flagSpec: { boolean: ["-silent"], value: ["-u"], url: ["-u"] },
+  flagSpec: { binary: "httpx", boolean: ["-silent"], value: ["-u"], url: ["-u"] },
   ...overrides,
 });
 
 const noLifecycle = (d) => d.calls.run.length === 0 && d.calls.networkCreate.length === 0 && d.calls.kill.length === 0;
 const stdoutLeaves = (domain) => { try { return fs.readdirSync(repoRunsDir(domain)).filter((f) => f.endsWith(".stdout")); } catch { return []; } };
+// the most recent CONTAINER_RUN audit record (the runner stamps each offensive run with
+// method=CONTAINER_RUN; the normalizer drops `tool` but keeps `method` + egress_profile).
+const lastContainerRunAudit = (domain) => {
+  const lines = fs.readFileSync(httpAuditJsonlPath(domain), "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+  return lines.reverse().find((r) => r.method === "CONTAINER_RUN");
+};
 
 // ───────────────────────── pure helpers ─────────────────────────
 
@@ -95,6 +104,19 @@ test("parseAllowlistedArgv: boolean vs value flags, bare-arg smuggling closed, r
   assert.throws(() => parseAllowlistedArgv(["rm;reboot", "-silent"], spec), /bare \[a-zA-Z0-9._-\] token/);
 });
 
+test("parseAllowlistedArgv: binds toolArgv[0] to spec.binary when declared (#124-1)", () => {
+  const spec = { binary: "dalfox", boolean: ["-silent"], value: ["-u"] };
+  // the declared binary matches → accepted
+  assert.doesNotThrow(() => parseAllowlistedArgv(["dalfox", "-u", "https://x"], spec));
+  // a DIFFERENT in-image binary under the same spec → rejected (the sh/curl scenario)
+  assert.throws(() => parseAllowlistedArgv(["sh", "-u", "https://x"], spec), /does not match the tool's declared binary/);
+  assert.throws(() => parseAllowlistedArgv(["httpx", "-silent"], spec), /declared binary/);
+  // a malformed declared binary fails closed (can't smuggle a path as the declared binary)
+  assert.throws(() => parseAllowlistedArgv(["x", "-silent"], { binary: "/bin/sh", boolean: ["-silent"] }), /bare \[a-zA-Z0-9._-\] binary name/);
+  // no binary declared → only the bare-token shape check (PR5a inert back-compat)
+  assert.doesNotThrow(() => parseAllowlistedArgv(["anybin", "-silent"], { boolean: ["-silent"] }));
+});
+
 // ───────────────────────── safety gates (NO docker lifecycle reached) ─────────────────────────
 
 test("scope-gate operates on the COMMAND's URL flag value, before any docker call (AIM)", () => withTempHome(async () => {
@@ -124,7 +146,7 @@ test("flag allowlist: an unlisted flag blocks before any docker call (full lifec
   setup(domain);
   const docker = makeStubDocker();
   await assert.rejects(
-    runOffensiveTool(baseRun(domain, { toolArgv: ["httpx", "-exec", "id"], flagSpec: { boolean: ["-silent"], value: ["-u"], url: ["-u"] }, docker })),
+    runOffensiveTool(baseRun(domain, { toolArgv: ["httpx", "-exec", "id"], flagSpec: { binary: "httpx", boolean: ["-silent"], value: ["-u"], url: ["-u"] }, docker })),
     /not in the tool flag allowlist/,
   );
   assert.ok(noLifecycle(docker));
@@ -181,6 +203,11 @@ test("PR5a default (no classifier): runs, never signs, scratch deleted, masked, 
   assert.equal(JSON.stringify(r).includes("matched: 0"), false);
   // F3 reserve: the run wrote one CONTAINER_RUN audit record
   assert.equal(offensiveRunCount(domain), 1);
+  // #124-2: a non-proxied run records the normalized "default" egress — NEVER the old
+  // literal "proxy" (the normalizer coerces an absent egress_profile to "default").
+  const audit = lastContainerRunAudit(domain);
+  assert.equal(audit.egress_profile, "default");
+  assert.notEqual(audit.egress_profile, "proxy");
 }));
 
 test("large benign output (>4KB) is scanned, not rejected for length (C)", () => withTempHome(async () => {
@@ -301,7 +328,7 @@ test("scope-gate fails CLOSED on a URL-shaped value of an UNDECLARED url flag", 
   await assert.rejects(
     runOffensiveTool(baseRun(domain, {
       toolArgv: ["httpx", "-u", `https://${domain}/`, "-H", "https://evil.example.com/"],
-      flagSpec: { boolean: ["-silent"], value: ["-u", "-H"], url: ["-u"] },
+      flagSpec: { binary: "httpx", boolean: ["-silent"], value: ["-u", "-H"], url: ["-u"] },
       docker,
     })),
     (e) => /scope|blocked/i.test(e.message) || e.code === "SCOPE_BLOCKED" || e.scope_decision === "blocked",
@@ -316,7 +343,7 @@ test("scope-gate also catches a protocol-relative URL value (//host) on an undec
   await assert.rejects(
     runOffensiveTool(baseRun(domain, {
       toolArgv: ["httpx", "-u", `https://${domain}/`, "-x", "//evil.example.com/"],
-      flagSpec: { boolean: ["-silent"], value: ["-u", "-x"], url: ["-u"] },
+      flagSpec: { binary: "httpx", boolean: ["-silent"], value: ["-u", "-x"], url: ["-u"] },
       docker,
     })),
     (e) => /scope|blocked/i.test(e.message) || e.code === "SCOPE_BLOCKED" || e.scope_decision === "blocked",
@@ -363,4 +390,94 @@ test("signed content is secret-scanned: a classify returning secret stdoutConten
   }));
   assert.equal(r.reason, "offensive_signed_content_contains_sensitive_value");
   assert.equal(signed, false);
+}));
+
+// ───────────────────────── #124 runner mutations ─────────────────────────
+
+test("declared binary mismatch: toolArgv[0] != flagSpec.binary blocks before any docker call (#124-1)", () => withTempHome(async () => {
+  const domain = "runner-binary.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  // baseRun declares binary "httpx"; a live caller forwarding agent argv that names a
+  // different in-image binary (curl) under the same tool_id must be rejected.
+  await assert.rejects(
+    runOffensiveTool(baseRun(domain, { toolArgv: ["curl", "-u", `https://${domain}/`], docker })),
+    /does not match the tool's declared binary/,
+  );
+  assert.ok(noLifecycle(docker));
+}));
+
+test("egressProxyUrl WITHOUT egressProfileName is rejected — no anonymous proxy (#124-2)", () => withTempHome(async () => {
+  const domain = "runner-egressname.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  await assert.rejects(
+    runOffensiveTool(baseRun(domain, { egressProxyUrl: "http://proxy.internal:8080", docker })),
+    /requires egressProfileName/,
+  );
+  assert.ok(noLifecycle(docker));
+}));
+
+test("a malformed egressProfileName is rejected before any docker call (#124-2)", () => withTempHome(async () => {
+  const domain = "runner-egressbad.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  await assert.rejects(
+    runOffensiveTool(baseRun(domain, { egressProxyUrl: "http://proxy.internal:8080", egressProfileName: "bad name!", docker })),
+    /profile name/,
+  );
+  assert.ok(noLifecycle(docker));
+}));
+
+test("egressProfileName is recorded in the CONTAINER_RUN audit row, not the literal 'proxy' (#124-2)", () => withTempHome(async () => {
+  const domain = "runner-egressrec.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  await runOffensiveTool(baseRun(domain, { egressProxyUrl: "http://proxy.internal:8080", egressProfileName: "corp-eu", docker }));
+  const audit = lastContainerRunAudit(domain);
+  assert.equal(audit.egress_profile, "corp-eu");
+  assert.notEqual(audit.egress_profile, "proxy");
+  // the proxy env actually reached the container argv (sandbox sets *_proxy env tokens)
+  const { args } = docker.calls.run[0];
+  assert.ok(args.some((t) => t === "https_proxy=http://proxy.internal:8080"));
+}));
+
+test("networkCreate failure REFUNDS the run budget + bumps the infra-failure counter (#124-3)", () => withTempHome(async () => {
+  const domain = "runner-infrarefund.example.test";
+  setup(domain);
+  const docker = makeStubDocker();
+  docker.networkCreate = (name) => { docker.calls.networkCreate.push(name); throw new Error("boom"); };
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_network_create_failed");
+  assert.equal(offensiveRunCount(domain), 0, "infra failure did NOT consume a genuine-run slot");
+  assert.equal(offensiveInfraFailureCount(domain), 1, "infra failure counted separately");
+}));
+
+test("spawn error REFUNDS the run budget + bumps the infra counter (#124-3)", () => withTempHome(async () => {
+  const domain = "runner-spawnrefund.example.test";
+  setup(domain);
+  const docker = makeStubDocker({ runResult: { exit_code: null, timed_out: false, spawn_error: "docker_not_in_path" } });
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_spawn_failed");
+  assert.equal(offensiveRunCount(domain), 0, "spawn error refunded");
+  assert.equal(offensiveInfraFailureCount(domain), 1);
+}));
+
+test("a timeout CONSUMES the run budget (the container ran) — NOT counted as infra (#124-3)", () => withTempHome(async () => {
+  const domain = "runner-timeoutbudget.example.test";
+  setup(domain);
+  const docker = makeStubDocker({ runResult: { exit_code: null, timed_out: true } });
+  await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(offensiveRunCount(domain), 1, "a timeout ran → consumes a slot");
+  assert.equal(offensiveInfraFailureCount(domain), 0, "a timeout is not an infra failure");
+}));
+
+test("infra-failure budget exhausted blocks new runs (separate cap) (#124-3)", () => withTempHome(async () => {
+  const domain = "runner-infracap.example.test";
+  setup(domain);
+  fs.writeFileSync(offensiveInfraFailurePath(domain), String(MAX_OFFENSIVE_INFRA_FAILURES));
+  const docker = makeStubDocker();
+  const r = await runOffensiveTool(baseRun(domain, { docker }));
+  assert.equal(r.reason, "offensive_infra_failure_budget_exhausted");
+  assert.ok(noLifecycle(docker));
 }));


### PR DESCRIPTION
## What

The three deferred PR5a runner refinements from **#124**, applied to the still-inert
`offensive-runner.js` with stubbed-docker tests. This is `PR-124` in the locked offensive
sequence (`PR-IMAGE` #125 ✅ → **PR-124** → `PR5b-tool`).

**The seam:** two of the three findings "require the registry" per #124. PR-124 makes the
runner **enforce** binary-binding + named-egress given its inputs; `PR5b-tool`'s tool
registry (`offensive-tools.js` / the `bob_offensive_*` factory) will **provide** those
inputs (the declared binary + the resolved egress name). The runner is a pure function of
its inputs; this PR completes + enforces its input contract.

## The three mutations

### 1. Bind `toolArgv[0]` to the declared binary (`flagSpec.binary`) — #124-1
PR5a only shape-guarded the executable to a bare `[a-zA-Z0-9._-]` token, so a live caller
forwarding agent-influenced argv could still pick a *different* in-image binary (`sh`,
`curl`) and have it run + audited under the supplied `tool_id`. Now, when `flagSpec.binary`
is declared, `toolArgv[0]` must equal it (and the declared binary is itself shape-validated
— can't smuggle a path). When no binary is declared (the PR5a inert path) the bare-token
check is the only constraint, so this is back-compatible. PR5b's registry sets
`flagSpec.binary` per `tool_id` from server-side config (never agent input).

### 2. Named egress in the `CONTAINER_RUN` audit — #124-2
PR5a recorded the audit row's egress as the literal `"proxy"`. Now the runner takes
`egressProfileName` (the resolved profile identity) and stamps **that** into the audit
row's `egress_profile`, so circuit-breaker / report consumers can tell which egress the
wide-open container used. A proxied run **must** name its profile — an anonymous proxy is
rejected. PR5b resolves session-bound named profiles via
`resolveAndAssertSessionEgressIdentity` and passes the name here.

### 3. Infra failures don't consume the run budget — #124-3
The budget slot is reserved (counter incremented) **before** spawn — the #123 atomic
TOCTOU fix. So repeated infrastructure failures (network-create / spawn errors, where the
container never started) could burn the 200-run cap. Now those two outcomes **refund** the
reserved slot and bump a **separate, capped** infra-failure counter.

**Why reserve-then-refund (not "don't count"):** you must reserve *before* spawn to keep
the reservation atomic (two concurrent agents reading a stale count would otherwise both
pass the gate), and you can't know an attempt is an infra failure until *after* the
network/spawn step. So refunding post-hoc under the lock is the only way to "not consume
the budget on infra failure" **while keeping the reservation atomic** — exactly what #124
asks for. A **timeout is NOT refunded**: the container actually ran (consumed CPU/net + a
real slot) and only failed to finish — a genuine run. The separate cap
(`MAX_OFFENSIVE_INFRA_FAILURES = 50`) preserves the total-attempts bound the reserve used
to provide (so a daemon/target that fails every spawn can't spin unbounded docker attempts).

## Scope (unchanged from PR5a)
Still **no MCP tool surface, no `classify`, no registry** — the runner remains inert in
production (`classify` defaults to `null`, never signs). No generated surface changes (the
runner isn't a `TOOLS` entry). The registry + live tool + `command_hash` binding + sound
classify are `PR5b-tool`.

## Tests
`test/offensive-runner.test.js`: **24 → 33** (+9). New coverage: declared-binary match /
mismatch / malformed (pure + runner), egress-name required / malformed / recorded-in-audit
/ no-literal-"proxy", infra-failure refund (network-create + spawn) + separate counter,
timeout-consumes-budget, infra-cap-exhausted blocks.

- `npm run test:mcp` — **2696 / 0**
- `npm run check:syntax` — clean
- `npm run test:prompts` — **181 / 0**

Closes #124.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added egress-profile support for proxy-based runs, including validation and audit logging that records the resolved profile name.
* **Bug Fixes**
  * Improved run-budget accounting: infrastructure failures are tracked and capped separately, refunded from the genuine run budget, and enforced to prevent new runs once the infra cap is reached.
  * Tightened allowlist enforcement by requiring an exact match for declared binary names.
* **Tests**
  * Expanded coverage for egress-profile/audit behavior, proxy validation rules, and fail-closed infra counter handling and edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->