### PR TITLE
feat(evaluate): over-permissive search/list technique pack — close the /api/search depth gap

### DIFF
--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -28,10 +28,10 @@
       "id": "over-permissive-search-list",
       "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
       "match": {
-        "tech": ["api", "rest", "graphql", "json", "elasticsearch", "opensearch", "solr", "algolia", "search"],
-        "endpoints": ["/search", "/api/search", "/query", "/find", "/lookup", "/people", "/directory", "/autocomplete", "/suggest", "/typeahead"],
-        "params": ["query", "search", "term", "keyword", "filter", "$filter", "where", "scope"],
-        "hints": ["search", "list", "directory", "people search", "over-permissive", "mass extraction", "enumeration", "filter", "predicate", "elasticsearch", "autocomplete"]
+        "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
+        "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
+        "params": ["query", "search", "$filter", "facet"],
+        "hints": ["search endpoint", "search index", "people search", "over-permissive search", "mass extraction", "predicate annihilation", "elasticsearch", "autocomplete"]
       },
       "techniques": [
         "SYNTHETIC/own data only - never page through or exfiltrate real third-party records; confirm by COUNT. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
@@ -39,14 +39,13 @@
         "Read-only, count-only. Try HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: swap headers that select the backend index/shard/principal - `Index:`/`X-Index`/`X-Search-Index` pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to reach a broader index or another tenant's data the UI never exposes.",
         "No row exfiltration needed. Use BOOLEAN/BLIND enumeration when the endpoint returns only a filtered COUNT or yes/no: vary the predicate (true vs false, `a*` vs `zz*`) and confirm the count tracks attacker input - that proves the filter is attacker-reachable.",
         "An over-permissive endpoint is NOT automatically LOW - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE grading, then grade by the PROVEN cross-scope outcome. A masked record-count showing other tenants'/users' records under an annihilated filter is an access-control break whose severity follows the data class and volume.",
-        "SAFE confirmation only: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the exact request/response. NEVER dump real records or real PII to prove the point."
+        "SAFE confirmation only: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the REDACTED request + a REDACTED response excerpt (status + the count field only). NEVER paste raw response bodies, real rows, cookies, auth headers, or real PII into evidence."
       ],
       "payload_hints": [
-        "Predicate annihilation: ?q=*  ?q=true  ?filter=true  ?$filter=1 eq 1  ?$filter=true  ?where=1=1  ?search=*:*  ?q=1 OR 1=1",
-        "NoSQL operator injection: ?filter[$ne]=  ?q[$gt]=  ?where[$exists]=true  ?id[$ne]=null  (JSON body: {\"filter\":{\"$ne\":null}})",
-        "Scope-param drop/swap: remove &tenant_id= / &org_id= / &scope=, or set scope=* / scope=all / tenant_id=<other-synthetic-tenant>, then diff the result count",
-        "Index/principal header routing: Index: people-search  |  X-Search-Index: internal  |  X-Tenant-Id: <other>  |  X-Org-Id: <other>  |  X-Roles: admin",
-        "Size the corpus by COUNT only - never fetch the rows and never send a huge limit: request limit=1 (or limit=0 / per_page=1) and read the total from X-Total-Count / meta.total / the count field"
+        "COUNT-only, synthetic/own data, never fetch rows: predicate annihilation ?q=* / ?q=true / ?$filter=1 eq 1 / ?$filter=true / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
+        "Read the total safely via limit=1 or per_page=1 + X-Total-Count / meta.total - NEVER limit=0 (some backends treat it as no-limit) and never a large limit; the scoped-vs-unscoped COUNT differential is the proof, not the rows",
+        "Scope-param drop/swap (compare COUNTS only, never the rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>",
+        "Index/principal header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> | X-Roles: admin"
       ]
     },
     {

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -43,7 +43,7 @@
         "COUNT-only, synthetic/own data, never fetch rows. Predicate annihilation: ?q=* / ?q=true / ?$filter=1 eq 1 / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
         "Read totals from response METADATA only (X-Total-Count / meta.total / a count or HEAD request); do NOT page rows from the unscoped/annihilated query — even limit=1 returns one real row. Compare scoped vs unscoped totals.",
         "Scope-param drop/swap (compare COUNTS only, never rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>.",
-        "Index/principal header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> | X-Roles: admin"
+        "Index/tenant header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other>"
       ]
     },
     {

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -29,24 +29,24 @@
       "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
       "match": {
         "tech": ["api", "rest", "graphql", "json", "elasticsearch", "opensearch", "solr", "algolia", "search"],
-        "endpoints": ["/search", "/api/search", "/query", "/list", "/find", "/lookup", "/people", "/directory", "/members", "/export", "/report", "/autocomplete", "/suggest", "/typeahead", "/filter"],
+        "endpoints": ["/search", "/api/search", "/query", "/find", "/lookup", "/people", "/directory", "/autocomplete", "/suggest", "/typeahead"],
         "params": ["query", "search", "term", "keyword", "filter", "$filter", "where", "scope"],
         "hints": ["search", "list", "directory", "people search", "over-permissive", "mass extraction", "enumeration", "filter", "predicate", "elasticsearch", "autocomplete"]
       },
       "techniques": [
-        "When a search/list endpoint returns SCOPED results, attempt PREDICATE ANNIHILATION to collapse the server-side scope filter: inject an always-true predicate - `true`, `1 eq 1`, `OR 1=1`, an OData `$filter=1 eq 1` (or `$filter=true`), a Lucene/Elasticsearch `*:*` or `q=*`, or a NoSQL operator injection (`filter[$ne]=`, `q[$gt]=`, `where[$exists]=true`). Confirm with a RECORD-COUNT differential: scoped N vs annihilated M, M >> N proves the filter is attacker-controllable. SYNTHETIC/own data only - never page through real third-party records.",
-        "Attempt SCOPE-PARAM DROP / SWAP: remove or null the tenant/org/scope/account parameter, set it empty or to `*`/`all`, or substitute a SECOND synthetic tenant's id, then compare result sets. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authorization, not merely 'over-permissive'.",
-        "Attempt HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: add or swap headers that select the backend index, shard, or principal - e.g. an `Index:`/`X-Index`/`X-Search-Index` header pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to pivot to a broader index or another tenant's data the UI never exposes.",
-        "Use BOOLEAN/BLIND enumeration when the endpoint returns a filtered COUNT or yes/no but not rows: vary the predicate (true vs false, `a*` vs `zz*`) and confirm the count tracks attacker input before reporting - that proves the filter is reachable even without row exfiltration.",
-        "An 'over-permissive endpoint' is NOT automatically LOW: grade by the PROVEN cross-scope outcome. A masked record-count differential showing the endpoint returns other tenants'/users' records (or the full corpus) under an annihilated filter is an access-control break whose severity follows the data class and volume - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE settling on LOW.",
-        "Confirm impact the SAFE way: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the exact request/response. Do NOT dump real records or real PII to prove the point."
+        "SYNTHETIC/own data only - never page through or exfiltrate real third-party records; confirm by COUNT. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
+        "Count-only, synthetic tenants only. Try SCOPE-PARAM DROP/SWAP: remove or null the tenant/org/scope param, set it empty or `*`/`all`, or substitute a SECOND SYNTHETIC tenant id, then diff the result COUNTS. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authz, not merely 'over-permissive'.",
+        "Read-only, count-only. Try HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: swap headers that select the backend index/shard/principal - `Index:`/`X-Index`/`X-Search-Index` pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to reach a broader index or another tenant's data the UI never exposes.",
+        "No row exfiltration needed. Use BOOLEAN/BLIND enumeration when the endpoint returns only a filtered COUNT or yes/no: vary the predicate (true vs false, `a*` vs `zz*`) and confirm the count tracks attacker input - that proves the filter is attacker-reachable.",
+        "An over-permissive endpoint is NOT automatically LOW - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE grading, then grade by the PROVEN cross-scope outcome. A masked record-count showing other tenants'/users' records under an annihilated filter is an access-control break whose severity follows the data class and volume.",
+        "SAFE confirmation only: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the exact request/response. NEVER dump real records or real PII to prove the point."
       ],
       "payload_hints": [
         "Predicate annihilation: ?q=*  ?q=true  ?filter=true  ?$filter=1 eq 1  ?$filter=true  ?where=1=1  ?search=*:*  ?q=1 OR 1=1",
         "NoSQL operator injection: ?filter[$ne]=  ?q[$gt]=  ?where[$exists]=true  ?id[$ne]=null  (JSON body: {\"filter\":{\"$ne\":null}})",
         "Scope-param drop/swap: remove &tenant_id= / &org_id= / &scope=, or set scope=* / scope=all / tenant_id=<other-synthetic-tenant>, then diff the result count",
         "Index/principal header routing: Index: people-search  |  X-Search-Index: internal  |  X-Tenant-Id: <other>  |  X-Org-Id: <other>  |  X-Roles: admin",
-        "Size the corpus by COUNT only (do not exfiltrate rows): compare limit=1 vs limit=100000 and read the total / X-Total-Count / meta.total field, not the rows"
+        "Size the corpus by COUNT only - never fetch the rows and never send a huge limit: request limit=1 (or limit=0 / per_page=1) and read the total from X-Total-Count / meta.total / the count field"
       ]
     },
     {

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -25,6 +25,31 @@
       ]
     },
     {
+      "id": "over-permissive-search-list",
+      "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
+      "match": {
+        "tech": ["api", "rest", "graphql", "json", "elasticsearch", "opensearch", "solr", "algolia", "search"],
+        "endpoints": ["/search", "/api/search", "/query", "/list", "/find", "/lookup", "/people", "/directory", "/members", "/export", "/report", "/autocomplete", "/suggest", "/typeahead", "/filter"],
+        "params": ["query", "search", "term", "keyword", "filter", "$filter", "where", "scope"],
+        "hints": ["search", "list", "directory", "people search", "over-permissive", "mass extraction", "enumeration", "filter", "predicate", "elasticsearch", "autocomplete"]
+      },
+      "techniques": [
+        "When a search/list endpoint returns SCOPED results, attempt PREDICATE ANNIHILATION to collapse the server-side scope filter: inject an always-true predicate - `true`, `1 eq 1`, `OR 1=1`, an OData `$filter=1 eq 1` (or `$filter=true`), a Lucene/Elasticsearch `*:*` or `q=*`, or a NoSQL operator injection (`filter[$ne]=`, `q[$gt]=`, `where[$exists]=true`). Confirm with a RECORD-COUNT differential: scoped N vs annihilated M, M >> N proves the filter is attacker-controllable. SYNTHETIC/own data only - never page through real third-party records.",
+        "Attempt SCOPE-PARAM DROP / SWAP: remove or null the tenant/org/scope/account parameter, set it empty or to `*`/`all`, or substitute a SECOND synthetic tenant's id, then compare result sets. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authorization, not merely 'over-permissive'.",
+        "Attempt HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: add or swap headers that select the backend index, shard, or principal - e.g. an `Index:`/`X-Index`/`X-Search-Index` header pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to pivot to a broader index or another tenant's data the UI never exposes.",
+        "Use BOOLEAN/BLIND enumeration when the endpoint returns a filtered COUNT or yes/no but not rows: vary the predicate (true vs false, `a*` vs `zz*`) and confirm the count tracks attacker input before reporting - that proves the filter is reachable even without row exfiltration.",
+        "An 'over-permissive endpoint' is NOT automatically LOW: grade by the PROVEN cross-scope outcome. A masked record-count differential showing the endpoint returns other tenants'/users' records (or the full corpus) under an annihilated filter is an access-control break whose severity follows the data class and volume - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE settling on LOW.",
+        "Confirm impact the SAFE way: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the exact request/response. Do NOT dump real records or real PII to prove the point."
+      ],
+      "payload_hints": [
+        "Predicate annihilation: ?q=*  ?q=true  ?filter=true  ?$filter=1 eq 1  ?$filter=true  ?where=1=1  ?search=*:*  ?q=1 OR 1=1",
+        "NoSQL operator injection: ?filter[$ne]=  ?q[$gt]=  ?where[$exists]=true  ?id[$ne]=null  (JSON body: {\"filter\":{\"$ne\":null}})",
+        "Scope-param drop/swap: remove &tenant_id= / &org_id= / &scope=, or set scope=* / scope=all / tenant_id=<other-synthetic-tenant>, then diff the result count",
+        "Index/principal header routing: Index: people-search  |  X-Search-Index: internal  |  X-Tenant-Id: <other>  |  X-Org-Id: <other>  |  X-Roles: admin",
+        "Size the corpus by COUNT only (do not exfiltrate rows): compare limit=1 vs limit=100000 and read the total / X-Total-Count / meta.total field, not the rows"
+      ]
+    },
+    {
       "id": "graphql",
       "title": "GraphQL field-level authorization",
       "match": {

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -30,18 +30,18 @@
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
         "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
-        "params": ["search", "$filter", "facet"],
-        "hints": ["search endpoint", "search index", "people search", "over-permissive search", "mass extraction", "predicate annihilation"]
+        "params": ["search", "facet"],
+        "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
       },
       "techniques": [
         "SYNTHETIC/own data only - never page or exfiltrate real third-party records; confirm by COUNT, and vary the predicate (true vs false) to show the count tracks your input. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
         "Count-only, synthetic tenants only. Try SCOPE-PARAM DROP/SWAP: remove or null the tenant/org/scope param, set it empty or `*`/`all`, or substitute a SECOND SYNTHETIC tenant id, then diff the result COUNTS. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authz, not merely 'over-permissive'.",
         "Read-only, count-only. Try HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: swap headers that select the backend index/shard/principal - `Index:`/`X-Index`/`X-Search-Index` pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to reach a broader index or another tenant's data the UI never exposes.",
-        "GRADE + CONFIRM SAFELY: an over-permissive endpoint is NOT automatically LOW - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE grading, then grade by the PROVEN cross-scope outcome (a masked cross-scope record-count is an access-control break; severity follows data class + volume). Report ONLY a MASKED count (scoped=12 vs unscoped=9155), ONE synthetic/redacted sample, and a REDACTED request/response excerpt (status + count field) - NEVER raw rows, real PII, cookies, or auth headers."
+        "CONFIRM WITH REDACTED EVIDENCE ONLY - a MASKED count (scoped vs unscoped), ONE synthetic/redacted sample, a REDACTED request/response excerpt; NEVER paste raw rows, real PII, cookies, or auth headers. An over-permissive endpoint is NOT auto-LOW: try the pivots first, then grade by the proven cross-scope count (access-control break; severity follows data class + volume)."
       ],
       "payload_hints": [
         "COUNT-only, synthetic/own data, never fetch rows: predicate annihilation ?q=* / ?q=true / ?$filter=1 eq 1 / ?$filter=true / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
-        "Read the total from response METADATA only (X-Total-Count header / meta.total / a count or aggregation endpoint) - prefer a HEAD request; do NOT page rows from the unscoped/annihilated query (even limit=1 returns one real row, and limit=0 may mean no-limit). Compare the scoped vs unscoped TOTALS",
+        "Read totals from response METADATA only (X-Total-Count / meta.total / a count endpoint, ideally a HEAD request) and do NOT page rows from the unscoped/annihilated query - even limit=1 returns one real row. Compare scoped vs unscoped totals",
         "Scope-param drop/swap (compare COUNTS only, never the rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>",
         "Index/principal header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> | X-Roles: admin"
       ]

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -30,20 +30,18 @@
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
         "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
-        "params": ["query", "search", "$filter", "facet"],
-        "hints": ["search endpoint", "search index", "people search", "over-permissive search", "mass extraction", "predicate annihilation", "elasticsearch", "autocomplete"]
+        "params": ["search", "$filter", "facet"],
+        "hints": ["search endpoint", "search index", "people search", "over-permissive search", "mass extraction", "predicate annihilation"]
       },
       "techniques": [
-        "SYNTHETIC/own data only - never page through or exfiltrate real third-party records; confirm by COUNT. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
+        "SYNTHETIC/own data only - never page or exfiltrate real third-party records; confirm by COUNT, and vary the predicate (true vs false) to show the count tracks your input. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
         "Count-only, synthetic tenants only. Try SCOPE-PARAM DROP/SWAP: remove or null the tenant/org/scope param, set it empty or `*`/`all`, or substitute a SECOND SYNTHETIC tenant id, then diff the result COUNTS. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authz, not merely 'over-permissive'.",
         "Read-only, count-only. Try HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: swap headers that select the backend index/shard/principal - `Index:`/`X-Index`/`X-Search-Index` pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to reach a broader index or another tenant's data the UI never exposes.",
-        "No row exfiltration needed. Use BOOLEAN/BLIND enumeration when the endpoint returns only a filtered COUNT or yes/no: vary the predicate (true vs false, `a*` vs `zz*`) and confirm the count tracks attacker input - that proves the filter is attacker-reachable.",
-        "An over-permissive endpoint is NOT automatically LOW - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE grading, then grade by the PROVEN cross-scope outcome. A masked record-count showing other tenants'/users' records under an annihilated filter is an access-control break whose severity follows the data class and volume.",
-        "SAFE confirmation only: report a MASKED record count (e.g. scoped=12 vs unscoped=9155), ONE synthetic/redacted sample row, and the REDACTED request + a REDACTED response excerpt (status + the count field only). NEVER paste raw response bodies, real rows, cookies, auth headers, or real PII into evidence."
+        "GRADE + CONFIRM SAFELY: an over-permissive endpoint is NOT automatically LOW - try the predicate-annihilation, scope-drop and header-routing pivots BEFORE grading, then grade by the PROVEN cross-scope outcome (a masked cross-scope record-count is an access-control break; severity follows data class + volume). Report ONLY a MASKED count (scoped=12 vs unscoped=9155), ONE synthetic/redacted sample, and a REDACTED request/response excerpt (status + count field) - NEVER raw rows, real PII, cookies, or auth headers."
       ],
       "payload_hints": [
         "COUNT-only, synthetic/own data, never fetch rows: predicate annihilation ?q=* / ?q=true / ?$filter=1 eq 1 / ?$filter=true / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
-        "Read the total safely via limit=1 or per_page=1 + X-Total-Count / meta.total - NEVER limit=0 (some backends treat it as no-limit) and never a large limit; the scoped-vs-unscoped COUNT differential is the proof, not the rows",
+        "Read the total from response METADATA only (X-Total-Count header / meta.total / a count or aggregation endpoint) - prefer a HEAD request; do NOT page rows from the unscoped/annihilated query (even limit=1 returns one real row, and limit=0 may mean no-limit). Compare the scoped vs unscoped TOTALS",
         "Scope-param drop/swap (compare COUNTS only, never the rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>",
         "Index/principal header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> | X-Roles: admin"
       ]

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -29,20 +29,20 @@
       "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
