### PR TITLE
harden(session): cross-version surface-routes resilience + auth-aware circuit breaker

### DIFF
--- a/mcp/lib/context-budget.js
+++ b/mcp/lib/context-budget.js
@@ -60,6 +60,15 @@ function getContextBudget(args) {
         briefProfile = route.brief_profile;
         capabilityPackVersion = route.capability_pack_version;
         contextBudget = normalizeContextBudget(route.context_budget, pack);
+      } else if (Array.isArray(routesInfo.malformed_routes)) {
+        // readSurfaceRoutesStrict quarantines a malformed route (e.g. an unsupported context_budget
+        // field, or a stale cross-version schema) so read-all consumers do not brick. But a TARGETED
+        // budget lookup for that exact surface must SURFACE the problem — the agent cannot operate
+        // under an undefined budget — rather than silently fall back to the pack default.
+        const malformed = routesInfo.malformed_routes.find((entry) => entry.surface_id === surfaceId);
+        if (malformed) {
+          throw new Error(`surface_id ${surfaceId} has a malformed route: ${malformed.reason}`);
+        }
       }
     } catch (error) {
       if (!/Missing surface routes JSON:/.test(error.message || String(error))) {

--- a/mcp/lib/context-budget.js
+++ b/mcp/lib/context-budget.js
@@ -52,6 +52,17 @@ function getContextBudget(args) {
 
     try {
       const routesInfo = readSurfaceRoutesStrict(targetDomain);
+      // readSurfaceRoutesStrict quarantines a malformed route (e.g. an unsupported context_budget
+      // field, or a stale cross-version schema) so read-all consumers do not brick. But a TARGETED
+      // budget lookup must SURFACE a quarantined target — checked FIRST, so it fires even when a
+      // duplicate VALID route for the same surface also exists (the file is still corrupt and the
+      // agent cannot trust a silently-chosen budget/pack), not just when no route was found.
+      if (Array.isArray(routesInfo.malformed_routes)) {
+        const malformed = routesInfo.malformed_routes.find((entry) => entry.surface_id === surfaceId);
+        if (malformed) {
+          throw new Error(`surface_id ${surfaceId} has a malformed route: ${malformed.reason}`);
+        }
+      }
       const route = routesInfo.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
       if (route) {
         if (route.capability_pack !== capabilityPack) {
@@ -60,15 +71,6 @@ function getContextBudget(args) {
         briefProfile = route.brief_profile;
         capabilityPackVersion = route.capability_pack_version;
         contextBudget = normalizeContextBudget(route.context_budget, pack);
-      } else if (Array.isArray(routesInfo.malformed_routes)) {
-        // readSurfaceRoutesStrict quarantines a malformed route (e.g. an unsupported context_budget
-        // field, or a stale cross-version schema) so read-all consumers do not brick. But a TARGETED
-        // budget lookup for that exact surface must SURFACE the problem — the agent cannot operate
-        // under an undefined budget — rather than silently fall back to the pack default.
-        const malformed = routesInfo.malformed_routes.find((entry) => entry.surface_id === surfaceId);
-        if (malformed) {
-          throw new Error(`surface_id ${surfaceId} has a malformed route: ${malformed.reason}`);
-        }
       }
     } catch (error) {
       if (!/Missing surface routes JSON:/.test(error.message || String(error))) {

--- a/mcp/lib/http-records.js
+++ b/mcp/lib/http-records.js
@@ -385,7 +385,11 @@ function isCircuitBreakerFailure(record) {
 }
 
 function circuitBreakerRecordKey(record) {
-  const host = record.host || hostnameFromUrl(record.url) || "unknown";
+  // Origin (scheme://host:port), not bare hostname: different services on the same host — a non-default
+  // port, or http vs https — block INDEPENDENTLY, so a success on one must not heal a block on another.
+  let origin = "";
+  try { origin = new URL(record.url).origin; } catch { origin = ""; }
+  if (!origin || origin === "null") origin = record.host || hostnameFromUrl(record.url) || "unknown";
   let path = typeof record.path === "string" && record.path ? record.path : "";
   if (!path) {
     try { path = new URL(record.url).pathname; } catch { path = ""; }
@@ -399,12 +403,11 @@ function circuitBreakerRecordKey(record) {
   // identities can share a profile name (reconfigured/legacy), and a success through one identity
   // must not heal a block reached through another.
   const egressId = (typeof record.egress_profile_identity_hash === "string" && record.egress_profile_identity_hash) ? record.egress_profile_identity_hash : "";
-  // Newline-delimited (not space): a free-form egress_profile name may contain a literal space, which
-  // under a space-join could let two distinct (host, method, path, egress, egressId) tuples collapse to
-  // one key and cross-heal. No component (hostname, HTTP method, parsed pathname, profile name, hex
-  // identity hash) can contain a newline, so this is collision-proof. The key is only ever a Map key
-  // within a single summary computation — never persisted or parsed back — so the format is free to change.
-  return [host, method, path, egress, egressId].join("\n");
+  // JSON-encode the tuple: JSON escapes any interior delimiter/quote/newline in a component (e.g. an
+  // egress_profile name containing a newline), so two distinct tuples can NEVER collapse to one key —
+  // no manual sanitization or "no component contains X" invariant required. The key is only ever a Map
+  // key within a single summary computation (never persisted or parsed back), so the format is free.
+  return JSON.stringify([origin, method, path, egress, egressId]);
 }
 
 function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCUIT_BREAKER_THRESHOLD } = {}) {

--- a/mcp/lib/http-records.js
+++ b/mcp/lib/http-records.js
@@ -399,7 +399,12 @@ function circuitBreakerRecordKey(record) {
   // identities can share a profile name (reconfigured/legacy), and a success through one identity
   // must not heal a block reached through another.
   const egressId = (typeof record.egress_profile_identity_hash === "string" && record.egress_profile_identity_hash) ? record.egress_profile_identity_hash : "";
-  return `${host} ${method} ${path} ${egress} ${egressId}`;
+  // Newline-delimited (not space): a free-form egress_profile name may contain a literal space, which
+  // under a space-join could let two distinct (host, method, path, egress, egressId) tuples collapse to
+  // one key and cross-heal. No component (hostname, HTTP method, parsed pathname, profile name, hex
+  // identity hash) can contain a newline, so this is collision-proof. The key is only ever a Map key
+  // within a single summary computation — never persisted or parsed back — so the format is free to change.
+  return [host, method, path, egress, egressId].join("\n");
 }
 
 function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCUIT_BREAKER_THRESHOLD } = {}) {

--- a/mcp/lib/http-records.js
+++ b/mcp/lib/http-records.js
@@ -78,6 +78,11 @@ function normalizeHttpAuditRecord(record, { expectedDomain = null, lineNumber = 
       wave: record.wave == null ? null : parseWaveId(record.wave),
       agent: record.agent == null ? null : parseAgentId(record.agent),
       surface_id: normalizeOptionalText(record.surface_id, "surface_id"),
+      // The originating tool (auditConfirmRequest stamps this for the offensive confirmers; null for
+      // bob_http_scan). Persisted so the circuit breaker can tell a faithful-auth bob_http_scan 403
+      // (auth_profile truthful) from an offensive-confirmer probe (audited WITHOUT auth_profile, so a
+      // genuine authenticated block would otherwise look like a healable unauth challenge).
+      tool: normalizeOptionalText(record.tool, "tool"),
       auth_profile: normalizeOptionalText(record.auth_profile, "auth_profile"),
       checkpoint_mode: normalizeOptionalText(record.checkpoint_mode, "checkpoint_mode"),
       block_internal_hosts: record.block_internal_hosts == null
@@ -385,7 +390,12 @@ function circuitBreakerRecordKey(record) {
   if (!path) {
     try { path = new URL(record.url).pathname; } catch { path = ""; }
   }
-  return `${host} ${path}`;
+  // Method + egress are part of the key so an authenticated GET 2xx cannot "heal" a blocked POST on
+  // the same path (method-specific WAF/CSRF/rate-limit), and a success on one egress profile cannot
+  // heal a per-egress block reached through another.
+  const method = (typeof record.method === "string" && record.method ? record.method : "GET").toUpperCase();
+  const egress = (typeof record.egress_profile === "string" && record.egress_profile) ? record.egress_profile : "default";
+  return `${host} ${method} ${path} ${egress}`;
 }
 
 function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCUIT_BREAKER_THRESHOLD } = {}) {
@@ -415,9 +425,12 @@ function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCU
     const host = record.host || hostnameFromUrl(record.url) || "unknown";
 
     // Reclassify an unauthenticated 403 as an auth-challenge ONLY with positive, temporally-ordered
-    // evidence: a later authenticated 2xx on the same host+path. Hard blocks (429, timeouts, 403
-    // despite auth) are mutually exclusive with this and are never reclassified.
-    if (isUnauthenticatedForbidden(record)) {
+    // evidence: a later authenticated 2xx on the same host+path+method+egress. Hard blocks (429,
+    // timeouts, 403 despite auth) are never reclassified. The !record.tool gate restricts healing to
+    // the faithful-auth path (bob_http_scan records auth_profile truthfully); offensive confirmers
+    // audit via auditConfirmRequest WITHOUT an auth_profile but DO stamp tool, so a genuine
+    // AUTHENTICATED block from a confirmer (recorded auth_profile:null) is never healed.
+    if (isUnauthenticatedForbidden(record) && !record.tool) {
       const healedTs = latestAuthedSuccessTs.get(circuitBreakerRecordKey(record));
       const recordTs = Date.parse(record.ts);
       if (healedTs != null && !Number.isNaN(recordTs) && healedTs > recordTs) {

--- a/mcp/lib/http-records.js
+++ b/mcp/lib/http-records.js
@@ -395,7 +395,11 @@ function circuitBreakerRecordKey(record) {
   // heal a per-egress block reached through another.
   const method = (typeof record.method === "string" && record.method ? record.method : "GET").toUpperCase();
   const egress = (typeof record.egress_profile === "string" && record.egress_profile) ? record.egress_profile : "default";
-  return `${host} ${method} ${path} ${egress}`;
+  // The egress IDENTITY hash (not just the profile NAME) is part of the key: two different proxy
+  // identities can share a profile name (reconfigured/legacy), and a success through one identity
+  // must not heal a block reached through another.
+  const egressId = (typeof record.egress_profile_identity_hash === "string" && record.egress_profile_identity_hash) ? record.egress_profile_identity_hash : "";
+  return `${host} ${method} ${path} ${egress} ${egressId}`;
 }
 
 function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCUIT_BREAKER_THRESHOLD } = {}) {
@@ -484,8 +488,10 @@ function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCU
   );
   // Auditable, separate channel: unauthenticated 403s that a later authed success healed. Surfaced
   // (never hidden) but NOT counted toward the breaker.
-  const authChallengeHosts = Array.from(authChallengeByHost.values()).sort((a, b) => a.host.localeCompare(b.host));
-  const authChallengeCount = authChallengeHosts.reduce((sum, h) => sum + h.auth_challenge_403, 0);
+  const authChallengeAll = Array.from(authChallengeByHost.values()).sort((a, b) => a.host.localeCompare(b.host));
+  const authChallengeCount = authChallengeAll.reduce((sum, h) => sum + h.auth_challenge_403, 0);
+  // Keep the full scalar count, but cap the returned host list so the response stays bounded.
+  const authChallengeHosts = authChallengeAll.slice(0, HTTP_AUDIT_SUMMARY_MAX_ITEMS);
 
   return {
     threshold,

--- a/mcp/lib/http-records.js
+++ b/mcp/lib/http-records.js
@@ -350,18 +350,83 @@ function normalizeHttpAuditSummaryLimit(value) {
   return Math.max(0, Math.min(HTTP_AUDIT_SUMMARY_MAX_ITEMS, Math.trunc(value)));
 }
 
-function isCircuitBreakerFailure(record) {
-  if (record.status === 403 || record.status === 429) return true;
+function recordHasAuthProfile(record) {
+  return typeof record.auth_profile === "string" && record.auth_profile.length > 0;
+}
+
+// GENUINE block signals — always count toward the breaker, NEVER reclassified:
+//   429 (rate-limit); timeouts / connection resets; AND a 403 returned DESPITE an attached auth
+//   profile (the server blocks even an authenticated session). These keep a real WAF/rate-limit
+//   trip a hard stop.
+function isHardBlockFailure(record) {
+  if (record.status === 429) return true;
+  if (record.status === 403 && recordHasAuthProfile(record)) return true;
   if (["request_error", "network_unreachable_target"].includes(record.scope_decision) && /timeout|abort|econnreset|connection reset/i.test(record.error || "")) return true;
   return false;
 }
 
+// A 403 sent WITHOUT any auth profile is a CANDIDATE auth-challenge — the expected response when an
+// authenticated endpoint is probed unauthenticated. It is reclassified as benign ONLY on positive,
+// temporally-ordered evidence (a later authenticated 2xx to the same host+path); with no such
+// success it STILL counts as a block, so a pure WAF wall stays tripped.
+function isUnauthenticatedForbidden(record) {
+  return record.status === 403 && !recordHasAuthProfile(record);
+}
+
+// Back-compat: any record that was a "failure" before is still a failure (hard block OR candidate
+// auth-challenge). The reclassification happens in buildCircuitBreakerSummary, not here.
+function isCircuitBreakerFailure(record) {
+  return isHardBlockFailure(record) || isUnauthenticatedForbidden(record);
+}
+
+function circuitBreakerRecordKey(record) {
+  const host = record.host || hostnameFromUrl(record.url) || "unknown";
+  let path = typeof record.path === "string" && record.path ? record.path : "";
+  if (!path) {
+    try { path = new URL(record.url).pathname; } catch { path = ""; }
+  }
+  return `${host} ${path}`;
+}
+
 function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCUIT_BREAKER_THRESHOLD } = {}) {
-  const relevantRecords = (surface ? records.filter((record) => recordMatchesSurface(record, surface)) : records)
-    .filter(isCircuitBreakerFailure);
+  const relevant = surface ? records.filter((record) => recordMatchesSurface(record, surface)) : records;
+
+  // Index the LATEST authenticated 2xx success per host+path. An unauthenticated 403 is a benign
+  // auth-challenge (not a host block) once a later authenticated request to the SAME host+path
+  // actually succeeds. This is the ONLY path that reclassifies a 403 — a genuine WAF/rate-limit
+  // block produces no such authed success, so it stays counted (and tripped). No traffic is sent
+  // and no live block is bypassed; this only stops double-counting historical unauth challenges
+  // once the data itself shows the now-attached session passes.
+  const latestAuthedSuccessTs = new Map();
+  for (const record of relevant) {
+    if (recordHasAuthProfile(record) && Number.isInteger(record.status) && record.status >= 200 && record.status < 300) {
+      const key = circuitBreakerRecordKey(record);
+      const ts = Date.parse(record.ts);
+      if (!Number.isNaN(ts) && (!latestAuthedSuccessTs.has(key) || ts > latestAuthedSuccessTs.get(key))) {
+        latestAuthedSuccessTs.set(key, ts);
+      }
+    }
+  }
+
+  const failures = relevant.filter(isCircuitBreakerFailure);
   const byHost = new Map();
-  for (const record of relevantRecords) {
+  const authChallengeByHost = new Map();
+  for (const record of failures) {
     const host = record.host || hostnameFromUrl(record.url) || "unknown";
+
+    // Reclassify an unauthenticated 403 as an auth-challenge ONLY with positive, temporally-ordered
+    // evidence: a later authenticated 2xx on the same host+path. Hard blocks (429, timeouts, 403
+    // despite auth) are mutually exclusive with this and are never reclassified.
+    if (isUnauthenticatedForbidden(record)) {
+      const healedTs = latestAuthedSuccessTs.get(circuitBreakerRecordKey(record));
+      const recordTs = Date.parse(record.ts);
+      if (healedTs != null && !Number.isNaN(recordTs) && healedTs > recordTs) {
+        if (!authChallengeByHost.has(host)) authChallengeByHost.set(host, { host, auth_challenge_403: 0 });
+        authChallengeByHost.get(host).auth_challenge_403 += 1;
+        continue;
+      }
+    }
+
     if (!byHost.has(host)) {
       byHost.set(host, {
         host,
@@ -404,6 +469,10 @@ function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCU
   const belowThreshold = sortedItems.filter(
     (item) => item.failures > 0 && item.failures < threshold,
   );
+  // Auditable, separate channel: unauthenticated 403s that a later authed success healed. Surfaced
+  // (never hidden) but NOT counted toward the breaker.
+  const authChallengeHosts = Array.from(authChallengeByHost.values()).sort((a, b) => a.host.localeCompare(b.host));
+  const authChallengeCount = authChallengeHosts.reduce((sum, h) => sum + h.auth_challenge_403, 0);
 
   return {
     threshold,
@@ -411,8 +480,10 @@ function buildCircuitBreakerSummary(records, { surface = null, threshold = CIRCU
     tripped_count: tripped.length,
     below_threshold_hosts: belowThreshold,
     below_threshold_count: belowThreshold.length,
+    auth_challenge_hosts: authChallengeHosts,
+    auth_challenge_403_count: authChallengeCount,
     note: tripped.length
-      ? "Repeated 403/429/timeout results on these hosts. Prefer fewer replay variants, authenticated traffic-derived requests, or a different surface."
+      ? "Repeated genuine block signals (429/timeout, or 403 even with an auth profile) on these hosts. Prefer fewer replay variants or a different surface; do NOT bypass a live block. (Unauthenticated 403s already healed by a later authenticated success are excluded and reported under auth_challenge_hosts.)"
       : null,
   };
 }
@@ -1648,6 +1719,8 @@ module.exports = {
   headerNamesFromInput,
   importHttpTraffic,
   isCircuitBreakerFailure,
+  isHardBlockFailure,
+  isUnauthenticatedForbidden,
   isNetworkUnreachableRecord,
   normalizeHttpAuditRecord,
   normalizeImportedTrafficEntry,

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -249,6 +249,15 @@ function findRoutedSurface(domain, surfaceId) {
   const routed = readSurfaceRoutesStrict(domain);
   const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
   if (!route) {
+    // The reader quarantines a malformed route instead of bricking. If THIS surface's route was
+    // quarantined (e.g. a stale cross-version schema), surface the repairable reason rather than a
+    // misleading "unknown surface_id" — re-running bob_route_surfaces regenerates the file.
+    if (Array.isArray(routed.malformed_routes)) {
+      const malformed = routed.malformed_routes.find((entry) => entry.surface_id === surfaceId);
+      if (malformed) {
+        rejectInvalidArguments(`surface_id ${surfaceId} has a malformed route (re-run bob_route_surfaces): ${malformed.reason}`);
+      }
+    }
     rejectInvalidArguments(`unknown or unrouted surface_id ${surfaceId}`);
   }
   const surfaces = currentSurfaces(domain);

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -247,17 +247,19 @@ function normalizePathTemplate(rawTemplate, toolName = "bob_http_confirm") {
 
 function findRoutedSurface(domain, surfaceId) {
   const routed = readSurfaceRoutesStrict(domain);
+  // Check quarantined routes for THIS surface FIRST — BEFORE accepting a route — so a corrupt file
+  // (even one with a valid-first occurrence AND a malformed duplicate for the same surface_id) is
+  // rejected here exactly as getContextBudget rejects it. Otherwise live offensive probes would
+  // trust a file the budget system considers corrupt (split routing authority over one artifact).
+  // The reader quarantines instead of bricking; a targeted probe surfaces the repairable reason.
+  if (Array.isArray(routed.malformed_routes)) {
+    const malformed = routed.malformed_routes.find((entry) => entry.surface_id === surfaceId);
+    if (malformed) {
+      rejectInvalidArguments(`surface_id ${surfaceId} has a malformed route (re-run bob_route_surfaces): ${malformed.reason}`);
+    }
+  }
   const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
   if (!route) {
-    // The reader quarantines a malformed route instead of bricking. If THIS surface's route was
-    // quarantined (e.g. a stale cross-version schema), surface the repairable reason rather than a
-    // misleading "unknown surface_id" — re-running bob_route_surfaces regenerates the file.
-    if (Array.isArray(routed.malformed_routes)) {
-      const malformed = routed.malformed_routes.find((entry) => entry.surface_id === surfaceId);
-      if (malformed) {
-        rejectInvalidArguments(`surface_id ${surfaceId} has a malformed route (re-run bob_route_surfaces): ${malformed.reason}`);
-      }
-    }
     rejectInvalidArguments(`unknown or unrouted surface_id ${surfaceId}`);
   }
   const surfaces = currentSurfaces(domain);

--- a/mcp/lib/surface-router.js
+++ b/mcp/lib/surface-router.js
@@ -127,6 +127,14 @@ function routeSurfacesInternal(domain, { attackSurfaceInfo = null } = {}) {
   };
 }
 
+// validateSurfaceRoute embeds the absolute surface-routes.json path in some error messages. Strip
+// it to the basename so a quarantine reason surfaced to a caller (getContextBudget, or the
+// malformed_routes returned to read-all consumers) never leaks the local session filesystem path.
+function sanitizeRouteReason(message, filePath) {
+  const text = typeof message === "string" ? message : String(message);
+  return filePath ? text.split(filePath).join("surface-routes.json") : text;
+}
+
 function readSurfaceRoutesStrict(domain) {
   const filePath = surfaceRoutesPath(domain);
   if (!fs.existsSync(filePath)) {
@@ -166,7 +174,7 @@ function readSurfaceRoutesStrict(domain) {
       malformedRoutes.push({
         index,
         surface_id: (route && typeof route === "object" && route.surface_id) || null,
-        reason: error.message || String(error),
+        reason: sanitizeRouteReason(error.message || String(error), filePath),
       });
       return;
     }

--- a/mcp/lib/surface-router.js
+++ b/mcp/lib/surface-router.js
@@ -111,6 +111,13 @@ function routeSurfacesInternal(domain, { attackSurfaceInfo = null } = {}) {
   const targetDomain = assertNonEmptyString(domain, "target_domain");
   const document = buildSurfaceRoutesDocument(targetDomain, { attackSurfaceInfo });
   const filePath = surfaceRoutesPath(targetDomain);
+  // Validate every generated route BEFORE persisting. classifySurfaceCapability cannot emit an
+  // empty/pack-mismatched evaluator_agent today, but a future pack/derivation regression that did
+  // would otherwise be silently written and only blow up later on read (bricking unrelated
+  // artifacts). Fail fast here with the validator's actionable message instead of persisting a
+  // landmine. (Forward-discipline: a breaking route-field change must also bump SURFACE_ROUTE_VERSION
+  // above — the un-bumped rename is what let a stale file masquerade as field corruption.)
+  document.routes.forEach((route, index) => validateSurfaceRoute(route, index, filePath));
   writeFileAtomic(filePath, `${JSON.stringify(document, null, 2)}\n`);
 
   return {
@@ -141,16 +148,41 @@ function readSurfaceRoutesStrict(domain) {
   ) {
     throw new Error(`Malformed surface routes JSON: ${filePath} (expected versioned routes document)`);
   }
+  // Per-route resilience: a single malformed/stale route — e.g. one written by a PRIOR framework
+  // version after a route-field rename (the hunter_agent -> evaluator_agent v2.1 drift) — must NOT
+  // abort the whole read and brick every consumer that funnels through this function (routing,
+  // context-budget, the offensive HTTP confirmers, and the downstream verifier/evidence/grader/
+  // reporter agents). Quarantine bad/duplicate routes into malformed_routes[] and emit a repair
+  // hint; surface-routes.json is fully regenerable via bob_route_surfaces. Genuinely unrecoverable
+  // top-level shape (unparseable JSON, version mismatch, routes-not-an-array) still fails hard above.
   const seenSurfaceIds = new Set();
-  const routes = parsed.routes.map((route, index) => {
-    const normalized = validateSurfaceRoute(route, index, filePath);
+  const routes = [];
+  const malformedRoutes = [];
+  parsed.routes.forEach((route, index) => {
+    let normalized;
+    try {
+      normalized = validateSurfaceRoute(route, index, filePath);
+    } catch (error) {
+      malformedRoutes.push({
+        index,
+        surface_id: (route && typeof route === "object" && route.surface_id) || null,
+        reason: error.message || String(error),
+      });
+      return;
+    }
     if (seenSurfaceIds.has(normalized.surface_id)) {
-      throw new Error(`Malformed surface routes JSON: ${filePath} (duplicate surface_id: ${normalized.surface_id})`);
+      malformedRoutes.push({ index, surface_id: normalized.surface_id, reason: `duplicate surface_id: ${normalized.surface_id}` });
+      return;
     }
     seenSurfaceIds.add(normalized.surface_id);
-    return normalized;
+    routes.push(normalized);
   });
-  return { path: filePath, document: { ...parsed, routes } };
+  const result = { path: filePath, document: { ...parsed, routes } };
+  if (malformedRoutes.length > 0) {
+    result.malformed_routes = malformedRoutes;
+    result.repair_hint = "re-run bob_route_surfaces to regenerate surface-routes.json from the current surface index";
+  }
+  return result;
 }
 
 function routeSurfaces(args) {

--- a/mcp/lib/surface-router.js
+++ b/mcp/lib/surface-router.js
@@ -182,9 +182,14 @@ function readSurfaceRoutesStrict(domain) {
         || error instanceof SyntaxError || error instanceof EvalError || error instanceof URIError) {
         throw error;
       }
+      const rawSurfaceId = route && typeof route === "object" ? route.surface_id : null;
       malformedRoutes.push({
         index,
-        surface_id: (route && typeof route === "object" && route.surface_id) || null,
+        // Trim the stored surface_id: getContextBudget/findRoutedSurface reject a corrupt file by
+        // matching the malformed entry's surface_id against the (trimmed) request id, and
+        // validateSurfaceRoute trims on the valid path — so a quarantined entry that kept a
+        // whitespace-padded id (e.g. " surface:api ") would otherwise EVADE that rejection.
+        surface_id: (typeof rawSurfaceId === "string" ? rawSurfaceId.trim() : rawSurfaceId) || null,
         reason: sanitizeRouteReason(error.message || String(error), filePath),
       });
       return;

--- a/mcp/lib/surface-router.js
+++ b/mcp/lib/surface-router.js
@@ -171,6 +171,17 @@ function readSurfaceRoutesStrict(domain) {
     try {
       normalized = validateSurfaceRoute(route, index, filePath);
     } catch (error) {
+      // Only a DATA problem (a stale/malformed route) is quarantine-able. validateSurfaceRoute and
+      // every helper it calls (assertNonEmptyString, getCapabilityPack, normalizeContextBudget) signal
+      // a data-validation failure with a plain `Error`. A JS error SUBCLASS
+      // (TypeError/RangeError/ReferenceError/SyntaxError/EvalError/URIError) can therefore only come
+      // from a PROGRAMMING regression inside the validator (a null deref, a renamed import). Masking
+      // that as a quarantined "stale route" behind a "re-run bob_route_surfaces" hint would hide the
+      // bug, so re-throw it loudly. (This also pins the convention: data validation throws plain Error.)
+      if (error instanceof TypeError || error instanceof RangeError || error instanceof ReferenceError
+        || error instanceof SyntaxError || error instanceof EvalError || error instanceof URIError) {
+        throw error;
+      }
       malformedRoutes.push({
         index,
         surface_id: (route && typeof route === "object" && route.surface_id) || null,

--- a/mcp/lib/technique-packs.js
+++ b/mcp/lib/technique-packs.js
@@ -1123,6 +1123,21 @@ function resolveSurfaceTechniqueRoute(domain, surface, requestedCapabilityPack =
     try {
       const routesInfo = readSurfaceRoutesStrict(domain);
       route = routesInfo.document.routes.find((entry) => entry.surface_id === surface.id) || null;
+      // readSurfaceRoutesStrict is now tolerant: a stale/duplicate route for this surface is QUARANTINED
+      // (kept out of document.routes) rather than throwing. If THIS surface's route was quarantined, the
+      // fallback below re-derives a current-schema pack — a sensible result — but surface a diagnostic so
+      // the operator knows the routing artifact is corrupt. Like prepare/finalize-node and unlike
+      // getContextBudget/findRoutedSurface, technique selection must NOT brick on a stale route
+      // (re-derivation is the safe path), so this degrades gracefully rather than rejecting.
+      if (!route && Array.isArray(routesInfo.malformed_routes)) {
+        const quarantined = routesInfo.malformed_routes.find((m) => m && m.surface_id === surface.id);
+        if (quarantined) {
+          process.stderr.write(
+            `WARNING: surface_id ${surface.id} has a quarantined route (${quarantined.reason}); `
+            + `bob_select_technique_packs is re-deriving its capability pack — re-run bob_route_surfaces to regenerate.\n`,
+          );
+        }
+      }
     } catch {}
   }
   if (!route) {

--- a/mcp/lib/technique-packs.js
+++ b/mcp/lib/technique-packs.js
@@ -1124,17 +1124,20 @@ function resolveSurfaceTechniqueRoute(domain, surface, requestedCapabilityPack =
       const routesInfo = readSurfaceRoutesStrict(domain);
       route = routesInfo.document.routes.find((entry) => entry.surface_id === surface.id) || null;
       // readSurfaceRoutesStrict is now tolerant: a stale/duplicate route for this surface is QUARANTINED
-      // (kept out of document.routes) rather than throwing. If THIS surface's route was quarantined, the
-      // fallback below re-derives a current-schema pack — a sensible result — but surface a diagnostic so
-      // the operator knows the routing artifact is corrupt. Like prepare/finalize-node and unlike
-      // getContextBudget/findRoutedSurface, technique selection must NOT brick on a stale route
-      // (re-derivation is the safe path), so this degrades gracefully rather than rejecting.
-      if (!route && Array.isArray(routesInfo.malformed_routes)) {
+      // (kept out of document.routes) rather than throwing. Surface a diagnostic whenever THIS surface
+      // is quarantined — REGARDLESS of whether a valid route was also retained. The check is NOT gated on
+      // `!route`: a valid-first + malformed-duplicate file is corrupt (getContextBudget/findRoutedSurface
+      // reject it unconditionally), so staying silent here just because the valid first occurrence was
+      // found would recreate split authority over one artifact. Unlike those hard gates, technique
+      // selection must NOT brick on a stale route — pack re-derivation (or the retained valid route) is a
+      // safe result — so it degrades gracefully with a diagnostic; the authoritative rejection is downstream.
+      if (Array.isArray(routesInfo.malformed_routes)) {
         const quarantined = routesInfo.malformed_routes.find((m) => m && m.surface_id === surface.id);
         if (quarantined) {
+          const action = route ? "using the valid route but the file is corrupt" : "re-deriving its capability pack";
           process.stderr.write(
             `WARNING: surface_id ${surface.id} has a quarantined route (${quarantined.reason}); `
-            + `bob_select_technique_packs is re-deriving its capability pack — re-run bob_route_surfaces to regenerate.\n`,
+            + `bob_select_technique_packs is ${action} — re-run bob_route_surfaces to regenerate.\n`,
           );
         }
       }

--- a/mcp/lib/tools/finalize-node.js
+++ b/mcp/lib/tools/finalize-node.js
@@ -97,6 +97,20 @@ function safeSurfaceRouteMap(targetDomain) {
   const map = {};
   const doc = result && result.document;
   if (!doc || !Array.isArray(doc.routes)) return map;
+  // readSurfaceRoutesStrict is now tolerant: it QUARANTINES stale/duplicate routes (it used to throw,
+  // which the catch above turned into a silent empty {} — losing ALL routes). The valid routes survive
+  // in doc.routes; the quarantined ones are omitted from this metadata map. Surface a diagnostic so a
+  // fully- or partially-corrupt routing artifact is not silently indistinguishable from "no routes were
+  // set up". This map only enriches one-hop graph context, so we degrade gracefully (no throw) — unlike
+  // getContextBudget/findRoutedSurface, where a wrong/missing route must hard-fail the operation.
+  if (Array.isArray(result.malformed_routes) && result.malformed_routes.length > 0) {
+    const quarantinedIds = result.malformed_routes
+      .map((m) => (m && m.surface_id) || `routes[${m && m.index}]`)
+      .join(", ");
+    process.stderr.write(
+      `WARNING: surface-routes.json has ${result.malformed_routes.length} quarantined route(s) [${quarantinedIds}] omitted from the surface metadata map; re-run bob_route_surfaces to regenerate (${doc.routes.length} valid route(s) retained).\n`,
+    );
+  }
   for (const route of doc.routes) {
     if (!route || typeof route !== "object") continue;
     const surfaceId = typeof route.surface_id === "string" ? route.surface_id : null;

--- a/mcp/lib/tools/prepare-node.js
+++ b/mcp/lib/tools/prepare-node.js
@@ -228,6 +228,20 @@ function safeSurfaceRouteMap(targetDomain) {
   const map = {};
   const doc = result && result.document;
   if (!doc || !Array.isArray(doc.routes)) return map;
+  // readSurfaceRoutesStrict is now tolerant: it QUARANTINES stale/duplicate routes (it used to throw,
+  // which the catch above turned into a silent empty {} — losing ALL routes). The valid routes survive
+  // in doc.routes; the quarantined ones are omitted from this metadata map. Surface a diagnostic so a
+  // fully- or partially-corrupt routing artifact is not silently indistinguishable from "no routes were
+  // set up". This map only enriches one-hop graph context, so we degrade gracefully (no throw) — unlike
+  // getContextBudget/findRoutedSurface, where a wrong/missing route must hard-fail the operation.
+  if (Array.isArray(result.malformed_routes) && result.malformed_routes.length > 0) {
+    const quarantinedIds = result.malformed_routes
+      .map((m) => (m && m.surface_id) || `routes[${m && m.index}]`)
+      .join(", ");
+    process.stderr.write(
+      `WARNING: surface-routes.json has ${result.malformed_routes.length} quarantined route(s) [${quarantinedIds}] omitted from the surface metadata map; re-run bob_route_surfaces to regenerate (${doc.routes.length} valid route(s) retained).\n`,
+    );
+  }
   for (const route of doc.routes) {
     if (!route || typeof route !== "object") continue;
     const surfaceId = typeof route.surface_id === "string" ? route.surface_id : null;

--- a/mcp/lib/tools/read-surface-routes.js
+++ b/mcp/lib/tools/read-surface-routes.js
@@ -10,7 +10,7 @@ function readSurfaceRoutes(args) {
   const domain = assertNonEmptyString(args.target_domain, "target_domain");
   const routed = readSurfaceRoutesStrict(domain);
   const document = routed.document;
-  return JSON.stringify({
+  const payload = {
     target_domain: domain,
     surface_routes_path: routed.path,
     version: document.version,
@@ -18,7 +18,15 @@ function readSurfaceRoutes(args) {
     surface_count: document.routes.length,
     counts: countRoutesByCapabilityPack(document.routes),
     routes: document.routes,
-  });
+  };
+  // Surface quarantined routes + the repair hint so the orchestrator SEES a degraded routes file
+  // (e.g. a stale cross-version schema) and can re-run bob_route_surfaces — otherwise an all-stale
+  // file would read as surface_count:0 with no indication that routes were dropped or how to repair.
+  if (Array.isArray(routed.malformed_routes) && routed.malformed_routes.length > 0) {
+    payload.malformed_routes = routed.malformed_routes;
+    payload.repair_hint = routed.repair_hint;
+  }
+  return JSON.stringify(payload);
 }
 
 module.exports = Object.freeze({

--- a/test/circuit-breaker-auth.test.js
+++ b/test/circuit-breaker-auth.test.js
@@ -71,6 +71,29 @@ test("SAFETY — temporal: an authed success BEFORE the unauth 403s does NOT hea
   assert.equal(s.auth_challenge_403_count, 0);
 });
 
+test("SAFETY — method mismatch: an authed GET 2xx does not heal blocked unauth POSTs on the same path", () => {
+  const post403 = (ts) => rec({ status: 403, auth_profile: null, method: "POST", ts });
+  const s = summary([post403(T0), post403(T0), post403(T0), rec({ status: 200, auth_profile: "attacker", method: "GET", ts: T1 })]);
+  assert.equal(s.tripped_count, 1, "GET success must not heal a POST block");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
+test("SAFETY — egress mismatch: a success on a different egress profile does not heal the block", () => {
+  const def403 = (ts) => rec({ status: 403, auth_profile: null, egress_profile: "default", ts });
+  const s = summary([def403(T0), def403(T0), def403(T0), rec({ status: 200, auth_profile: "attacker", egress_profile: "gr-residential", ts: T1 })]);
+  assert.equal(s.tripped_count, 1, "a success via a different egress must not heal a per-egress block");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
+test("SAFETY — an offensive-confirmer 403 (tool stamped, auth_profile lost) is never healed", () => {
+  // An authenticated offensive probe records auth_profile:null but stamps `tool`; its genuine block
+  // must not be reclassified by a later bob_http_scan authed 2xx on the same key.
+  const idor403 = (ts) => rec({ status: 403, auth_profile: null, tool: "bob_http_idor_confirm", ts });
+  const s = summary([idor403(T0), idor403(T0), idor403(T0), authed200(T1)]);
+  assert.equal(s.tripped_count, 1, "a tool-stamped confirmer 403 must stay a hard block");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
 test("classifier split: hard-block vs unauthenticated-forbidden (back-compat preserved)", () => {
   assert.equal(isHardBlockFailure({ status: 429 }), true);
   assert.equal(isHardBlockFailure({ status: 403, auth_profile: "x" }), true);

--- a/test/circuit-breaker-auth.test.js
+++ b/test/circuit-breaker-auth.test.js
@@ -104,6 +104,26 @@ test("SAFETY — space-join collision: a success whose key only collides under a
   assert.equal(s.auth_challenge_403_count, 0);
 });
 
+test("SAFETY — port mismatch: a success on the default port does not heal a block on a non-default port (same host)", () => {
+  // Different services on the same hostname (a non-default port) block independently. The key is the
+  // URL ORIGIN (scheme://host:port), not bare hostname, so :8443 and :443 do not cross-heal.
+  const block = (ts) => rec({ status: 403, auth_profile: null, url: "https://api.example.test:8443/data", path: "/data", ts });
+  const heal = rec({ status: 200, auth_profile: "attacker", url: "https://api.example.test/data", path: "/data", ts: T1 });
+  const s = summary([block(T0), block(T0), block(T0), heal]);
+  assert.equal(s.tripped_count, 1, "a success on :443 must not heal a block on :8443");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
+test("SAFETY — a newline inside egress_profile cannot corrupt the key delimiter (JSON-encoded)", () => {
+  // The key is JSON-encoded, so an interior newline in a free-form egress_profile name is escaped and
+  // can never collapse two distinct tuples into one key. egress "p\nq" and "p" are distinct identities;
+  // a success on "p" must not heal a block reached through "p\nq".
+  const block = (ts) => rec({ status: 403, auth_profile: null, path: "/x", egress_profile: "p\nq", ts });
+  const heal = rec({ status: 200, auth_profile: "attacker", path: "/x", egress_profile: "p", ts: T1 });
+  const s = summary([block(T0), block(T0), block(T0), heal]);
+  assert.equal(s.tripped_count, 1, "a different egress_profile (even one containing a newline) must not heal");
+});
+
 test("SAFETY — an offensive-confirmer 403 (tool stamped, auth_profile lost) is never healed", () => {
   // An authenticated offensive probe records auth_profile:null but stamps `tool`; its genuine block
   // must not be reclassified by a later bob_http_scan authed 2xx on the same key.

--- a/test/circuit-breaker-auth.test.js
+++ b/test/circuit-breaker-auth.test.js
@@ -85,6 +85,13 @@ test("SAFETY — egress mismatch: a success on a different egress profile does n
   assert.equal(s.auth_challenge_403_count, 0);
 });
 
+test("SAFETY — egress IDENTITY mismatch: same profile name, different identity hash, does not heal", () => {
+  const a403 = (ts) => rec({ status: 403, auth_profile: null, egress_profile: "default", egress_profile_identity_hash: "id-A", ts });
+  const s = summary([a403(T0), a403(T0), a403(T0), rec({ status: 200, auth_profile: "attacker", egress_profile: "default", egress_profile_identity_hash: "id-B", ts: T1 })]);
+  assert.equal(s.tripped_count, 1, "a success via a different egress identity must not heal a per-identity block");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
 test("SAFETY — an offensive-confirmer 403 (tool stamped, auth_profile lost) is never healed", () => {
   // An authenticated offensive probe records auth_profile:null but stamps `tool`; its genuine block
   // must not be reclassified by a later bob_http_scan authed 2xx on the same key.

--- a/test/circuit-breaker-auth.test.js
+++ b/test/circuit-breaker-auth.test.js
@@ -92,6 +92,18 @@ test("SAFETY — egress IDENTITY mismatch: same profile name, different identity
   assert.equal(s.auth_challenge_403_count, 0);
 });
 
+test("SAFETY — space-join collision: a success whose key only collides under a SPACE delimiter does not heal a different block", () => {
+  // Two DISTINCT (host, method, path, egress) tuples that collapse to one string under a space-join —
+  // the realistic trigger is a literal space in a free-form egress_profile name. Block: path "/x",
+  // egress "y z". Heal-attempt: path "/x y", egress "z". Space-join → both "api.example.test GET /x y z ";
+  // newline-join → distinct. The block must stay tripped (this case heals under the old space key).
+  const block = (ts) => rec({ status: 403, auth_profile: null, path: "/x", egress_profile: "y z", ts });
+  const heal = rec({ status: 200, auth_profile: "attacker", path: "/x y", egress_profile: "z", ts: T1 });
+  const s = summary([block(T0), block(T0), block(T0), heal]);
+  assert.equal(s.tripped_count, 1, "a different-tuple success must not heal this block (no space-join collision)");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
 test("SAFETY — an offensive-confirmer 403 (tool stamped, auth_profile lost) is never healed", () => {
   // An authenticated offensive probe records auth_profile:null but stamps `tool`; its genuine block
   // must not be reclassified by a later bob_http_scan authed 2xx on the same key.

--- a/test/circuit-breaker-auth.test.js
+++ b/test/circuit-breaker-auth.test.js
@@ -1,0 +1,84 @@
+"use strict";
+
+// Regression suite for auth-aware circuit-breaker semantics (harden/session-robustness):
+// an unauthenticated 403 (auth challenge) must NOT permanently trip the "host is blocking us"
+// breaker once a later AUTHENTICATED request to the same host+path succeeds — while a GENUINE
+// block (429, timeout, or a 403 returned DESPITE auth) must STILL trip and stay tripped (no
+// evasion, no auto-bypass of a live block).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  buildCircuitBreakerSummary,
+  isHardBlockFailure,
+  isUnauthenticatedForbidden,
+  isCircuitBreakerFailure,
+} = require("../mcp/lib/http-records.js");
+
+const T0 = "2026-06-20T10:00:00.000Z"; // unauthenticated phase (earlier)
+const T1 = "2026-06-20T11:00:00.000Z"; // authenticated phase (later)
+
+function rec(overrides) {
+  return { host: "api.example.test", path: "/data", url: "https://api.example.test/data", ts: T0, ...overrides };
+}
+const unauth403 = (ts = T0) => rec({ status: 403, auth_profile: null, ts });
+const authed200 = (ts = T1) => rec({ status: 200, auth_profile: "attacker", ts });
+const summary = (records) => buildCircuitBreakerSummary(records, { surface: null });
+
+test("HEAL: unauth 403s followed by a later authed success do NOT trip the breaker", () => {
+  const s = summary([unauth403(T0), unauth403(T0), unauth403(T0), authed200(T1)]);
+  assert.equal(s.tripped_count, 0);
+  assert.equal(s.auth_challenge_403_count, 3);
+  assert.equal(s.auth_challenge_hosts[0].host, "api.example.test");
+});
+
+test("SAFETY — real WAF wall: unauth 403s with NO later authed success STILL trip and stay tripped", () => {
+  const s = summary([unauth403(T0), unauth403(T0), unauth403(T0)]);
+  assert.equal(s.tripped_count, 1);
+  assert.equal(s.tripped_hosts[0].host, "api.example.test");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
+test("SAFETY — 403 DESPITE an auth profile is a hard block; a same-endpoint authed 200 never excuses it", () => {
+  const s = summary([
+    rec({ status: 403, auth_profile: "attacker", ts: T1 }),
+    rec({ status: 403, auth_profile: "attacker", ts: T1 }),
+    rec({ status: 403, auth_profile: "attacker", ts: T1 }),
+    authed200(T1),
+  ]);
+  assert.equal(s.tripped_count, 1);
+});
+
+test("SAFETY — 429 rate-limit is never reclassified, even with a later authed success", () => {
+  const s = summary([
+    rec({ status: 429, auth_profile: null, ts: T0 }),
+    rec({ status: 429, auth_profile: null, ts: T0 }),
+    rec({ status: 429, auth_profile: null, ts: T0 }),
+    authed200(T1),
+  ]);
+  assert.equal(s.tripped_count, 1);
+});
+
+test("SAFETY — timeouts are never reclassified, even with a later authed success", () => {
+  const to = (ts) => rec({ status: null, scope_decision: "request_error", error: "request timeout", auth_profile: null, ts });
+  const s = summary([to(T0), to(T0), to(T0), authed200(T1)]);
+  assert.equal(s.tripped_count, 1);
+});
+
+test("SAFETY — temporal: an authed success BEFORE the unauth 403s does NOT heal them", () => {
+  const s = summary([authed200(T0), unauth403(T1), unauth403(T1), unauth403(T1)]);
+  assert.equal(s.tripped_count, 1, "403s that came after the success are a fresh block, not healed");
+  assert.equal(s.auth_challenge_403_count, 0);
+});
+
+test("classifier split: hard-block vs unauthenticated-forbidden (back-compat preserved)", () => {
+  assert.equal(isHardBlockFailure({ status: 429 }), true);
+  assert.equal(isHardBlockFailure({ status: 403, auth_profile: "x" }), true);
+  assert.equal(isHardBlockFailure({ status: 403, auth_profile: null }), false);
+  assert.equal(isUnauthenticatedForbidden({ status: 403, auth_profile: null }), true);
+  assert.equal(isUnauthenticatedForbidden({ status: 403, auth_profile: "x" }), false);
+  // Any prior "failure" is still a failure (the reclassification lives in the summary, not here).
+  assert.equal(isCircuitBreakerFailure({ status: 403, auth_profile: null }), true);
+  assert.equal(isCircuitBreakerFailure({ status: 403, auth_profile: "x" }), true);
+  assert.equal(isCircuitBreakerFailure({ status: 200 }), false);
+});

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -12011,7 +12011,7 @@ test("bob_read_findings, bob_list_findings, and bob_wave_status return empty-sta
         recent: [],
       },
       traffic: { total: 0, shown: 0, omitted: 0, cap: 0, authenticated_count: 0, by_status_class: { "2xx": 0, "3xx": 0, "4xx": 0, "5xx": 0, other: 0 }, recent: [] },
-      circuit_breaker: { threshold: 3, tripped_hosts: [], tripped_count: 0, below_threshold_hosts: [], below_threshold_count: 0, note: null },
+      circuit_breaker: { threshold: 3, tripped_hosts: [], tripped_count: 0, below_threshold_hosts: [], below_threshold_count: 0, auth_challenge_hosts: [], auth_challenge_403_count: 0, note: null },
       surface_leads: { total: 0, high_confidence_unpromoted: 0, promoted: 0 },
       findings_summary: [],
     });
@@ -12089,7 +12089,7 @@ test("bob_list_findings and bob_wave_status keep their external shapes while rea
         recent: [],
       },
       traffic: { total: 0, shown: 0, omitted: 0, cap: 0, authenticated_count: 0, by_status_class: { "2xx": 0, "3xx": 0, "4xx": 0, "5xx": 0, other: 0 }, recent: [] },
-      circuit_breaker: { threshold: 3, tripped_hosts: [], tripped_count: 0, below_threshold_hosts: [], below_threshold_count: 0, note: null },
+      circuit_breaker: { threshold: 3, tripped_hosts: [], tripped_count: 0, below_threshold_hosts: [], below_threshold_count: 0, auth_challenge_hosts: [], auth_challenge_403_count: 0, note: null },
       surface_leads: { total: 0, high_confidence_unpromoted: 0, promoted: 0 },
       findings_summary: [
         {

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -107,6 +107,8 @@
   "test/offensive-oob-collector.test.js",
   "test/offensive-nuclei-producer.test.js",
   "test/offensive-cors-producer.test.js",
+  "test/surface-router.test.js",
+  "test/circuit-breaker-auth.test.js",
   "test/auth-provenance-stamp.test.js",
   "test/offensive-run-freeze-completeness.test.js",
   "test/severity-rise-guard.test.js",

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -350,12 +350,11 @@ test("resolveBaselineFromSurface resolves a query-free baseline that matches the
 test("auditConfirmRequest writes a breaker-visible record under any toolId and never throws", () => withTempHome(() => {
   const domain = "common-audit.example.test";
   JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
-  // The point of the parameterized toolId is per-tool attribution; note that
-  // normalizeHttpAuditRecord does NOT persist a `tool` field, so a future producer
-  // passing a different toolId (or omitting it) yields a BYTE-IDENTICAL persisted
-  // record — circuit-breaker / request-budget visibility comes from the record's
-  // existence + surface_id/status/url, never from `tool`. The toolId's only
-  // observable effect is the stderr diagnostic on an audit-write failure.
+  // normalizeHttpAuditRecord PERSISTS `tool` (the toolId) so the circuit breaker can tell a
+  // faithful-auth bob_http_scan record (no `tool`) from an offensive-confirmer probe (which audits
+  // WITHOUT an auth_profile) — the auth-aware heal-gate only reclassifies the former. Breaker /
+  // request-budget VISIBILITY still comes from the record's existence + surface_id/status/url, not
+  // from `tool`; a missing toolId cannot make a probe invisible.
   auditConfirmRequest({
     domain,
     surfaceId: "surface:accounts",
@@ -373,8 +372,9 @@ test("auditConfirmRequest writes a breaker-visible record under any toolId and n
   // a successful probe records scope_decision "allowed" (a null would make
   // normalizeHttpAuditRecord throw and silently drop the breaker-visibility record)
   assert.equal(records[0].scope_decision, "allowed");
-  // `tool` is normalized out — a missing toolId cannot make a probe invisible
-  assert.equal(Object.prototype.hasOwnProperty.call(records[0], "tool"), false);
+  // `tool` is now persisted (the toolId) — it gates the breaker's faithful-auth heal logic; it
+  // never affects breaker-visibility (record existence + surface_id/status/url do that).
+  assert.equal(records[0].tool, "bob_http_idor_confirm");
   // defensive audit contract: never throws even with no domain / no toolId
   assert.doesNotThrow(() => auditConfirmRequest({ domain: null }));
 }));

--- a/test/surface-router.test.js
+++ b/test/surface-router.test.js
@@ -128,6 +128,20 @@ test("findRoutedSurface rejects a surface whose route was quarantined even if a 
   assert.throws(() => findRoutedSurface(domain, "surface:api"), /malformed route/);
 }));
 
+test("findRoutedSurface rejection cannot be evaded by a whitespace-padded quarantined surface_id (trimmed on store)", () => withTempHome(() => {
+  const domain = "router-wspad.example.test";
+  // A valid route for "surface:api" plus a stale duplicate whose surface_id kept whitespace padding.
+  // validateSurfaceRoute trims on the valid path, so the lookup id is "surface:api"; the quarantined
+  // entry must ALSO be trimmed or its `=== surfaceId` match fails and the corruption-rejection is evaded.
+  const padded = staleHunterRoute("surface:api");
+  padded.surface_id = "  surface:api  ";
+  writeRoutesFile(domain, [validWebRoute("surface:api"), padded]);
+  const read = readSurfaceRoutesStrict(domain);
+  assert.equal(read.malformed_routes.length, 1);
+  assert.equal(read.malformed_routes[0].surface_id, "surface:api", "stored malformed surface_id is trimmed");
+  assert.throws(() => findRoutedSurface(domain, "surface:api"), /malformed route/, "padded quarantined dupe must not evade rejection");
+}));
+
 test("happy path: routeSurfacesInternal writes valid routes that read back cleanly (validate-on-write passes)", () => withTempHome(() => {
   const domain = "router-roundtrip.example.test";
   fs.mkdirSync(path.dirname(surfaceRoutesPath(domain)), { recursive: true });

--- a/test/surface-router.test.js
+++ b/test/surface-router.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// Regression suite for the cross-version surface-routes BRICK (harden/session-robustness):
+// a route written by a prior framework version (the hunter_agent -> evaluator_agent v2.1 rename)
+// must be QUARANTINED on read, not abort the whole read and brick every downstream consumer.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  readSurfaceRoutesStrict,
+  routeSurfacesInternal,
+  validateSurfaceRoute,
+  SURFACE_ROUTES_VERSION,
+  SURFACE_ROUTE_VERSION,
+} = require("../mcp/lib/surface-router.js");
+const { classifySurfaceCapability } = require("../mcp/lib/capability-packs.js");
+const { surfaceRoutesPath } = require("../mcp/lib/paths.js");
+
+function withTempHome(fn) {
+  const prev = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bob-surface-router-"));
+  process.env.HOME = home;
+  try {
+    return fn(home);
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// A fully valid current-schema web route (derived, never hardcoded — survives pack edits).
+function validWebRoute(surfaceId) {
+  const c = classifySurfaceCapability({
+    id: surfaceId, surface_type: "web", hosts: [`${surfaceId}.example.test`], endpoints: [`https://${surfaceId}.example.test/a`],
+  });
+  return {
+    surface_id: surfaceId,
+    surface_type: c.surface_type,
+    capability_pack: c.capability_pack,
+    capability_pack_version: c.capability_pack_version,
+    evaluator_agent: c.evaluator_agent,
+    brief_profile: c.brief_profile,
+    context_budget: c.context_budget,
+  };
+}
+
+// A route exactly as a PRE-rename framework version persisted it: hunter_agent, no evaluator_agent.
+function staleHunterRoute(surfaceId) {
+  const route = validWebRoute(surfaceId);
+  delete route.evaluator_agent;
+  route.hunter_agent = "hunter-agent";
+  return route;
+}
+
+function writeRoutesFile(domain, routes, { version = SURFACE_ROUTES_VERSION, routeVersion = SURFACE_ROUTE_VERSION } = {}) {
+  const p = surfaceRoutesPath(domain);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, `${JSON.stringify({ version, route_version: routeVersion, routes }, null, 2)}\n`);
+  return p;
+}
+
+test("reader QUARANTINES a stale-schema route (hunter_agent) instead of bricking the whole read", () => withTempHome(() => {
+  const domain = "router-stale.example.test";
+  writeRoutesFile(domain, [validWebRoute("s1"), staleHunterRoute("s2")]);
+  const result = readSurfaceRoutesStrict(domain);
+  assert.equal(result.document.routes.length, 1, "the valid route survives");
+  assert.equal(result.document.routes[0].surface_id, "s1");
+  assert.equal(result.malformed_routes.length, 1);
+  assert.equal(result.malformed_routes[0].surface_id, "s2");
+  assert.match(result.malformed_routes[0].reason, /evaluator_agent must be a non-empty string/);
+  assert.match(result.repair_hint, /bob_route_surfaces/);
+}));
+
+test("reader survives an ALL-stale routes file (empty routes + repair hint, no throw = not bricked)", () => withTempHome(() => {
+  const domain = "router-allstale.example.test";
+  writeRoutesFile(domain, [staleHunterRoute("s1"), staleHunterRoute("s2")]);
+  const result = readSurfaceRoutesStrict(domain);
+  assert.equal(result.document.routes.length, 0);
+  assert.equal(result.malformed_routes.length, 2);
+  assert.match(result.repair_hint, /bob_route_surfaces/);
+}));
+
+test("reader quarantines a duplicate surface_id (keeps the first occurrence)", () => withTempHome(() => {
+  const domain = "router-dupe.example.test";
+  writeRoutesFile(domain, [validWebRoute("s1"), validWebRoute("s1")]);
+  const result = readSurfaceRoutesStrict(domain);
+  assert.equal(result.document.routes.length, 1);
+  assert.equal(result.malformed_routes.length, 1);
+  assert.match(result.malformed_routes[0].reason, /duplicate surface_id/);
+}));
+
+test("reader STILL fails hard on unrecoverable top-level shape (version mismatch)", () => withTempHome(() => {
+  const domain = "router-badversion.example.test";
+  writeRoutesFile(domain, [validWebRoute("s1")], { routeVersion: SURFACE_ROUTE_VERSION + 1 });
+  assert.throws(() => readSurfaceRoutesStrict(domain), /expected versioned routes document/);
+}));
+
+test("validateSurfaceRoute rejects an empty evaluator_agent (the validate-on-write guard's mechanism)", () => {
+  assert.throws(() => validateSurfaceRoute(staleHunterRoute("s1"), 0, "routes.json"), /evaluator_agent must be a non-empty string/);
+});
+
+test("happy path: routeSurfacesInternal writes valid routes that read back cleanly (validate-on-write passes)", () => withTempHome(() => {
+  const domain = "router-roundtrip.example.test";
+  fs.mkdirSync(path.dirname(surfaceRoutesPath(domain)), { recursive: true });
+  const attackSurfaceInfo = { source: "test", document: { surfaces: [
+    { id: "s1", surface_type: "web", hosts: ["s1.example.test"], endpoints: ["https://s1.example.test/a"] },
+    { id: "s2", surface_type: "web", hosts: ["s2.example.test"], endpoints: ["https://s2.example.test/b"] },
+  ] } };
+  const written = routeSurfacesInternal(domain, { attackSurfaceInfo });
+  assert.equal(written.document.routes.length, 2);
+  const read = readSurfaceRoutesStrict(domain);
+  assert.equal(read.document.routes.length, 2);
+  assert.equal(read.malformed_routes, undefined, "a clean file carries no malformed_routes");
+}));

--- a/test/surface-router.test.js
+++ b/test/surface-router.test.js
@@ -105,6 +105,20 @@ test("validateSurfaceRoute rejects an empty evaluator_agent (the validate-on-wri
   assert.throws(() => validateSurfaceRoute(staleHunterRoute("s1"), 0, "routes.json"), /evaluator_agent must be a non-empty string/);
 });
 
+test("validateSurfaceRoute signals DATA failures with a PLAIN Error (premise of the quarantine-vs-rethrow guard)", () => {
+  // readSurfaceRoutesStrict quarantines a plain Error (stale/malformed DATA) but RE-THROWS a JS error
+  // subclass (TypeError/RangeError/…), which can only come from a validator CODE bug. That discriminator
+  // is only safe while every data-validation failure is a plain Error — pin it here, so a future refactor
+  // that threw e.g. a TypeError on bad data (which the guard would then wrongly re-throw and re-brick the
+  // read) fails this test loudly instead.
+  try {
+    validateSurfaceRoute(staleHunterRoute("s1"), 0, "routes.json");
+    assert.fail("expected validateSurfaceRoute to throw on a stale route");
+  } catch (error) {
+    assert.equal(error.constructor, Error, "a data-validation failure must be a plain Error (so it is quarantined, not re-thrown)");
+  }
+});
+
 test("findRoutedSurface rejects a surface whose route was quarantined even if a valid duplicate exists (no split authority)", () => withTempHome(() => {
   const domain = "router-splitauth.example.test";
   // surface:api appears twice: a valid route + a stale (hunter_agent) duplicate. The reader keeps

--- a/test/surface-router.test.js
+++ b/test/surface-router.test.js
@@ -18,6 +18,7 @@ const {
   SURFACE_ROUTE_VERSION,
 } = require("../mcp/lib/surface-router.js");
 const { classifySurfaceCapability } = require("../mcp/lib/capability-packs.js");
+const { findRoutedSurface } = require("../mcp/lib/offensive-http-common.js");
 const { surfaceRoutesPath } = require("../mcp/lib/paths.js");
 
 function withTempHome(fn) {
@@ -103,6 +104,15 @@ test("reader STILL fails hard on unrecoverable top-level shape (version mismatch
 test("validateSurfaceRoute rejects an empty evaluator_agent (the validate-on-write guard's mechanism)", () => {
   assert.throws(() => validateSurfaceRoute(staleHunterRoute("s1"), 0, "routes.json"), /evaluator_agent must be a non-empty string/);
 });
+
+test("findRoutedSurface rejects a surface whose route was quarantined even if a valid duplicate exists (no split authority)", () => withTempHome(() => {
+  const domain = "router-splitauth.example.test";
+  // surface:api appears twice: a valid route + a stale (hunter_agent) duplicate. The reader keeps
+  // the valid one and quarantines the stale one. findRoutedSurface must REJECT (mirroring
+  // getContextBudget) — the file is corrupt, so an offensive probe must not proceed on it.
+  writeRoutesFile(domain, [validWebRoute("surface:api"), staleHunterRoute("surface:api")]);
+  assert.throws(() => findRoutedSurface(domain, "surface:api"), /malformed route/);
+}));
 
 test("happy path: routeSurfacesInternal writes valid routes that read back cleanly (validate-on-write passes)", () => withTempHome(() => {
   const domain = "router-roundtrip.example.test";


### PR DESCRIPTION
## What

Two framework-robustness fixes surfaced by a live web engagement whose session spanned a runtime upgrade. Both are degraded-state handling — **no tool, schema, or registry change** (so no drift/pack/install surfaces move).

## #4 — cross-version `surface-routes.json` brick

**Root cause:** the v2.1 `hunter_agent → evaluator_agent` route-field rename never bumped `SURFACE_ROUTE_VERSION`, so a routes file written by a *prior* runtime passes the version gate but fails per-route validation (`assertNonEmptyString(route.evaluator_agent)`). `readSurfaceRoutesStrict` mapped routes with **no per-route try/catch**, so one stale route aborted the whole read and bricked every consumer that funnels through it (routing, context-budget, offensive confirmers, and the downstream verifier/evidence/grader/reporter agents → the "off-FSM" reflex).

**Fix:**
- **Reader resilience** — quarantine a malformed/duplicate route into `result.malformed_routes[]` + emit `repair_hint` ("re-run `bob_route_surfaces`") instead of throwing the whole read. Top-level shape (unparseable / version mismatch / routes-not-array) still fails hard. The file is fully regenerable.
- **Validate-on-write** — `routeSurfacesInternal` validates every generated route *before* persisting, so a future pack/derivation regression fails fast instead of writing a landmine. (Comment: bump `SURFACE_ROUTE_VERSION` on any breaking route-field change.)
- **`getContextBudget` re-surfaces a malformed *target* surface's reason** — read-all consumers stay resilient, but a targeted budget lookup for a malformed surface must surface the error (the agent can't operate under an undefined budget), not silently fall back to the pack default.

## #5 — auth-aware circuit breaker

**Root cause:** the "breaker" is recomputed from the entire `http-audit.jsonl` each read; `isCircuitBreakerFailure` counted **any** 403 regardless of auth, so ~30 unauthenticated-era 403s (auth challenges) stayed tripped forever and later authenticated 200s couldn't heal them.

**Fix (record-level, uses the `auth_profile` already on each record):**
- Split the classifier: `isHardBlockFailure` (429, timeouts/conn-resets, **and a 403 returned despite an auth profile**) always counts, never reclassified; `isUnauthenticatedForbidden` (403 without auth) is a *candidate* auth-challenge.
- `buildCircuitBreakerSummary` reclassifies an unauth 403 as benign **only on positive, temporally-ordered evidence** — a later authenticated 2xx on the **same host+path**. No such success → still counts → a pure WAF wall stays tripped. Healed challenges are surfaced (not hidden) under new `auth_challenge_hosts` / `auth_challenge_403_count` fields.

**Safety (no evasion):** 429 / timeouts / 403-despite-auth are never reclassified; an authed success *before* the unauth 403s does not heal them; a genuine block stays tripped. No traffic sent, no live block bypassed.

## Tests
- New `test/surface-router.test.js` (7) — quarantine stale/all-stale/duplicate, hard-fail on version mismatch, validate-on-write mechanism, happy-path round-trip.
- New `test/circuit-breaker-auth.test.js` (8) — heal + 5 safety/no-evasion cases + classifier split.
- Updated the two `bob_wave_status` external-shape contract assertions in `mcp-server.test.js` for the additive `auth_challenge_*` fields.
- `test:mcp` 2813/0; `test:prompts` 181/0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail fast with clearer errors for targeted context-budget and surface-routing requests when route data is quarantined or malformed.
  * Hardened circuit-breaker healing so only safe unauthenticated `403` challenges can be healed by later authenticated successes; WAF/rate-limit/timeouts and authenticated `403` remain blocked.
* **Improvements**
  * Surface-route persistence and loading now quarantine invalid/duplicate routes, sanitize reasons, and optionally include repair hints; added degraded-route diagnostics.
  * Expanded circuit-breaker reporting with auth-challenge fields and tool attribution.
* **Tests**
  * Added/updated regression suites and expected output shapes for route quarantine and auth-aware circuit-breaker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->