### PR TITLE
feat(offense): PR-PROV — arm the IDOR signed-row producer via synthetic-identity provenance stamping

### DIFF
--- a/mcp/lib/auth.js
+++ b/mcp/lib/auth.js
@@ -59,18 +59,21 @@ const PROFILE_METADATA_KEYS = Object.freeze(new Set([
   "expires_at", "expiresAt", "expiry", "expires",
 ]));
 
-// Merge a resolved auth profile's HEADER fields into an outbound header map, skipping the
-// Bob-local metadata above so the synthetic mailbox + provenance fingerprint (and
-// credentials/storage) never reach the TARGET as request headers. resolveAuthProfile
-// returns the RAW profile, so this is the required chokepoint for any outbound consumer.
-// Existing headers are never clobbered (matches the prior bob_http_scan `!headers[k]`).
+// Build an outbound header map from a base header set plus a resolved auth profile's HEADER
+// fields, skipping the Bob-local metadata above so the synthetic mailbox + provenance
+// fingerprint (and credentials/storage) never reach the TARGET as request headers.
+// resolveAuthProfile returns the RAW profile, so this is the required chokepoint for any
+// outbound consumer. PURE: returns a NEW object and never mutates the caller's `headers`.
+// A caller-supplied key is preserved by PRESENCE (so an intentional empty-string header is
+// NOT overwritten from the profile), not by truthiness.
 function applyAuthProfileHeaders(headers, profile) {
-  if (!profile || typeof profile !== "object") return headers;
+  const merged = headers && typeof headers === "object" ? { ...headers } : {};
+  if (!profile || typeof profile !== "object") return merged;
   for (const [k, v] of Object.entries(profile)) {
     if (PROFILE_METADATA_KEYS.has(k)) continue;
-    if (!headers[k]) headers[k] = v;
+    if (!(k in merged)) merged[k] = v;
   }
-  return headers;
+  return merged;
 }
 
 function resolveAuthJsonPath(targetDomain, { allowLegacyFallback = false } = {}) {

--- a/mcp/lib/auth.js
+++ b/mcp/lib/auth.js
@@ -45,6 +45,34 @@ function buildHeaderProfile(headers, cookies, storage) {
   return profile;
 }
 
+// The canonical set of profile keys that are Bob-LOCAL metadata, NEVER HTTP request
+// headers: credentials + browser storage + the PR-PROV synthetic-identity provenance
+// flags and synthetic mailbox + expiry hints. SINGLE source of truth for every consumer
+// that reads a raw profile from resolveAuthProfile and must not emit/surface these: the
+// outbound-header merge (applyAuthProfileHeaders, used by bob_http_scan), the
+// bob_list_auth_profiles summary (summarizeAuthProfile), and the IDOR producer's outbound
+// strip (offensive-idor-producer.js imports this). One set means a future provenance key
+// cannot leak through a reader that forgot to add it.
+const PROFILE_METADATA_KEYS = Object.freeze(new Set([
+  "credentials", "local_storage", "session_storage",
+  "synthetic", "email_origin", "provisioned_via", "email",
+  "expires_at", "expiresAt", "expiry", "expires",
+]));
+
+// Merge a resolved auth profile's HEADER fields into an outbound header map, skipping the
+// Bob-local metadata above so the synthetic mailbox + provenance fingerprint (and
+// credentials/storage) never reach the TARGET as request headers. resolveAuthProfile
+// returns the RAW profile, so this is the required chokepoint for any outbound consumer.
+// Existing headers are never clobbered (matches the prior bob_http_scan `!headers[k]`).
+function applyAuthProfileHeaders(headers, profile) {
+  if (!profile || typeof profile !== "object") return headers;
+  for (const [k, v] of Object.entries(profile)) {
+    if (PROFILE_METADATA_KEYS.has(k)) continue;
+    if (!headers[k]) headers[k] = v;
+  }
+  return headers;
+}
+
 function resolveAuthJsonPath(targetDomain, { allowLegacyFallback = false } = {}) {
   // Cycle P.2: scan the canonical `~/hacker-bob-sessions/` root for the
   // legacy-fallback discovery path. Sessions copied from
@@ -287,23 +315,15 @@ function profileExpiryHint(profile, mtimeMs) {
   };
 }
 
-// Keys excluded from the bob_list_auth_profiles `header_keys` summary: the existing
-// non-header metadata (credentials/storage) PLUS the PR-PROV synthetic-identity
-// provenance flags + synthetic mailbox that bob_auto_signup stamps. Mirrors the
-// producer's outbound-strip set (offensive-idor-producer.js PROFILE_METADATA_KEYS,
-// :154-158) — keep in sync. Without this, a signup-stamped profile would surface
-// synthetic/email_origin/provisioned_via as bogus "header_keys" and leak the synthetic
-// mailbox into the summary JSON. The producer reads the RAW profile, not this summary,
-// so excluding them here is operator-visibility hygiene only, never a gate change.
-const SUMMARY_EXCLUDED_KEYS = new Set([
-  "credentials", "local_storage", "session_storage",
-  "synthetic", "email_origin", "provisioned_via", "email",
-]);
-
+// bob_list_auth_profiles must not surface the Bob-local metadata keys (credentials/
+// storage + the PR-PROV provenance flags + synthetic mailbox) as bogus `header_keys` or
+// leak the mailbox into the summary JSON. Uses the canonical PROFILE_METADATA_KEYS so it
+// can never drift from the outbound-header merge + the producer strip. The producer reads
+// the RAW profile, not this summary, so this is operator-visibility hygiene only.
 function summarizeAuthProfile(name, profile, fileStats) {
   const normalizedProfile = profile && typeof profile === "object" ? profile : {};
   const headerKeys = Object.keys(normalizedProfile)
-    .filter((key) => !SUMMARY_EXCLUDED_KEYS.has(key))
+    .filter((key) => !PROFILE_METADATA_KEYS.has(key))
     .sort();
   const credentials = normalizedProfile.credentials && typeof normalizedProfile.credentials === "object"
     ? normalizedProfile.credentials
@@ -356,11 +376,13 @@ function listAuthProfiles(args) {
 }
 
 module.exports = {
+  applyAuthProfileHeaders,
   authStore,
   buildHeaderProfile,
   candidateAuthDomains,
   listAuthProfiles,
   migrateAuthJson,
+  PROFILE_METADATA_KEYS,
   readAuthJson,
   resolveAuthJsonPath,
   resolveAuthProfile,

--- a/mcp/lib/auth.js
+++ b/mcp/lib/auth.js
@@ -144,7 +144,7 @@ function persistAuthProfiles(domain, profilesByName) {
   return result;
 }
 
-function authStore(args) {
+function authStore(args, options = {}) {
   const domain = assertNonEmptyString(args.target_domain, "target_domain");
   assertSafeDomain(domain);
   const profileName = assertNonEmptyString(args.profile_name, "profile_name");
@@ -155,6 +155,30 @@ function authStore(args) {
 
   const profile = buildHeaderProfile(headers, cookies, storage);
   if (credentials) profile.credentials = credentials;
+
+  // PR-PROV: stamp the synthetic-identity provenance the IDOR signed-row producer
+  // (bob_http_idor_confirm, mint condition #18) requires before it will sign. This is
+  // accepted ONLY from the second positional argument, which the MCP tool dispatcher
+  // never supplies — dispatch.js and tool-registry.js both invoke tool.handler(args)
+  // with ONE argument, the identical seam the producer itself uses (idorConfirm(args),
+  // "dispatcher always calls with NO second argument"). So the public bob_auth_store
+  // tool (operator-supplied, possibly a real victim's pasted cookie/JWT) can NEVER
+  // stamp provenance; only the in-process bob_auto_signup success path — downstream of
+  // assertSignupEmailAllowed (tempMailboxIsKnown + operator-denylist) — passes it. Each
+  // field is copied only on an exact match to the frozen REQUIRED_PROVENANCE contract
+  // (offensive-idor-producer.js:140-144), so even the trusted caller cannot persist an
+  // arbitrary provenance value. PR-PROV adds NO key isolation: the same-UID in-process
+  // forge boundary (BEDROCK) remains open until the deferred offensive-SANDBOX PR.
+  const provenance = options && typeof options === "object" && options.provenance
+    && typeof options.provenance === "object"
+    ? options.provenance
+    : null;
+  if (provenance) {
+    if (provenance.synthetic === true) profile.synthetic = true;
+    if (provenance.email_origin === "temp_email") profile.email_origin = "temp_email";
+    if (provenance.provisioned_via === "bob_auto_signup") profile.provisioned_via = "bob_auto_signup";
+    if (typeof provenance.email === "string" && provenance.email) profile.email = provenance.email;
+  }
 
   const authPath = resolveAuthJsonPath(domain);
   let persisted = null;
@@ -263,10 +287,23 @@ function profileExpiryHint(profile, mtimeMs) {
   };
 }
 
+// Keys excluded from the bob_list_auth_profiles `header_keys` summary: the existing
+// non-header metadata (credentials/storage) PLUS the PR-PROV synthetic-identity
+// provenance flags + synthetic mailbox that bob_auto_signup stamps. Mirrors the
+// producer's outbound-strip set (offensive-idor-producer.js PROFILE_METADATA_KEYS,
+// :154-158) — keep in sync. Without this, a signup-stamped profile would surface
+// synthetic/email_origin/provisioned_via as bogus "header_keys" and leak the synthetic
+// mailbox into the summary JSON. The producer reads the RAW profile, not this summary,
+// so excluding them here is operator-visibility hygiene only, never a gate change.
+const SUMMARY_EXCLUDED_KEYS = new Set([
+  "credentials", "local_storage", "session_storage",
+  "synthetic", "email_origin", "provisioned_via", "email",
+]);
+
 function summarizeAuthProfile(name, profile, fileStats) {
   const normalizedProfile = profile && typeof profile === "object" ? profile : {};
   const headerKeys = Object.keys(normalizedProfile)
-    .filter((key) => key !== "credentials" && key !== "local_storage" && key !== "session_storage")
+    .filter((key) => !SUMMARY_EXCLUDED_KEYS.has(key))
     .sort();
   const credentials = normalizedProfile.credentials && typeof normalizedProfile.credentials === "object"
     ? normalizedProfile.credentials

--- a/mcp/lib/http-scan.js
+++ b/mcp/lib/http-scan.js
@@ -30,7 +30,7 @@ const {
   isFirstPartyHost,
   safeUrlObject,
 } = require("./url-surface.js");
-const { resolveAuthProfile } = require("./auth.js");
+const { applyAuthProfileHeaders, resolveAuthProfile } = require("./auth.js");
 const {
   resolveHttpScanTargetDomain,
 } = require("./scope.js");
@@ -197,9 +197,10 @@ async function httpScan(args) {
     const auth = resolveAuthProfile(authProfile, url, targetDomain);
 
     if (auth) {
-      for (const [k, v] of Object.entries(auth)) {
-        if (k !== "credentials" && !headers[k]) headers[k] = v;
-      }
+      // Merge only the profile's HEADER fields; the canonical PROFILE_METADATA_KEYS strip
+      // (credentials/storage + PR-PROV synthetic provenance flags + synthetic mailbox)
+      // ensures Bob-local secrets never reach the target as request headers.
+      applyAuthProfileHeaders(headers, auth);
     } else {
       audit({
         status: null,

--- a/mcp/lib/http-scan.js
+++ b/mcp/lib/http-scan.js
@@ -187,7 +187,7 @@ async function httpScan(args) {
     });
   }
 
-  const headers = args.headers || {};
+  let headers = args.headers || {};
   const body = args.body || undefined;
   const followRedirects = args.follow_redirects ?? false;
   const timeoutMs = args.timeout_ms || 10000;
@@ -199,8 +199,9 @@ async function httpScan(args) {
     if (auth) {
       // Merge only the profile's HEADER fields; the canonical PROFILE_METADATA_KEYS strip
       // (credentials/storage + PR-PROV synthetic provenance flags + synthetic mailbox)
-      // ensures Bob-local secrets never reach the target as request headers.
-      applyAuthProfileHeaders(headers, auth);
+      // ensures Bob-local secrets never reach the target as request headers. Pure helper:
+      // returns a new map, so reassign.
+      headers = applyAuthProfileHeaders(headers, auth);
     } else {
       audit({
         status: null,

--- a/mcp/lib/offensive-idor-producer.js
+++ b/mcp/lib/offensive-idor-producer.js
@@ -97,6 +97,7 @@ const {
 const {
   resolveAuthProfile,
   buildHeaderProfile,
+  PROFILE_METADATA_KEYS,
 } = require("./auth.js");
 const {
   withSessionLock,
@@ -143,19 +144,15 @@ const REQUIRED_PROVENANCE = Object.freeze({
   provisioned_via: "bob_auto_signup",
 });
 
-// An auth profile object co-mingles real HTTP headers (Authorization, Cookie,
-// X-*) with Bob-LOCAL metadata: credentials/local_storage/session_storage (the
-// summarizeAuthProfile exclusions) PLUS the PR-PROV provenance flags this
-// producer requires (synthetic/email_origin/provisioned_via) and the synthetic
-// mailbox (email) + expiry hints. buildHeaderProfile Object.assigns its first arg
-// verbatim into the outbound header map, so the full profile must NEVER be passed
-// as headers — that would leak Bob-local provenance and the synthetic mailbox to
-// the TARGET. These keys are stripped before building outbound headers.
-const PROFILE_METADATA_KEYS = Object.freeze(new Set([
-  "credentials", "local_storage", "session_storage",
-  "synthetic", "email_origin", "provisioned_via", "email",
-  "expires_at", "expiresAt", "expiry", "expires",
-]));
+// An auth profile object co-mingles real HTTP headers (Authorization, Cookie, X-*) with
+// Bob-LOCAL metadata: credentials/storage PLUS the PR-PROV provenance flags this producer
+// requires (synthetic/email_origin/provisioned_via) and the synthetic mailbox (email) +
+// expiry hints. buildHeaderProfile Object.assigns its first arg verbatim into the outbound
+// header map, so the full profile must NEVER be passed as headers — that would leak
+// Bob-local provenance and the synthetic mailbox to the TARGET. These keys are stripped
+// (resolveIdentity, below) before building outbound headers. The strip set is the canonical
+// PROFILE_METADATA_KEYS imported from auth.js — shared with bob_http_scan's outbound merge
+// and the bob_list_auth_profiles summary so no reader can drift and leak a future key.
 
 // Outbound HEADER names (lowercased) that must NEVER be sent on a read probe even if a
 // stored/imported auth profile carries them: method/verb overrides turn the producer's
@@ -447,6 +444,11 @@ function resolveIdentity(profileName, url, domain, label) {
 // so this can never be satisfied on the merged transport.
 function profileHasProvenance(profile) {
   if (!profile || typeof profile !== "object") return false;
+  // SECURITY-LOAD-BEARING: STRICT === against the frozen literals, and `synthetic` must be
+  // boolean true. Auth-profile HEADER values are schema-coerced to strings, so an agent
+  // that injects a header literally named `synthetic` (value "true") via bob_auth_store
+  // yields "true" !== true and the gate stays closed. Do NOT relax to ==/truthy or accept
+  // string "true" — that would open a forge onto a real (non-synthetic) identity.
   return profile.synthetic === REQUIRED_PROVENANCE.synthetic
     && profile.email_origin === REQUIRED_PROVENANCE.email_origin
     && profile.provisioned_via === REQUIRED_PROVENANCE.provisioned_via;

--- a/mcp/lib/offensive-idor-producer.js
+++ b/mcp/lib/offensive-idor-producer.js
@@ -449,9 +449,14 @@ function profileHasProvenance(profile) {
   // that injects a header literally named `synthetic` (value "true") via bob_auth_store
   // yields "true" !== true and the gate stays closed. Do NOT relax to ==/truthy or accept
   // string "true" — that would open a forge onto a real (non-synthetic) identity.
+  // A non-empty `email` (the synthetic mailbox) is required so the gate matches the full
+  // four-field stamp authStore writes AND so mint condition #17 (allowedEmails, :NNN) always
+  // has this identity's mailbox for the piiScan allowlist — a 3-marker profile lacking email
+  // must not pass, or the allowlist would be silently short an entry.
   return profile.synthetic === REQUIRED_PROVENANCE.synthetic
     && profile.email_origin === REQUIRED_PROVENANCE.email_origin
-    && profile.provisioned_via === REQUIRED_PROVENANCE.provisioned_via;
+    && profile.provisioned_via === REQUIRED_PROVENANCE.provisioned_via
+    && typeof profile.email === "string" && profile.email.length > 0;
 }
 
 // ── AC-2 cardinality + scan-trail provenance ─────────────────────────────────

--- a/mcp/lib/signup.js
+++ b/mcp/lib/signup.js
@@ -480,6 +480,22 @@ async function autoSignup(args) {
               headers: result.headers || {},
               local_storage: result.local_storage || {},
               credentials: { email, password },
+            }, {
+              // PR-PROV: stamp synthetic-identity provenance so the IDOR signed-row
+              // producer (bob_http_idor_confirm, mint condition #18) can use this
+              // identity. Sound to assert HERE because we are downstream of
+              // assertSignupEmailAllowed (signup.js:331 → tempMailboxIsKnown +
+              // emailMatchesOperatorDenylist): `email` (signup.js:329, the gated INPUT
+              // arg — never target-controlled result.*) is a live bob_temp_email mailbox
+              // this process itself minted, and is not an operator identifier. Passed as
+              // the 2nd positional arg, which the MCP tool dispatcher never supplies, so
+              // bob_auth_store can never forge these onto a real (operator-pasted) identity.
+              provenance: {
+                synthetic: true,
+                email_origin: "temp_email",
+                provisioned_via: "bob_auto_signup",
+                email,
+              },
             });
             result.auth_stored = true;
             result.auth_profile = profileName;

--- a/test/auth-provenance-stamp.test.js
+++ b/test/auth-provenance-stamp.test.js
@@ -20,10 +20,12 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  applyAuthProfileHeaders,
   authStore,
   resolveAuthProfile,
   resolveAuthJsonPath,
   listAuthProfiles,
+  PROFILE_METADATA_KEYS,
 } = require("../mcp/lib/auth.js");
 const { profileHasProvenance } = require("../mcp/lib/offensive-idor-producer.js");
 const { executeTool } = require("../mcp/lib/dispatch.js");
@@ -196,4 +198,65 @@ test("bob_list_auth_profiles does not surface provenance flags or the synthetic 
   assert.equal(prof.header_keys.includes("Cookie"), true);
   // The synthetic mailbox must not appear anywhere in the summary JSON.
   assert.doesNotMatch(JSON.stringify(summary), /eval_x@example\.test/);
+}));
+
+// ───────────────────────── B1: outbound-header leak fix ─────────────────────────
+// PR-PROV newly persists 4 top-level keys onto profiles; bob_http_scan's outbound merge
+// (http-scan.js) copies profile keys into request headers. These tests lock that the
+// canonical metadata strip prevents the synthetic mailbox + provenance fingerprint from
+// reaching the target.
+
+test("applyAuthProfileHeaders strips provenance/mailbox/credentials/storage from outbound headers (B1)", () => {
+  const profile = {
+    Authorization: "Bearer eyJatoken",
+    Cookie: "sid=abc",
+    synthetic: true,
+    email_origin: "temp_email",
+    provisioned_via: "bob_auto_signup",
+    email: "eval_x@example.test",
+    credentials: { email: "eval_x@example.test", password: "p" },
+    local_storage: { k: "v" },
+  };
+  const out = applyAuthProfileHeaders({}, profile);
+  // Real headers pass through.
+  assert.equal(out.Authorization, "Bearer eyJatoken");
+  assert.equal(out.Cookie, "sid=abc");
+  // None of the Bob-local metadata reaches the outbound header map.
+  for (const k of ["synthetic", "email_origin", "provisioned_via", "email", "credentials", "local_storage"]) {
+    assert.equal(k in out, false, `${k} must not be emitted as an outbound header`);
+  }
+  assert.doesNotMatch(JSON.stringify(out), /eval_x@example\.test/);
+});
+
+test("applyAuthProfileHeaders never clobbers a header the caller already set", () => {
+  const out = applyAuthProfileHeaders(
+    { Authorization: "Bearer caller" },
+    { Authorization: "Bearer profile", "X-Trace": "1" },
+  );
+  assert.equal(out.Authorization, "Bearer caller");
+  assert.equal(out["X-Trace"], "1");
+});
+
+test("PROFILE_METADATA_KEYS contains every PR-PROV provenance key (leak-set regression lock)", () => {
+  for (const k of ["synthetic", "email_origin", "provisioned_via", "email", "credentials"]) {
+    assert.equal(PROFILE_METADATA_KEYS.has(k), true, `${k} must be in the canonical metadata strip set`);
+  }
+});
+
+test("end-to-end: a stamped profile resolved from disk emits no provenance/mailbox headers (B1)", () => withTempHome(() => {
+  const domain = "prov-stamp-leak-e2e.test";
+  seedSession(domain);
+  authStore({
+    target_domain: domain,
+    profile_name: "attacker",
+    headers: { Authorization: "Bearer eyJatoken" },
+  }, { provenance: SYNTH });
+  // Exact path bob_http_scan uses: resolveAuthProfile -> applyAuthProfileHeaders.
+  const resolved = resolveAuthProfile("attacker", `https://${domain}/`, domain);
+  const out = applyAuthProfileHeaders({}, resolved);
+  assert.equal(out.Authorization, "Bearer eyJatoken");
+  for (const k of ["synthetic", "email_origin", "provisioned_via", "email"]) {
+    assert.equal(k in out, false, `${k} must not leak to the target`);
+  }
+  assert.doesNotMatch(JSON.stringify(out), /eval_x@example\.test/);
 }));

--- a/test/auth-provenance-stamp.test.js
+++ b/test/auth-provenance-stamp.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+// PR-PROV — arm the bob_http_idor_confirm signed-row producer by stamping synthetic-
+// identity provenance at the bob_auto_signup -> authStore seam.
+//
+// These tests lock the un-fakeability invariant: provenance (synthetic:true +
+// email_origin:"temp_email" + provisioned_via:"bob_auto_signup") may be stamped onto a
+// persisted auth profile ONLY via authStore's SECOND positional argument, which the MCP
+// tool dispatcher never supplies (dispatch.js / tool-registry.js both call
+// tool.handler(args) with ONE arg). So the public bob_auth_store tool — which an
+// operator may feed a REAL victim's pasted cookie/JWT — can never produce a
+// provenance-stamped profile, and an agent confined to the tool surface cannot forge a
+// "synthetic" identity to drive a false signed IDOR row. The producer's actual
+// refuse-to-sign predicate (profileHasProvenance) is asserted as the bridge.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  authStore,
+  resolveAuthProfile,
+  resolveAuthJsonPath,
+  listAuthProfiles,
+} = require("../mcp/lib/auth.js");
+const { profileHasProvenance } = require("../mcp/lib/offensive-idor-producer.js");
+const { executeTool } = require("../mcp/lib/dispatch.js");
+const { initSession } = require("../mcp/lib/session-state.js");
+const { ERROR_CODES } = require("../mcp/lib/envelope.js");
+
+// The exact frozen contract the producer's mint condition #18 requires
+// (offensive-idor-producer.js REQUIRED_PROVENANCE :140-144).
+const SYNTH = Object.freeze({
+  synthetic: true,
+  email_origin: "temp_email",
+  provisioned_via: "bob_auto_signup",
+  email: "eval_x@example.test",
+});
+
+function withTempHome(fn) {
+  const previousHome = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-auth-prov-"));
+  process.env.HOME = home;
+  return Promise.resolve()
+    .then(() => fn(home))
+    .finally(() => {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(home, { recursive: true, force: true });
+    });
+}
+
+function seedSession(domain) {
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+}
+
+test("authStore stamps flat synthetic provenance from the 2nd positional arg and round-trips", () => withTempHome(() => {
+  const domain = "prov-stamp-ok.test";
+  seedSession(domain);
+  authStore({
+    target_domain: domain,
+    profile_name: "identity_a",
+    headers: { Authorization: "Bearer eyJatoken" },
+  }, { provenance: SYNTH });
+
+  // Read through the SAME path the producer uses (resolveAuthProfile -> raw object).
+  const resolved = resolveAuthProfile("identity_a", `https://${domain}/`, domain);
+  assert.equal(resolved.synthetic, true);
+  assert.equal(resolved.email_origin, "temp_email");
+  assert.equal(resolved.provisioned_via, "bob_auto_signup");
+  assert.equal(resolved.email, "eval_x@example.test");
+  assert.equal(resolved.Authorization, "Bearer eyJatoken");
+
+  // The bridge: the stamped profile satisfies the producer's real refuse-to-sign gate.
+  assert.equal(profileHasProvenance(resolved), true);
+
+  // Persisted to disk verbatim, not merely cached.
+  const saved = JSON.parse(fs.readFileSync(resolveAuthJsonPath(domain), "utf8"));
+  assert.equal(saved.profiles.identity_a.synthetic, true);
+  assert.equal(saved.profiles.identity_a.email_origin, "temp_email");
+  assert.equal(saved.profiles.identity_a.provisioned_via, "bob_auto_signup");
+  assert.equal(saved.profiles.identity_a.email, "eval_x@example.test");
+}));
+
+test("authStore exact-value guards: non-contract provenance values are dropped (cannot forge a value)", () => withTempHome(() => {
+  const domain = "prov-stamp-badvalues.test";
+  seedSession(domain);
+  authStore({
+    target_domain: domain,
+    profile_name: "identity_a",
+    headers: { Authorization: "Bearer x" },
+  }, {
+    provenance: {
+      synthetic: "true",            // string, not boolean true
+      email_origin: "operator_pasted",
+      provisioned_via: "manual",
+      email: 12345,                 // not a string
+    },
+  });
+
+  const resolved = resolveAuthProfile("identity_a", `https://${domain}/`, domain);
+  assert.equal(resolved.synthetic, undefined);
+  assert.equal(resolved.email_origin, undefined);
+  assert.equal(resolved.provisioned_via, undefined);
+  assert.equal(resolved.email, undefined);
+  // Forged values cannot satisfy the gate.
+  assert.equal(profileHasProvenance(resolved), false);
+}));
+
+test("authStore with NO second arg (operator bob_auth_store path) carries no provenance — gate fails closed", () => withTempHome(() => {
+  const domain = "prov-stamp-operator.test";
+  seedSession(domain);
+  // Simulates an operator pasting a REAL victim session via bob_auth_store.
+  authStore({
+    target_domain: domain,
+    profile_name: "victim",
+    cookies: { session: "real-victim-cookie" },
+  });
+
+  const resolved = resolveAuthProfile("victim", `https://${domain}/`, domain);
+  assert.equal(resolved.synthetic, undefined);
+  assert.equal(profileHasProvenance(resolved), false);
+}));
+
+test("authStore IGNORES provenance-shaped fields in the FIRST positional arg (only the 2nd-arg seam stamps)", () => withTempHome(() => {
+  const domain = "prov-stamp-argsforge.test";
+  seedSession(domain);
+  // An attacker who could place these in `args` (the tool-surface object) STILL cannot
+  // stamp — authStore reads provenance only from options.provenance (the 2nd arg).
+  authStore({
+    target_domain: domain,
+    profile_name: "victim",
+    cookies: { session: "real-victim-cookie" },
+    synthetic: true,
+    email_origin: "temp_email",
+    provisioned_via: "bob_auto_signup",
+    email: "eval_x@example.test",
+  });
+
+  const resolved = resolveAuthProfile("victim", `https://${domain}/`, domain);
+  assert.equal(resolved.synthetic, undefined);
+  assert.equal(resolved.email_origin, undefined);
+  assert.equal(resolved.provisioned_via, undefined);
+  assert.equal(resolved.email, undefined);
+  assert.equal(profileHasProvenance(resolved), false);
+}));
+
+test("bob_auth_store TOOL surface cannot produce a provenance-stamped profile (forge attempt fails)", () => withTempHome(async () => {
+  const domain = "prov-stamp-tool.test";
+  seedSession(domain);
+  // Adversarial: try to stamp provenance through the public tool by passing the exact
+  // contract literals in the tool args.
+  const result = await executeTool("bob_auth_store", {
+    target_domain: domain,
+    profile_name: "victim",
+    cookies: { session: "real-victim-cookie" },
+    synthetic: true,
+    email_origin: "temp_email",
+    provisioned_via: "bob_auto_signup",
+    email: "eval_x@example.test",
+  });
+
+  // Two independent defenses converge on the invariant. (a) Schema validation rejects
+  // unknown top-level props (additionalProperties defaults to false). (b) Even if it
+  // didn't, one-arg dispatch never reaches the 2nd-arg seam, so the handler ignores
+  // them. Under BOTH, no provenance-stamped profile can result.
+  if (result.ok) {
+    const resolved = resolveAuthProfile("victim", `https://${domain}/`, domain);
+    assert.equal(profileHasProvenance(resolved), false);
+  } else {
+    assert.equal(result.error.code, ERROR_CODES.INVALID_ARGUMENTS);
+    assert.match(result.error.message, /not allowed/);
+  }
+}));
+
+test("bob_list_auth_profiles does not surface provenance flags or the synthetic mailbox", () => withTempHome(() => {
+  const domain = "prov-stamp-summary.test";
+  seedSession(domain);
+  authStore({
+    target_domain: domain,
+    profile_name: "identity_a",
+    headers: { Authorization: "Bearer eyJatoken" },
+    cookies: { sid: "abc" },
+  }, { provenance: SYNTH });
+
+  const summary = JSON.parse(listAuthProfiles({ target_domain: domain }));
+  const prof = summary.profiles.find((p) => p.profile_name === "identity_a");
+  assert.ok(prof, "identity_a must be summarized");
+  for (const leak of ["synthetic", "email_origin", "provisioned_via", "email"]) {
+    assert.equal(prof.header_keys.includes(leak), false, `${leak} must not surface as a header key`);
+  }
+  // The real header + cookie still surface.
+  assert.equal(prof.header_keys.includes("Authorization"), true);
+  assert.equal(prof.header_keys.includes("Cookie"), true);
+  // The synthetic mailbox must not appear anywhere in the summary JSON.
+  assert.doesNotMatch(JSON.stringify(summary), /eval_x@example\.test/);
+}));

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -106,6 +106,7 @@
   "test/offensive-xss-exec-producer.test.js",
   "test/offensive-oob-collector.test.js",
   "test/offensive-nuclei-producer.test.js",
+  "test/auth-provenance-stamp.test.js",
   "test/offensive-run-freeze-completeness.test.js",
   "test/severity-rise-guard.test.js",
   "test/sarif-ingest.test.js",

--- a/test/offensive-idor-producer.test.js
+++ b/test/offensive-idor-producer.test.js
@@ -305,8 +305,13 @@ test("piiScan EXACT-matches provisioned mailboxes only (no eval_* prefix hole), 
   assert.ok(piiScan({ phone: "+1 (415) 555-0142" }, []).length >= 1);
 });
 
-test("profileHasProvenance requires all three synthetic flags", () => {
-  assert.equal(profileHasProvenance({ synthetic: true, email_origin: "temp_email", provisioned_via: "bob_auto_signup" }), true);
+test("profileHasProvenance requires all three synthetic flags AND the synthetic mailbox", () => {
+  const full = { synthetic: true, email_origin: "temp_email", provisioned_via: "bob_auto_signup", email: "eval_a@example.test" };
+  assert.equal(profileHasProvenance(full), true);
+  // The three markers without the synthetic mailbox must NOT pass — mint condition #17
+  // (allowedEmails) depends on profile.email, so the gate requires the full four-field stamp.
+  assert.equal(profileHasProvenance({ synthetic: true, email_origin: "temp_email", provisioned_via: "bob_auto_signup" }), false);
+  assert.equal(profileHasProvenance({ ...full, email: "" }), false);
   assert.equal(profileHasProvenance({ synthetic: true, email_origin: "temp_email" }), false);
   assert.equal(profileHasProvenance({}), false);
   assert.equal(profileHasProvenance(null), false);

--- a/test/offensive-idor-producer.test.js
+++ b/test/offensive-idor-producer.test.js
@@ -30,7 +30,7 @@ const {
 } = require("../mcp/lib/offensive-idor-producer.js");
 const { initSession } = require("../mcp/lib/session-state.js");
 const { routeSurfaces } = require("../mcp/lib/surface-router.js");
-const { writeAuthFile, resolveAuthJsonPath } = require("../mcp/lib/auth.js");
+const { writeAuthFile, resolveAuthJsonPath, authStore } = require("../mcp/lib/auth.js");
 const { ensureHandoffSigningKey } = require("../mcp/lib/handoff-signing-key.js");
 const { attackSurfacePath, offensiveRunsJsonlPath, offensiveRunsDir } = require("../mcp/lib/paths.js");
 const {
@@ -346,6 +346,41 @@ test("AC-6 positive: a sound cross-tenant read mints EXACTLY ONE signed medium r
   // capture file on disk re-hashes to the row's stdout_hash (freeze re-hash path)
   const observed = projectExploitRunObservedRef(domain, { kind: "exploit_run", run_id: row.run_id });
   assert.equal(observed.stdout_hash, row.stdout_hash);
+}));
+
+// PR-PROV end-to-end: arm the three identities through the REAL production stamp path
+// (authStore with the 2nd-arg provenance the bob_auto_signup seam passes) instead of the
+// raw file-writer `seedSyntheticProfiles`. Proves the stamp the producer's mint
+// condition #18 reads is exactly what authStore persists, so the production arming path
+// actually drives the signer.
+test("AC-6 via production stamp: identities armed by authStore(2nd-arg provenance) mint EXACTLY ONE signed medium row", () => withTempHome(async () => {
+  const domain = "idor-prov-stamp.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedRoutedSurface(domain, SURFACE_ID, endpointFor(domain));
+  for (const tag of ["a", "b", "c"]) {
+    authStore({
+      target_domain: domain,
+      profile_name: `identity_${tag}`,
+      headers: { Authorization: `Bearer eyJ${tag}token` },
+    }, {
+      provenance: {
+        synthetic: true,
+        email_origin: "temp_email",
+        provisioned_via: "bob_auto_signup",
+        email: `eval_${tag}@example.test`,
+      },
+    });
+  }
+  ensureHandoffSigningKey(domain);
+
+  const result = await run(domain);
+  assert.equal(result.confirmed, true, JSON.stringify(result));
+  assert.equal(result.row_written, true);
+  assert.equal(result.offensive_outcome, "exploited_safely");
+  assert.equal(result.demonstrated_severity, "medium");
+  const rows = readOffensiveRunRecords(domain);
+  assert.equal(rows.length, 1);
+  assert.ok(rows[0].row_mac && rows[0].row_mac.digest, "row must be MAC-signed");
 }));
 
 test("AC-6 positive is canary-FIELD, not whole-body: per-viewer variance does NOT block", () => withTempHome(async () => {


### PR DESCRIPTION
## What

Arms the merged-but-**INERT** second-test-identity IDOR signed-row producer
`bob_http_idor_confirm` (#119) by stamping synthetic-identity provenance so its
refuse-to-sign gate (mint condition #18, `offensive-idor-producer.js:642`) becomes
satisfiable for a genuinely-synthetic identity. This is the change that turns Bob's
first *real* signed exploit producer from dormant to live.

The producer refuses to sign unless every resolved auth profile carries
`synthetic:true` + `email_origin:"temp_email"` + `provisioned_via:"bob_auto_signup"`,
and nothing stamped them. PR-PROV stamps that provenance **only** at the
`bob_auto_signup → authStore` success seam — the one site that has just proven the
email is a live `bob_temp_email` mailbox (`assertSignupEmailAllowed` →
`tempMailboxIsKnown` + operator-denylist). It fires no live request.

## The un-fakeability invariant

> Provenance may be written onto a persisted profile ONLY on a path that has already
> proven the identity is synthetic. It must be unreachable from the MCP tool surface.

Provenance is accepted **only from `authStore`'s 2nd positional argument**, which the
MCP dispatcher never supplies — `dispatch.js:77` and `tool-registry.js:295` both call
`tool.handler(args)` with **one** argument (the identical seam the producer itself uses:
`idorConfirm(args)`, "dispatcher always calls with NO second argument"). So the public
`bob_auth_store` tool — which an operator may feed a **real victim's** pasted cookie —
can never stamp provenance. Each field is copied only on an exact match to the frozen
contract literal. This is a *local, schema-independent* invariant (preferred over
routing provenance through `args`, whose soundness would depend on the tool schema
never changing).

## Honest boundary (NOT closed here)

The HMAC-signed row defends an agent confined to the MCP + guarded-Bash surface. It does
**not** defend a same-UID `node -e` that reads the 0600 signing key (BEDROCK). PR-PROV
adds zero key isolation — it neither widens nor narrows that boundary. Closure remains
the separately-deferred offensive-SANDBOX (UID/container) PR. Nothing here implies rows
are "un-forgeable."

## Changes

- `mcp/lib/auth.js`: `authStore(args, options)` stamps flat `synthetic`/`email_origin`/
  `provisioned_via`/`email` from `options.provenance` (exact-value guards);
  `summarizeAuthProfile` excludes those 4 keys from `header_keys` so
  `bob_list_auth_profiles` can't leak the flags or the synthetic mailbox.
- `mcp/lib/signup.js`: `autoSignup` passes `{provenance:{…, email}}` with the **gated
  input** `email` (never target-controlled `result.*`).
- `test/auth-provenance-stamp.test.js` (new, 6 cases) + an end-to-end arming case in
  `test/offensive-idor-producer.test.js`, all bridged to the producer's real
  `profileHasProvenance` predicate. Core tripwires: operator-path / args-forge /
  tool-surface-forge all **refuse**.

No producer logic edited (gate/ceiling/strip-set already built in #119). **No new tool.**

## Deferred to PR-D

Live self-provisioning, dispatcher `provision` wiring, container egress proxy,
path-segment cache-buster, `scripts/measure-idor-oracle.js`.

## Pre-push adversarial review

A self-run 4-skeptic red-team **confirmed the forge path is closed** (single-arg
dispatch, schema rejects unknown props, `signup.js:476` is the only `authStore`/2nd-arg
caller, boolean `synthetic===true` anchor) and found **one MERGE-CRITICAL leak (B1),
now fixed** in `3fbb319`:

- **B1:** `http-scan.js`'s outbound auth-header merge copied every non-`credentials`
  profile key into request headers, so PR-PROV's new top-level provenance keys leaked
  the synthetic mailbox + pentest-account fingerprint to the in-scope target via
  `bob_auto_signup`→`bob_http_scan`. **Fix:** one canonical `PROFILE_METADATA_KEYS` +
  exported `applyAuthProfileHeaders` chokepoint, imported by all **three** raw-profile
  readers (outbound merge, summary, producer strip — local dup removed), so no future
  key can leak through a forgotten reader. +4 regression tests.
- **Deferred-with-reason:** a test driving the real `autoSignup` success branch
  (`execFile`, no injectable seam; the `{provenance}` wiring is review-visible and
  **fails closed**) — PR-D follow-up.

## Local gates

`test:mcp` 2776/0 · `check:syntax` clean · `test:prompts` 181/0 · `test:install` 15/0 ·
`test:package` CI-tree pack **3.200 MB < 3.3 MB** (the local 3.31 MB is pre-existing
untracked design docs; `test/` isn't in the `files` glob so the new test isn't packed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added standardized auth profile header assembly that automatically strips internal/provenance fields while preserving any caller-provided headers.

* **Bug Fixes**
  * Implemented conditional “synthetic provenance” stamping during automated signup, and tightened validation to prevent forged provenance.
  * Reduced risk of internal auth metadata leaking through outbound request headers.

* **Tests**
  * Added end-to-end and unit tests covering provenance stamping, leak prevention, and header-merge/strip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->