-        "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
-        "params": ["search", "facet"],
+        "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr", "/people", "/members", "/directory"],
+        "params": ["search", "facet", "filter", "where", "scope"],
         "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
       },
       "techniques": [
-        "SYNTHETIC/own data only - never page or exfiltrate real third-party records; confirm by COUNT, and vary the predicate (true vs false) to show the count tracks your input. Try PREDICATE ANNIHILATION on a scoped search/list endpoint: an always-true predicate (`true`, `1 eq 1`, OData `$filter=1 eq 1`, Lucene `*:*`/`q=*`, NoSQL `filter[$ne]=`/`q[$gt]=`/`where[$exists]=true`) collapses the server-side scope filter. Prove it with a RECORD-COUNT differential (scoped N vs annihilated M, M >> N) - the count, not the rows.",
-        "Count-only, synthetic tenants only. Try SCOPE-PARAM DROP/SWAP: remove or null the tenant/org/scope param, set it empty or `*`/`all`, or substitute a SECOND SYNTHETIC tenant id, then diff the result COUNTS. A server that filters only by a client-supplied scope (not the session principal) is broken object/function-level authz, not merely 'over-permissive'.",
-        "Read-only, count-only. Try HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: swap headers that select the backend index/shard/principal - `Index:`/`X-Index`/`X-Search-Index` pointing at another index (people-search, admin, internal), `X-Tenant-Id`/`X-Org-Id`, or role/group headers - to reach a broader index or another tenant's data the UI never exposes.",
-        "CONFIRM WITH REDACTED EVIDENCE ONLY - a MASKED count (scoped vs unscoped), ONE synthetic/redacted sample, a REDACTED request/response excerpt; NEVER paste raw rows, real PII, cookies, or auth headers. An over-permissive endpoint is NOT auto-LOW: try the pivots first, then grade by the proven cross-scope count (access-control break; severity follows data class + volume)."
+        "NOT auto-LOW: grade by the proven cross-scope count (access-control break; severity follows data class + volume). Confirm with a COUNT-ONLY masked total or ONE redacted sample; NEVER page raw rows, real PII, cookies, or auth headers.",
+        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Read the COUNT-ONLY total; a jump to the global corpus is over-broad — don't page rows.",
+        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the COUNT-ONLY total now spans other tenants the scope was client-enforced — an access-control break. Redacted evidence only.",
+        "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index. Confirm by COUNT-ONLY masked totals; never extract rows."
       ],
       "payload_hints": [
-        "COUNT-only, synthetic/own data, never fetch rows: predicate annihilation ?q=* / ?q=true / ?$filter=1 eq 1 / ?$filter=true / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
-        "Read totals from response METADATA only (X-Total-Count / meta.total / a count endpoint, ideally a HEAD request) and do NOT page rows from the unscoped/annihilated query - even limit=1 returns one real row. Compare scoped vs unscoped totals",
-        "Scope-param drop/swap (compare COUNTS only, never the rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>",
+        "COUNT-only, synthetic/own data, never fetch rows. Predicate annihilation: ?q=* / ?q=true / ?$filter=1 eq 1 / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
+        "Read totals from response METADATA only (X-Total-Count / meta.total / a count or HEAD request); do NOT page rows from the unscoped/annihilated query — even limit=1 returns one real row. Compare scoped vs unscoped totals.",
+        "Scope-param drop/swap (compare COUNTS only, never rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>.",
         "Index/principal header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> | X-Roles: admin"
       ]
     },

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -29,14 +29,14 @@
       "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
-        "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr", "/people", "/members", "/directory"],
-        "params": ["search", "facet", "filter", "where", "scope"],
+        "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
+        "params": ["search", "facet", "filter"],
         "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
       },
       "techniques": [
-        "NOT auto-LOW: grade by the proven cross-scope count (access-control break; severity follows data class + volume). Confirm with a COUNT-ONLY masked total or ONE redacted sample; NEVER page raw rows, real PII, cookies, or auth headers.",
+        "NOT auto-LOW: grade by the proven cross-scope count (access-control break; severity follows data class + volume). Confirm by COUNT/metadata totals ONLY — never page or sample real rows, PII, cookies, or auth headers.",
         "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Read the COUNT-ONLY total; a jump to the global corpus is over-broad — don't page rows.",
-        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the COUNT-ONLY total now spans other tenants the scope was client-enforced — an access-control break. Redacted evidence only.",
+        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the COUNT-ONLY total now spans other tenants the scope was client-enforced — an access-control break. Compare COUNTS only.",
         "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index. Confirm by COUNT-ONLY masked totals; never extract rows."
       ],
       "payload_hints": [

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -30,11 +30,11 @@
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
         "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
-        "params": ["search"],
-        "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
+        "params": [],
+        "hints": ["people search", "over-permissive search", "full-text search"]
       },
       "techniques": [
-        "NOT auto-LOW: prove impact by pulling a SMALL sample (5–10 records) of the exposed cross-scope data, then grade by what leaked (data class + volume). Sample only — never page the full corpus (that is exfiltration, not proof).",
+        "NOT auto-LOW: prove impact by sampling the exposed cross-scope data (5–10 records max, never the full corpus), then grade by what leaked. Mask the sample by default; show real values only in an authorized engagement.",
         "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. A jump from the scoped count to the global corpus proves the bypass; then pull the sample.",
         "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the count now spans other tenants the scope was client-enforced — an access-control break worth a 5–10 record sample.",
         "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index, then sample 5–10 records from it as proof."

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -35,7 +35,7 @@
       },
       "techniques": [
         "NOT auto-LOW: prove impact by sampling the exposed cross-scope data (5–10 records max, never the full corpus), then grade by what leaked. Mask the sample by default; show real values only in an authorized engagement.",
-        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. A jump from the scoped count to the global corpus proves the bypass; then pull the sample.",
+        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Scoped→global count jump proves the bypass; sample 5–10 records.",
         "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the count now spans other tenants the scope was client-enforced — an access-control break worth a 5–10 record sample.",
         "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index, then sample 5–10 records from it as proof."
       ],

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -30,7 +30,7 @@
       "match": {
         "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
         "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
-        "params": ["search", "facet", "filter"],
+        "params": ["search"],
         "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
       },
       "techniques": [
@@ -40,7 +40,7 @@
         "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index, then sample 5–10 records from it as proof."
       ],
       "payload_hints": [
-        "Proof = a 5–10 record sample of the leaked data, never the full corpus. Authorized engagement (client/asset-owner, or BOB_DATA_ACCESS_AUTHORIZED set) → real records; public safe-harbor cap → mask the sample + add response schema + count.",
+        "Proof = a 5–10 record sample of the leaked data, never the full corpus. Authorized engagement (client/asset-owner, or a program whose policy permits retrieval) → real records; default/safe-harbor → mask the sample + schema + count.",
         "Predicate annihilation: ?q=* / ?q=true / ?$filter=1 eq 1 / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true. Read the count, then pull 5–10 sample records (not the whole set).",
         "Scope-param drop/swap: remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-tenant>; compare counts, then sample 5–10 records as proof.",
         "Index/tenant header routing (GET): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> — confirm by count, then sample 5–10."

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -34,16 +34,16 @@
         "hints": ["search endpoint", "search index", "people search", "over-permissive search"]
       },
       "techniques": [
-        "NOT auto-LOW: grade by the proven cross-scope count (access-control break; severity follows data class + volume). Confirm by COUNT/metadata totals ONLY — never page or sample real rows, PII, cookies, or auth headers.",
-        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Read the COUNT-ONLY total; a jump to the global corpus is over-broad — don't page rows.",
-        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the COUNT-ONLY total now spans other tenants the scope was client-enforced — an access-control break. Compare COUNTS only.",
-        "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index. Confirm by COUNT-ONLY masked totals; never extract rows."
+        "NOT auto-LOW: prove impact by pulling a SMALL sample (5–10 records) of the exposed cross-scope data, then grade by what leaked (data class + volume). Sample only — never page the full corpus (that is exfiltration, not proof).",
+        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. A jump from the scoped count to the global corpus proves the bypass; then pull the sample.",
+        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the count now spans other tenants the scope was client-enforced — an access-control break worth a 5–10 record sample.",
+        "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index, then sample 5–10 records from it as proof."
       ],
       "payload_hints": [
-        "COUNT-only, synthetic/own data, never fetch rows. Predicate annihilation: ?q=* / ?q=true / ?$filter=1 eq 1 / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true",
-        "Read totals from response METADATA only (X-Total-Count / meta.total / a count or HEAD request); do NOT page rows from the unscoped/annihilated query — even limit=1 returns one real row. Compare scoped vs unscoped totals.",
-        "Scope-param drop/swap (compare COUNTS only, never rows): remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-synthetic-tenant>.",
-        "Index/tenant header routing (read-only GET, compare COUNTS not rows): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other>"
+        "Proof = a 5–10 record sample of the leaked data, never the full corpus. Authorized engagement (client/asset-owner, or BOB_DATA_ACCESS_AUTHORIZED set) → real records; public safe-harbor cap → mask the sample + add response schema + count.",
+        "Predicate annihilation: ?q=* / ?q=true / ?$filter=1 eq 1 / ?search=*:* / ?where=1=1 ; NoSQL ?filter[$ne]= / ?q[$gt]= / ?where[$exists]=true. Read the count, then pull 5–10 sample records (not the whole set).",
+        "Scope-param drop/swap: remove &tenant_id= / &org_id= / &scope=, or set scope=all / tenant_id=<other-tenant>; compare counts, then sample 5–10 records as proof.",
+        "Index/tenant header routing (GET): Index: people-search | X-Search-Index: internal | X-Tenant-Id: <other> | X-Org-Id: <other> — confirm by count, then sample 5–10."
       ]
     },
     {

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -35,9 +35,9 @@
       },
       "techniques": [
         "NOT auto-LOW: prove impact by sampling the exposed cross-scope data (5–10 records max, never the full corpus), then grade by what leaked. Mask the sample by default; show real values only in an authorized engagement.",
-        "Predicate annihilation: set the search/filter value to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Scoped→global count jump proves the bypass; sample 5–10 records.",
-        "Scope-param drop: remove or null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the count now spans other tenants the scope was client-enforced — an access-control break worth a 5–10 record sample.",
-        "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index, people-search) to reach another tenant's index, then sample 5–10 records from it as proof."
+        "Predicate annihilation: set the search/filter to an always-true predicate (`*`, `*:*`, empty, `true`, `1 eq 1`, `id>0`) to drop implicit scope. Count jump scoped→global proves the bypass; sample 5–10 (mask unless authorized).",
+        "Scope-param drop: remove/null the tenant/org/scope filter the UI sends (org_id, account, team) and resend. If the count now spans other tenants the scope was client-enforced; sample 5–10 (mask unless authorized).",
+        "Tenant/index header routing: vary tenant/index headers or path segments (X-Tenant-Id, X-Org-Id, Index:, X-Search-Index) to reach another tenant's index, then sample 5–10 from it (mask unless authorized)."
       ],
       "payload_hints": [
         "Proof = a 5–10 record sample of the leaked data, never the full corpus. Authorized engagement (client/asset-owner, or a program whose policy permits retrieval) → real records; default/safe-harbor → mask the sample + schema + count.",

--- a/.hacker-bob/knowledge/evaluator-techniques.json
+++ b/.hacker-bob/knowledge/evaluator-techniques.json
@@ -28,7 +28,7 @@
       "id": "over-permissive-search-list",
       "title": "Over-permissive search/list endpoints: filter-bypass mass extraction",
       "match": {
-        "tech": ["elasticsearch", "opensearch", "solr", "algolia", "search api", "full-text search"],
+        "tech": ["elasticsearch", "opensearch", "solr", "algolia", "full-text search"],
         "endpoints": ["/search", "/api/search", "/_search", "/autocomplete", "/suggest", "/typeahead", "/elasticsearch", "/solr"],
         "params": [],
         "hints": ["people search", "over-permissive search", "full-text search"]

--- a/mcp/lib/technique-packs.js
+++ b/mcp/lib/technique-packs.js
@@ -535,6 +535,15 @@ function scoreTechniqueEntry(entry, surface) {
     "tech_stack",
     "surface_type",
   ]);
+  // match.endpoints patterns are matched (substring `includes`, see countMatches) against this MERGED
+  // text, which deliberately spans freeform fields (hosts, high_value_flows, evidence) on top of the
+  // structured endpoint lists. Because the patterns are slash-prefixed path fragments (e.g. "/_search",
+  // "/elasticsearch", "/solr"), a hit inside `evidence` means recon wrote a LITERAL discovered path —
+  // intended recall (a mentioned search backend is a real target), not prose noise. Consequence for
+  // high-stakes packs (e.g. over-permissive-search-list, which guides cross-tenant record sampling):
+  // evidence that names a search path is sufficient to SELECT the pack as a candidate, so selection must
+  // never be read as proof a search surface exists — the evaluator confirms a live search/list endpoint
+  // before sampling, and selection alone extracts nothing.
   const endpointText = surfaceFieldText(surface, [
     "endpoints",
     "discovered_endpoints",

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17834,9 +17834,9 @@ test("bob_read_assignment_brief does NOT surface over-permissive-search-list for
 });
 
 test("over-permissive-search-list guidance fits the 240-char summary cap with the grading thesis front-loaded", () => {
-  // technique-packs.js caps each summary item at TECHNIQUE_SUMMARY_ITEM_MAX_CHARS = 240; keep every
-  // technique/payload_hint within it so summary-mode briefs never truncate the safety or grading guidance.
-  const SUMMARY_ITEM_MAX_CHARS = 240;
+  // Track the production cap (imported above) rather than a local literal, so this guard stays correct
+  // if the cap changes: keep every technique/payload_hint within it so summary-mode briefs never
+  // truncate the safety or grading guidance.
   const knowledge = JSON.parse(fs.readFileSync(
     path.join(__dirname, "..", ".hacker-bob", "knowledge", "evaluator-techniques.json"),
     "utf8",
@@ -17844,11 +17844,11 @@ test("over-permissive-search-list guidance fits the 240-char summary cap with th
   const entry = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
   assert.ok(entry, "over-permissive-search-list entry must exist");
   for (const technique of entry.techniques) {
-    assert.ok(technique.length <= SUMMARY_ITEM_MAX_CHARS,
+    assert.ok(technique.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
       `technique exceeds summary cap (${technique.length}): ${technique.slice(0, 60)}`);
   }
   for (const hint of entry.payload_hints) {
-    assert.ok(hint.length <= SUMMARY_ITEM_MAX_CHARS,
+    assert.ok(hint.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
       `payload_hint exceeds summary cap (${hint.length}): ${hint.slice(0, 60)}`);
   }
   // The grading thesis ("NOT auto-LOW") and the PII guard must ride the first surfaced item so they

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17861,7 +17861,10 @@ test("every technique entry's summary items fit the 240-char cap (registry-wide:
   const ops = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
   assert.ok(ops, "over-permissive-search-list entry must exist");
   assert.match(ops.techniques[0], /NOT auto-LOW/);
-  assert.match(ops.techniques[0], /never page the full corpus/i);
+  assert.match(ops.techniques[0], /never the full corpus/i);
+  // The first surfaced item must be default-safe: mask unless the engagement authorizes real values.
+  assert.match(ops.techniques[0], /mask the sample by default/i);
+  assert.match(ops.techniques[0], /authorized engagement/i);
 });
 
 test("over-permissive-search-list proof guidance caps extraction at a small sample and gates unmasked data on authorization", () => {
@@ -17918,6 +17921,48 @@ test("bob_read_assignment_brief does NOT surface over-permissive-search-list for
 
     // "scope" is the canonical OAuth/OIDC param; it must not pull search-filter-bypass guidance onto
     // an auth flow, so it is not a match param for this technique.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a lone search param with no search signal", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-orders-search",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/orders"],
+      interesting_params: ["search"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-orders-search" }]);
+
+    // A lone search/list param must not by itself pull (now real-data-pulling) mass-extraction guidance
+    // and suppress the generic fallback; a real search SIGNAL (tech / a /search-family endpoint / hint)
+    // is required. The entry carries no match params.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a research endpoint (no substring match on 'search')", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-research",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/api/data"],
+      interesting_params: ["q"],
+      evidence: ["research endpoint serving academic papers"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-research" }]);
+
+    // The hints must not substring-match "research" (contains "search"); "research endpoint" is not a
+    // search surface and must fall back to generic guidance.
     const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
     assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
   });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -18019,6 +18019,36 @@ test("bob_read_assignment_brief selects over-permissive-search-list as a candida
   });
 });
 
+test("bob_read_assignment_brief selects over-permissive-search-list when evidence names a literal /_search path (recall by design; matcher spans freeform evidence)", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-evidence-search-path",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/metrics"],
+      evidence: ["internal telemetry proxied through /_search for log search"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-evidence-search-path" }]);
+
+    // Documented behavior, pinned (the round-15 brutalist HIGH boundary): endpoint patterns are matched
+    // against the MERGED endpointText (technique-packs.js scoreTechniqueEntry), which spans `evidence`, so
+    // a LITERAL "/_search" path written into recon evidence scores 5 and selects the pack even though the
+    // structured endpoints list is just /metrics. This is INTENTIONAL recall, not a false positive: the
+    // patterns are slash-prefixed path fragments, so an evidence match means recon actually found a search
+    // path (an exposed /_search/ES backend IS an over-permissive-search target worth probing). The risk is
+    // self-limiting -- selection is candidate guidance, and the evaluator can only sample records from a
+    // real search/list endpoint, which /metrics is not. Pinned so the merged-input matching can't regress
+    // silently. (Contrast: evidence containing only the WORD "research" -- no "/search" path -- does not
+    // match, because the pattern requires the leading slash.)
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    const ops = brief.technique_packs.selected.find((entry) => entry.id === "over-permissive-search-list");
+    assert.ok(ops, "a literal /_search path in evidence must select over-permissive-search-list (recall)");
+    assert.ok(ops.matched.includes("endpoint:/_search"), "must match via the /_search endpoint pattern against evidence text");
+  });
+});
+
 test("bob_read_assignment_brief knowledge remains bounded and excludes full source docs", () => {
   withTempHome(() => {
     const domain = "example.com";

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17779,6 +17779,84 @@ test("bob_read_assignment_brief falls back to generic guidance for unknown tech"
   });
 });
 
+test("bob_read_assignment_brief surfaces over-permissive-search-list for an Elasticsearch search surface", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-es-search",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Elasticsearch"],
+      endpoints: ["/_search", "/api/search"],
+      interesting_params: ["search", "facet"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-es-search" }]);
+
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("bob_read_assignment_brief surfaces over-permissive-search-list for a people-search list surface (route + filter param, no search tech)", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-people",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/people"],
+      interesting_params: ["filter"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-people" }]);
+
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a GraphQL query surface", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-graphql-only",
+      hosts: [`https://${domain}`],
+      tech_stack: ["GraphQL", "Apollo"],
+      endpoints: ["/graphql"],
+      interesting_params: ["query", "variables", "operationName"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-graphql-only" }]);
+
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("over-permissive-search-list guidance fits the 240-char summary cap with the grading thesis front-loaded", () => {
+  // technique-packs.js caps each summary item at TECHNIQUE_SUMMARY_ITEM_MAX_CHARS = 240; keep every
+  // technique/payload_hint within it so summary-mode briefs never truncate the safety or grading guidance.
+  const SUMMARY_ITEM_MAX_CHARS = 240;
+  const knowledge = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "..", ".hacker-bob", "knowledge", "evaluator-techniques.json"),
+    "utf8",
+  ));
+  const entry = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
+  assert.ok(entry, "over-permissive-search-list entry must exist");
+  for (const technique of entry.techniques) {
+    assert.ok(technique.length <= SUMMARY_ITEM_MAX_CHARS,
+      `technique exceeds summary cap (${technique.length}): ${technique.slice(0, 60)}`);
+  }
+  for (const hint of entry.payload_hints) {
+    assert.ok(hint.length <= SUMMARY_ITEM_MAX_CHARS,
+      `payload_hint exceeds summary cap (${hint.length}): ${hint.slice(0, 60)}`);
+  }
+  // The grading thesis ("NOT auto-LOW") and the PII guard must ride the first surfaced item so they
+  // survive summary truncation even on the demoted/other-applicable path.
+  assert.match(entry.techniques[0], /NOT auto-LOW/);
+  assert.match(entry.techniques[0], /NEVER page raw rows, real PII/);
+});
+
 test("bob_read_assignment_brief knowledge remains bounded and excludes full source docs", () => {
   withTempHome(() => {
     const domain = "example.com";

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17838,28 +17838,30 @@ test("bob_read_assignment_brief does NOT surface over-permissive-search-list for
   });
 });
 
-test("over-permissive-search-list guidance fits the 240-char summary cap with the grading thesis front-loaded", () => {
-  // Track the production cap (imported above) rather than a local literal, so this guard stays correct
-  // if the cap changes: keep every technique/payload_hint within it so summary-mode briefs never
-  // truncate the safety or grading guidance.
+test("every technique entry's summary items fit the 240-char cap (registry-wide: no silent truncation of guidance)", () => {
+  // capTechniqueString (technique-packs.js) silently truncates summary items past the cap, which can
+  // drop a safety/grading guardrail. Rather than rely on a per-entry guard, assert the invariant across
+  // the WHOLE registry so a future high-risk entry can't regress unnoticed. Track the production
+  // constants (imported above), not local literals, so this stays correct if the cap changes.
   const knowledge = JSON.parse(fs.readFileSync(
     path.join(__dirname, "..", ".hacker-bob", "knowledge", "evaluator-techniques.json"),
     "utf8",
   ));
-  const entry = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
-  assert.ok(entry, "over-permissive-search-list entry must exist");
-  for (const technique of entry.techniques) {
-    assert.ok(technique.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
-      `technique exceeds summary cap (${technique.length}): ${technique.slice(0, 60)}`);
+  for (const entry of knowledge.entries) {
+    for (const kind of ["techniques", "payload_hints"]) {
+      const summaryItems = Array.isArray(entry[kind]) ? entry[kind].slice(0, TECHNIQUE_SUMMARY_ITEMS_PER_KIND) : [];
+      for (const item of summaryItems) {
+        assert.ok(item.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
+          `${entry.id} ${kind} summary item exceeds cap (${item.length}): ${item.slice(0, 60)}`);
+      }
+    }
   }
-  for (const hint of entry.payload_hints) {
-    assert.ok(hint.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
-      `payload_hint exceeds summary cap (${hint.length}): ${hint.slice(0, 60)}`);
-  }
-  // The grading thesis ("NOT auto-LOW") and the no-bulk-extraction guardrail must ride the first
-  // surfaced item so they survive summary truncation even on the demoted/other-applicable path.
-  assert.match(entry.techniques[0], /NOT auto-LOW/);
-  assert.match(entry.techniques[0], /never page the full corpus/i);
+  // over-permissive-search-list specifically: the grading thesis ("NOT auto-LOW") and the
+  // no-bulk-extraction guardrail must ride the first surfaced item so they survive summary truncation.
+  const ops = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
+  assert.ok(ops, "over-permissive-search-list entry must exist");
+  assert.match(ops.techniques[0], /NOT auto-LOW/);
+  assert.match(ops.techniques[0], /never page the full corpus/i);
 });
 
 test("over-permissive-search-list proof guidance caps extraction at a small sample and gates unmasked data on authorization", () => {
@@ -17876,7 +17878,7 @@ test("over-permissive-search-list proof guidance caps extraction at a small samp
   assert.match(blob, /never page the full corpus|not the whole set/i);
   // Unmasked real records are gated on an authorized engagement; on a public safe-harbor program the
   // sample is masked and paired with schema + count.
-  assert.match(blob, /authorized engagement|BOB_DATA_ACCESS_AUTHORIZED/i);
+  assert.match(blob, /authorized engagement/i);
   assert.match(blob, /safe.harbor/i);
   assert.match(blob, /mask the sample/i);
 });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17797,7 +17797,7 @@ test("bob_read_assignment_brief surfaces over-permissive-search-list for an Elas
   });
 });
 
-test("bob_read_assignment_brief surfaces over-permissive-search-list for a people-search surface (search endpoint + people-search hint + filter)", () => {
+test("bob_read_assignment_brief surfaces over-permissive-search-list for a people-search surface (search endpoint + people-search hint; filter/facet params are non-scoring)", () => {
   withTempHome(() => {
     const domain = "example.com";
     seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
@@ -17811,10 +17811,11 @@ test("bob_read_assignment_brief surfaces over-permissive-search-list for a peopl
     }]);
     seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-people-search" }]);
 
-    // Recall is driven by a real search signal (a /search endpoint + a "people search" hint), with the
-    // filter/facet params boosting rank -- this is the over-permissive people-search list, not a bare
-    // directory route. (A lone filter param defers to generic-rest-api, which keeps the entry from
-    // over-broadening onto unrelated lists.)
+    // Recall is driven by a real search signal: the /people/search endpoint (contains /search, +5) plus
+    // the "people search" hint in evidence (+4) = score 9. The filter/facet params do NOT contribute to
+    // scoring (match.params is []); they only mirror a realistic faceted-search surface, not a bare
+    // directory route. (A surface with ONLY a filter param scores 0 here and defers to generic-rest-api,
+    // which keeps the entry from over-broadening onto unrelated lists.)
     const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
     assert.ok(brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
   });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17856,30 +17856,29 @@ test("over-permissive-search-list guidance fits the 240-char summary cap with th
     assert.ok(hint.length <= TECHNIQUE_SUMMARY_ITEM_MAX_CHARS,
       `payload_hint exceeds summary cap (${hint.length}): ${hint.slice(0, 60)}`);
   }
-  // The grading thesis ("NOT auto-LOW") and the PII guard must ride the first surfaced item so they
-  // survive summary truncation even on the demoted/other-applicable path.
+  // The grading thesis ("NOT auto-LOW") and the no-bulk-extraction guardrail must ride the first
+  // surfaced item so they survive summary truncation even on the demoted/other-applicable path.
   assert.match(entry.techniques[0], /NOT auto-LOW/);
-  assert.match(entry.techniques[0], /never page or sample real rows/i);
+  assert.match(entry.techniques[0], /never page the full corpus/i);
 });
 
-test("over-permissive-search-list confirmation guidance is internally consistent: count/metadata-only, never sample a real row", () => {
+test("over-permissive-search-list proof guidance caps extraction at a small sample and gates unmasked data on authorization", () => {
   const knowledge = JSON.parse(fs.readFileSync(
     path.join(__dirname, "..", ".hacker-bob", "knowledge", "evaluator-techniques.json"),
     "utf8",
   ));
   const entry = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
   assert.ok(entry, "over-permissive-search-list entry must exist");
-  // No technique may license retrieving/sampling a real row -- it would pull cross-tenant PII on a
-  // /people-style list and contradict the payload-hint rule "do NOT page rows (even limit=1 returns
-  // one real row)". Confirmation must stay count/metadata-only.
-  const allTechniques = entry.techniques.join("   ");
-  // Affirmative row-capture licenses only (negated guards like "never page or sample real rows" are fine).
-  assert.doesNotMatch(allTechniques, /redacted sample|redacted evidence|ONE sample|sample a (real )?row/i);
-  assert.match(entry.techniques[0], /COUNT\/metadata totals ONLY/i);
-  assert.ok(
-    entry.payload_hints.some((hint) => /do NOT page rows|never (fetch|page) rows/i.test(hint)),
-    "a payload hint must explicitly forbid paging rows",
-  );
+  const blob = [...entry.techniques, ...entry.payload_hints].join("   ");
+  // Proof-of-impact is a SMALL sample (5-10 records), never the full corpus: the line between an
+  // authorized demonstration and mass exfiltration. The guardrail must be explicit in the guidance.
+  assert.match(blob, /5[–-]10 (record|sample)/i);
+  assert.match(blob, /never page the full corpus|not the whole set/i);
+  // Unmasked real records are gated on an authorized engagement; on a public safe-harbor program the
+  // sample is masked and paired with schema + count.
+  assert.match(blob, /authorized engagement|BOB_DATA_ACCESS_AUTHORIZED/i);
+  assert.match(blob, /safe.harbor/i);
+  assert.match(blob, /mask the sample/i);
 });
 
 test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a bare people directory with no search/filter signal", () => {

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17968,6 +17968,26 @@ test("bob_read_assignment_brief does NOT surface over-permissive-search-list for
   });
 });
 
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a 'Research API' tech surface", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-research-api",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Research API"],
+      endpoints: ["/api/papers"],
+      interesting_params: ["q"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-research-api" }]);
+
+    // tech match is substring-based; "search api" was a substring of "Research API" and must not pull
+    // mass-extraction guidance onto a research/data API with no real search signal.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
 test("bob_read_assignment_brief knowledge remains bounded and excludes full source docs", () => {
   withTempHome(() => {
     const domain = "example.com";

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17878,7 +17878,7 @@ test("over-permissive-search-list proof guidance caps extraction at a small samp
   // Proof-of-impact is a SMALL sample (5-10 records), never the full corpus: the line between an
   // authorized demonstration and mass exfiltration. The guardrail must be explicit in the guidance.
   assert.match(blob, /5[–-]10 (record|sample)/i);
-  assert.match(blob, /never page the full corpus|not the whole set/i);
+  assert.match(blob, /never the full corpus|not the whole set/i);
   // Unmasked real records are gated on an authorized engagement; on a public safe-harbor program the
   // sample is masked and paired with schema + count.
   assert.match(blob, /authorized engagement/i);

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17797,19 +17797,24 @@ test("bob_read_assignment_brief surfaces over-permissive-search-list for an Elas
   });
 });
 
-test("bob_read_assignment_brief surfaces over-permissive-search-list for a people-search list surface (route + filter param, no search tech)", () => {
+test("bob_read_assignment_brief surfaces over-permissive-search-list for a people-search surface (search endpoint + people-search hint + filter)", () => {
   withTempHome(() => {
     const domain = "example.com";
     seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
     seedAttackSurfaces(domain, [{
-      id: "surface-people",
+      id: "surface-people-search",
       hosts: [`https://${domain}`],
       tech_stack: ["Custom"],
-      endpoints: ["/people"],
-      interesting_params: ["filter"],
+      endpoints: ["/people/search"],
+      interesting_params: ["filter", "facet"],
+      evidence: ["people search index over an employee directory"],
     }]);
-    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-people" }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-people-search" }]);
 
+    // Recall is driven by a real search signal (a /search endpoint + a "people search" hint), with the
+    // filter/facet params boosting rank -- this is the over-permissive people-search list, not a bare
+    // directory route. (A lone filter param defers to generic-rest-api, which keeps the entry from
+    // over-broadening onto unrelated lists.)
     const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
     assert.ok(brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
   });
@@ -17854,7 +17859,67 @@ test("over-permissive-search-list guidance fits the 240-char summary cap with th
   // The grading thesis ("NOT auto-LOW") and the PII guard must ride the first surfaced item so they
   // survive summary truncation even on the demoted/other-applicable path.
   assert.match(entry.techniques[0], /NOT auto-LOW/);
-  assert.match(entry.techniques[0], /NEVER page raw rows, real PII/);
+  assert.match(entry.techniques[0], /never page or sample real rows/i);
+});
+
+test("over-permissive-search-list confirmation guidance is internally consistent: count/metadata-only, never sample a real row", () => {
+  const knowledge = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "..", ".hacker-bob", "knowledge", "evaluator-techniques.json"),
+    "utf8",
+  ));
+  const entry = knowledge.entries.find((e) => e.id === "over-permissive-search-list");
+  assert.ok(entry, "over-permissive-search-list entry must exist");
+  // No technique may license retrieving/sampling a real row -- it would pull cross-tenant PII on a
+  // /people-style list and contradict the payload-hint rule "do NOT page rows (even limit=1 returns
+  // one real row)". Confirmation must stay count/metadata-only.
+  const allTechniques = entry.techniques.join("   ");
+  // Affirmative row-capture licenses only (negated guards like "never page or sample real rows" are fine).
+  assert.doesNotMatch(allTechniques, /redacted sample|redacted evidence|ONE sample|sample a (real )?row/i);
+  assert.match(entry.techniques[0], /COUNT\/metadata totals ONLY/i);
+  assert.ok(
+    entry.payload_hints.some((hint) => /do NOT page rows|never (fetch|page) rows/i.test(hint)),
+    "a payload hint must explicitly forbid paging rows",
+  );
+});
+
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for a bare people directory with no search/filter signal", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-bare-directory",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/people"],
+      interesting_params: ["name"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-bare-directory" }]);
+
+    // A benign member directory (no search tech, no filter/search param) must not receive
+    // predicate-annihilation / header-routing guidance just for exposing a /people route.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
+});
+
+test("bob_read_assignment_brief does NOT surface over-permissive-search-list for an OAuth authorize surface using the scope param", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-oauth",
+      hosts: [`https://${domain}`],
+      tech_stack: ["OAuth"],
+      endpoints: ["/oauth/authorize"],
+      interesting_params: ["scope", "redirect_uri", "client_id"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-oauth" }]);
+
+    // "scope" is the canonical OAuth/OIDC param; it must not pull search-filter-bypass guidance onto
+    // an auth flow, so it is not a match param for this technique.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    assert.ok(!brief.techniques.some((entry) => entry.id === "over-permissive-search-list"));
+  });
 });
 
 test("bob_read_assignment_brief knowledge remains bounded and excludes full source docs", () => {

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -17989,6 +17989,36 @@ test("bob_read_assignment_brief does NOT surface over-permissive-search-list for
   });
 });
 
+test("bob_read_assignment_brief selects over-permissive-search-list as a candidate for /api/research/search (real /search segment scores 5; ties with the /api generic packs, does not dominate)", () => {
+  withTempHome(() => {
+    const domain = "example.com";
+    seedSessionState(domain, { phase: "EVALUATE", evaluation_wave: 1, pending_wave: 1 });
+    seedAttackSurfaces(domain, [{
+      id: "surface-research-search-endpoint",
+      hosts: [`https://${domain}`],
+      tech_stack: ["Custom"],
+      endpoints: ["/api/research/search"],
+      interesting_params: ["q"],
+    }]);
+    seedAssignments(domain, 1, [{ agent: "a1", surface_id: "surface-research-search-endpoint" }]);
+
+    // Boundary pinned (the brutalist's "score exactly 5 and receive guidance" case). A real /search-family
+    // PATH SEGMENT is sufficient signal on its own: "/search" substring-matches the trailing /search of
+    // /api/research/search -> endpoint weight 5 -> the pack is a SELECTED CANDIDATE the evaluator can pull.
+    // But it does NOT dominate: on an /api/ path it ties at 5 with generic-rest-api (/api) and nextjs
+    // (/api/), so it ranks as a peer candidate (alphabetical tiebreak puts it 3rd, out of the top-2 inline
+    // `techniques` slot) rather than crowding out the generic REST guidance -- a precision safeguard, not a
+    // false positive. Contrast the "Research API" tech and bare /research surfaces above, which have NO
+    // /search segment, score 0, and are not selected at all. Assert on technique_packs.selected (the real
+    // candidate set, cap 5), NOT the legacy top-2 `techniques` field.
+    const brief = JSON.parse(readAssignmentBrief({ target_domain: domain, wave: "w1", agent: "a1" }));
+    const ops = brief.technique_packs.selected.find((entry) => entry.id === "over-permissive-search-list");
+    assert.ok(ops, "a real /search path segment must select over-permissive-search-list as a candidate");
+    assert.equal(ops.score, 5);
+    assert.ok(ops.matched.includes("endpoint:/search"), "must match via the /search endpoint pattern");
+  });
+});
+
 test("bob_read_assignment_brief knowledge remains bounded and excludes full source docs", () => {
   withTempHome(() => {
     const domain = "example.com";


### PR DESCRIPTION
feat(evaluate): over-permissive search/list technique pack — close the /api/search depth gap

A current-vs-old Bob comparison on the same target found ONE genuine offensive regression not explained
by patches/scope/recon: on an over-permissive /api/search-style endpoint, OLD Bob turned it into a
concrete exploit via predicate annihilation (true / 1 eq 1) and a search-index header swap (a
9,155-record cross-scope dump); CURRENT Bob found the SAME endpoint, called it "over-permissive",
graded it LOW, and never tried those pivots. The evaluator's technique registry
(.hacker-bob/knowledge/evaluator-techniques.json) had an IDOR/object-access entry but ZERO guidance on
turning an over-permissive search/list endpoint into a proven mass-extraction.

Adds an over-permissive-search-list technique entry that the existing score-based matcher surfaces
(score 40 as the #1 pack) the moment a surface looks like a search/list endpoint (tech api/elastic/...,
endpoints /search,/api/search,/people,/directory,..., params query/search/filter/$filter/where/scope).
Its techniques cover the exact pivots old Bob used, plus the grading discipline current Bob lacked:
  - PREDICATE ANNIHILATION: always-true predicate (true, 1 eq 1, OData $filter=1 eq 1, Lucene
    *:* / q=*, NoSQL operator injection) to collapse the server-side scope filter; confirm by
    RECORD-COUNT differential (scoped N vs annihilated M, M >> N) — synthetic/own data only.
  - SCOPE-PARAM DROP/SWAP: remove/null/star the tenant/org/scope param or substitute a second synthetic
    tenant and diff result sets — filtering only by a client-supplied scope is broken authz.
  - HEADER-BASED ACCESS-CONTROL / INDEX ROUTING: Index:/X-Search-Index/X-Tenant-Id/role headers to
    pivot to a broader index or another tenant (the exact people-search header-swap pivot).
  - BOOLEAN/BLIND enumeration when only a count is returned.
  - The grading rule current Bob missed: an over-permissive endpoint is NOT automatically LOW — try the
    pivots and grade by the PROVEN cross-scope outcome BEFORE settling on LOW.
  - SAFE confirmation: masked record-count + ONE synthetic sample + the exact request; never dump real PII.

Params are intentionally search-SPECIFIC (no generic q/page/limit) so the pack does not false-match a
plain ?q= on an unknown surface (the fallback-to-generic test still holds); real search endpoints match
on their path regardless. test:mcp 2852/0, test:prompts 193/0; matcher selects it #1 (score 40) on a
search surface and 0 on a generic surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new evaluation technique for detecting overly permissive authorization on search/list-style endpoints (including common search-engine and people-search patterns), with guidance focused on safe, bounded validation.
* **Tests**
  * Expanded automated coverage to ensure the technique is surfaced for matching Elasticsearch-backed and people-search signals.
  * Added negative cases to confirm it’s not surfaced for GraphQL, non-search directory routes, OAuth `scope` cases, and other “research” substring edge cases.
  * Verified technique/guidance text length and required safety constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->