### PR TITLE
Bind lab-target authorization to an operator env var, not a published token

### DIFF
--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -117,17 +117,18 @@ Do not use a real company, public service, customer environment, or bug bounty t
 
 ### Private / lab targets (loopback & RFC1918)
 
-By default Bob's scope kernel rejects any non-public target — bare IPs, loopback, and RFC1918 hosts all fail with "not a public DNS domain", because a registrable public domain is the ownership signal Bob relies on. To scan a private lab host that **you own and are authorized to test**, the **operator** must enable the escape out-of-band; the agent cannot enable it for itself:
+By default Bob's scope kernel rejects any non-public target — bare IPs, loopback, and RFC1918 hosts all fail with "not a public DNS domain", because a registrable public domain is the ownership signal Bob relies on. To scan a private lab host that **you own and are authorized to test**, the **operator** must enable the escape out-of-band; the agent cannot enable it for itself (it controls tool arguments, but never the server's environment):
 
-1. Set the operator attestation in the MCP server's environment **before launch** (the agent cannot read or set the server's environment, so this is an operator-only control):
+1. Set **two** operator controls in the MCP server's environment, and keep them set for the whole session (they are re-checked at every scan, not only at init — if you relaunch the server without them, scans of the lab target start failing with "not a public DNS domain"):
 
    ```text
    export BOB_LAB_TARGET_ACK=i-own-and-am-authorized-to-test-these-private-targets
+   export BOB_LAB_TARGET=192.168.1.53        # the exact host(s) you authorize; comma-separated for several
    ```
 
-2. Declare intent at init by passing `lab_authorization: { "private_targets": true }` to `bob_init_session`.
+2. Declare intent at init by passing `lab_authorization: { "private_targets": true }` to `bob_init_session` with `target_domain` set to that host.
 
-Both are required. Without the env var, the declaration alone does nothing and the public-DNS gate still rejects the target. Only IPv4 loopback (`127.0.0.0/8`) and RFC1918 (`10/8`, `172.16/12`, `192.168/16`) are eligible; IPv6, link-local (`169.254/16`), cloud-metadata, and `.internal`/`.local` names are never eligible even with the attestation. The attestation is recorded as an audit-graded session artifact, pins scope to that one host, and requires the default (direct) egress profile.
+All three are required. Without the env vars the declaration alone does nothing, and the grant is **bound to the host(s) named in `BOB_LAB_TARGET`** — so an active session cannot be turned against a neighboring private host. Only IPv4 loopback (`127.0.0.0/8`) and RFC1918 (`10/8`, `172.16/12`, `192.168/16`) are eligible; IPv6, link-local (`169.254/16`), cloud-metadata, and `.internal`/`.local` names are never eligible even with the attestation. The attestation is recorded as an audit-graded session artifact, pins scope to that one host, and requires the default (direct) egress profile.
 
 ## Lifecycle States
 

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -115,6 +115,20 @@ For a first smoke test, use a private lab target or an intentionally vulnerable 
 
 Do not use a real company, public service, customer environment, or bug bounty target until you have confirmed that the target is in scope and you understand the allowed testing methods.
 
+### Private / lab targets (loopback & RFC1918)
+
+By default Bob's scope kernel rejects any non-public target — bare IPs, loopback, and RFC1918 hosts all fail with "not a public DNS domain", because a registrable public domain is the ownership signal Bob relies on. To scan a private lab host that **you own and are authorized to test**, the **operator** must enable the escape out-of-band; the agent cannot enable it for itself:
+
+1. Set the operator attestation in the MCP server's environment **before launch** (the agent cannot read or set the server's environment, so this is an operator-only control):
+
+   ```text
+   export BOB_LAB_TARGET_ACK=i-own-and-am-authorized-to-test-these-private-targets
+   ```
+
+2. Declare intent at init by passing `lab_authorization: { "private_targets": true }` to `bob_init_session`.
+
+Both are required. Without the env var, the declaration alone does nothing and the public-DNS gate still rejects the target. Only IPv4 loopback (`127.0.0.0/8`) and RFC1918 (`10/8`, `172.16/12`, `192.168/16`) are eligible; IPv6, link-local (`169.254/16`), cloud-metadata, and `.internal`/`.local` names are never eligible even with the attestation. The attestation is recorded as an audit-graded session artifact, pins scope to that one host, and requires the default (direct) egress profile.
+
 ## Lifecycle States
 
 A `/bob-evaluate` run advances through six lifecycle states driven by `bob_advance_session(to_state)`:

--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -7,12 +7,14 @@
 // hosts all fail with "not a public DNS domain". That gate is the scope-ownership
 // control: a registrable public domain is provable program scope; a private IP
 // carries no ownership signal. This module is the ONLY sanctioned escape — an
-// operator who OWNS a private lab host sets BOB_LAB_TARGET_ACK in the server
-// environment AND declares private_targets intent at bob_init_session; that
-// attestation, recorded as an audit-graded (agent-unforgeable) session artifact,
-// lets the kernel scope a session to that one private host. The ack is an
-// operator env var, never a tool argument, so a model cannot self-authorize by
-// reading a published token from its own schema.
+// operator who OWNS a private lab host sets BOB_LAB_TARGET_ACK (consent) and
+// BOB_LAB_TARGET (the exact authorized host) in the server environment AND
+// declares private_targets intent at bob_init_session; that attestation,
+// recorded as an audit-graded (agent-unforgeable) session artifact, lets the
+// kernel scope a session to that one named private host. Both controls are
+// operator env vars, never tool arguments, so a model can neither self-authorize
+// by reading a published token from its own schema nor — while an ack is set for
+// one lab box — pivot the grant to a neighboring private host.
 //
 // Design mirrors enforcement-attest.js:
 //   * the ack is an operator ENV var (BOB_LAB_TARGET_ACK), out of the model's
@@ -42,14 +44,38 @@ const net = require("net");
 // CLOSED — not a secret, which is why it is fine for it to live in source.
 const LAB_TARGET_ACK_TOKEN = "i-own-and-am-authorized-to-test-these-private-targets";
 const LAB_TARGET_ACK_ENV = "BOB_LAB_TARGET_ACK";
+// The operator also names the EXACT host(s) they authorize, comma-separated, in
+// BOB_LAB_TARGET. This binds the grant to the intended host: while the ack is set
+// for one lab box, a prompt-injected orchestrator must not be able to scope a
+// session to a NEIGHBORING private host (e.g. sweep the operator's RFC1918 LAN).
+const LAB_TARGET_HOST_ENV = "BOB_LAB_TARGET";
 
 const LAB_AUTHORIZATION_BASENAME = "lab-authorization.json";
 
-// The operator-only gate: true iff the exact ack token is set in the server
-// environment. Read ONLY from process.env — never from a tool argument or the
-// published schema — so a prompt-injected evaluator cannot satisfy it.
+// The operator-only consent gate: true iff the exact ack token is set in the
+// server environment. Read ONLY from process.env — never from a tool argument or
+// the published schema — so a prompt-injected evaluator cannot satisfy it.
 function operatorLabAckPresent() {
   return process.env[LAB_TARGET_ACK_ENV] === LAB_TARGET_ACK_TOKEN;
+}
+
+// The operator-declared set of exact authorized lab hosts (from BOB_LAB_TARGET).
+// Bracketed IPv6-style wrappers are stripped for comparison parity.
+function operatorAuthorizedLabHosts() {
+  const raw = process.env[LAB_TARGET_HOST_ENV];
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((h) => h.trim().replace(/^\[|\]$/g, ""))
+    .filter(Boolean);
+}
+
+// The operator-only host-binding gate: true iff `host` is one of the exact hosts
+// the operator named in BOB_LAB_TARGET. Read ONLY from process.env, so the agent
+// (which controls target_domain) cannot widen the grant to another private host.
+function operatorAuthorizedLabHost(host) {
+  const address = String(host || "").replace(/^\[|\]$/g, "");
+  return operatorAuthorizedLabHosts().includes(address);
 }
 
 function ipv4Octets(address) {
@@ -110,10 +136,14 @@ function parseLabAuthorization(raw) {
   });
 }
 
-// A host is permitted iff it is lab-eligible AND a valid attestation is present.
+// A host is permitted iff it is lab-eligible AND a valid attestation is present
+// AND the operator named this exact host in BOB_LAB_TARGET. The host-binding
+// stops an active ack (set for one lab box) from being reused by a prompt-injected
+// agent to scope a session to a neighboring private host.
 function labTargetPermitted(host, { authorization } = {}) {
   if (!labTargetEligibleHost(host)) return false;
-  return parseLabAuthorization(authorization) != null;
+  if (parseLabAuthorization(authorization) == null) return false;
+  return operatorAuthorizedLabHost(host);
 }
 
 // Read the persisted, audit-graded attestation for a target's session. Returns
@@ -153,7 +183,9 @@ function recordLabAuthorization(targetDomain, authorization) {
 module.exports = {
   LAB_TARGET_ACK_TOKEN,
   LAB_TARGET_ACK_ENV,
+  LAB_TARGET_HOST_ENV,
   operatorLabAckPresent,
+  operatorAuthorizedLabHost,
   LAB_AUTHORIZATION_BASENAME,
   labTargetEligibleHost,
   parseLabAuthorization,

--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -7,13 +7,17 @@
 // hosts all fail with "not a public DNS domain". That gate is the scope-ownership
 // control: a registrable public domain is provable program scope; a private IP
 // carries no ownership signal. This module is the ONLY sanctioned escape — an
-// operator who OWNS a private lab host attests to it at bob_init_session, and
-// that attestation, recorded as an audit-graded (agent-unforgeable) session
-// artifact, lets the kernel scope a session to that one private host.
+// operator who OWNS a private lab host sets BOB_LAB_TARGET_ACK in the server
+// environment AND declares private_targets intent at bob_init_session; that
+// attestation, recorded as an audit-graded (agent-unforgeable) session artifact,
+// lets the kernel scope a session to that one private host. The ack is an
+// operator env var, never a tool argument, so a model cannot self-authorize by
+// reading a published token from its own schema.
 //
 // Design mirrors enforcement-attest.js:
-//   * one home for the exact-match ack token; a typo fails CLOSED (no escape);
-//   * OFF by default — no attestation, no escape, default public-DNS gate intact;
+//   * the ack is an operator ENV var (BOB_LAB_TARGET_ACK), out of the model's
+//     reach; a typo/unset fails CLOSED (no escape);
+//   * OFF by default — no env ack, no escape, default public-DNS gate intact;
 //   * eligibility is deliberately narrow: IPv4 loopback (127.0.0.0/8) + RFC1918
 //     (10/8, 172.16/12, 192.168/16) only. IPv6, hostnames (incl. "localhost"),
 //     link-local (169.254/16), cloud-metadata, and .internal/.local names are
@@ -27,11 +31,26 @@
 
 const net = require("net");
 
-// Exact attestation token. The operator must pass it verbatim; any other value
-// (typo, truncation, "yes") fails closed and the private target stays rejected.
+// Operator attestation channel. The ack is an ENVIRONMENT variable, NOT a tool
+// argument: a model that can call bob_init_session must not be able to authorize
+// a private target by passing a value it can read from its own tool schema. The
+// operator sets BOB_LAB_TARGET_ACK to this exact token in the MCP server's
+// environment at launch; a running model cannot mutate the server process's
+// environment (nor a peer process's), so this is an operator-only control even
+// for a prompt-injected evaluator with shell access. The token value is the
+// agreed env contract — a deliberate, exact opt-in signal whose typo/unset fails
+// CLOSED — not a secret, which is why it is fine for it to live in source.
 const LAB_TARGET_ACK_TOKEN = "i-own-and-am-authorized-to-test-these-private-targets";
+const LAB_TARGET_ACK_ENV = "BOB_LAB_TARGET_ACK";
 
 const LAB_AUTHORIZATION_BASENAME = "lab-authorization.json";
+
+// The operator-only gate: true iff the exact ack token is set in the server
+// environment. Read ONLY from process.env — never from a tool argument or the
+// published schema — so a prompt-injected evaluator cannot satisfy it.
+function operatorLabAckPresent() {
+  return process.env[LAB_TARGET_ACK_ENV] === LAB_TARGET_ACK_TOKEN;
+}
 
 function ipv4Octets(address) {
   const parts = String(address).split(".");
@@ -67,14 +86,26 @@ function labTargetEligibleHost(host) {
 }
 
 // Validate + normalize an operator attestation. Returns a frozen authorization
-// object or null. FAIL CLOSED: anything malformed, or a non-exact ack, → null.
+// object or null. FAIL CLOSED: anything malformed, intent not asserted, OR the
+// operator env ack absent → null. The tool argument carries only the non-secret
+// INTENT (private_targets); the binding operator control is the env ack, so a
+// model that supplies the intent (even with a guessed/published token field) is
+// rejected unless the operator has set BOB_LAB_TARGET_ACK. The legacy `ack`
+// argument field is intentionally ignored (it is no longer a control surface).
 function parseLabAuthorization(raw) {
+  // Read the operator gate FIRST, before touching any attacker-influenced field
+  // of `raw`. A hostile in-process object could expose `private_targets` as a
+  // getter that sets the env var as a read side-effect and then satisfy the gate;
+  // checking the env before reading `raw` makes that ordering impossible (and we
+  // return early without ever invoking the getter). The stdio JSON transport
+  // already delivers inert plain data, so this is defense for any future
+  // non-JSON / in-process caller.
+  if (!operatorLabAckPresent()) return null;
   if (raw == null || typeof raw !== "object" || Array.isArray(raw)) return null;
   if (raw.private_targets !== true) return null;
-  if (raw.ack !== LAB_TARGET_ACK_TOKEN) return null;
   return Object.freeze({
     private_targets: true,
-    ack: LAB_TARGET_ACK_TOKEN,
+    ack_source: "operator_env",
     scope: "rfc1918_loopback_ipv4",
   });
 }
@@ -121,6 +152,8 @@ function recordLabAuthorization(targetDomain, authorization) {
 
 module.exports = {
   LAB_TARGET_ACK_TOKEN,
+  LAB_TARGET_ACK_ENV,
+  operatorLabAckPresent,
   LAB_AUTHORIZATION_BASENAME,
   labTargetEligibleHost,
   parseLabAuthorization,

--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -173,9 +173,18 @@ function recordLabAuthorization(targetDomain, authorization) {
   if (!normalized) return null;
   const { labAuthorizationPath } = require("./paths.js");
   const { writeFileAtomic } = require("./storage.js");
+  // Persist a self-describing audit record: the normalized attestation PLUS the
+  // exact host this session was scoped to and the operator's authorized-host set
+  // at mint time, so the artifact is forensically meaningful on its own. The
+  // live gate still reads the env (operatorAuthorizedLabHost), not this file.
+  const record = {
+    ...normalized,
+    target_host: targetDomain,
+    authorized_hosts: operatorAuthorizedLabHosts(),
+  };
   writeFileAtomic(
     labAuthorizationPath(targetDomain),
-    `${JSON.stringify(normalized, null, 2)}\n`,
+    `${JSON.stringify(record, null, 2)}\n`,
   );
   return normalized;
 }

--- a/mcp/lib/tools/init-session.js
+++ b/mcp/lib/tools/init-session.js
@@ -71,7 +71,7 @@ module.exports = Object.freeze({
       },
       "lab_authorization": {
         "type": "object",
-        "description": "OFF BY DEFAULT. Declares intent to scope this session to a private host (IPv4 loopback 127.0.0.0/8 or RFC1918: 10/8, 172.16/12, 192.168/16) that the OPERATOR owns and is authorized to test. This declaration ALONE does NOT grant the escape: the operator must ALSO set the BOB_LAB_TARGET_ACK environment variable on the MCP server (an operator-only control the agent cannot supply). Without both, the public-DNS gate rejects non-public targets. Cloud-metadata, link-local, IPv6, and .internal/.local hosts are never eligible. Recorded as an audit-graded artifact and implies allow_internal_hosts for this session; cannot be combined with block_internal_hosts.",
+        "description": "OFF BY DEFAULT. Declares intent to scope this session to a private host (IPv4 loopback 127.0.0.0/8 or RFC1918: 10/8, 172.16/12, 192.168/16) that the OPERATOR owns and is authorized to test. This declaration ALONE does NOT grant the escape: the operator must ALSO set, on the MCP server (operator-only controls the agent cannot supply), BOTH the BOB_LAB_TARGET_ACK environment variable (consent) AND BOB_LAB_TARGET to the exact host (e.g. 192.168.1.53; comma-separated for several). Without all of these, the public-DNS gate rejects non-public targets, and the grant is bound to the named host(s) only. Cloud-metadata, link-local, IPv6, and .internal/.local hosts are never eligible. Recorded as an audit-graded artifact and implies allow_internal_hosts for this session; cannot be combined with block_internal_hosts.",
         "properties": {
           "private_targets": {
             "type": "boolean",

--- a/mcp/lib/tools/init-session.js
+++ b/mcp/lib/tools/init-session.js
@@ -71,18 +71,14 @@ module.exports = Object.freeze({
       },
       "lab_authorization": {
         "type": "object",
-        "description": "OFF BY DEFAULT. Operator attestation that target_domain is a private host you OWN and are AUTHORIZED to test (IPv4 loopback 127.0.0.0/8 or RFC1918: 10/8, 172.16/12, 192.168/16). Required to scope a session to a private IP literal; without it the public-DNS gate rejects non-public targets. Cloud-metadata, link-local, IPv6, and .internal/.local hosts are never eligible. Recorded as an audit-graded artifact and implies allow_internal_hosts for this session; cannot be combined with block_internal_hosts.",
+        "description": "OFF BY DEFAULT. Declares intent to scope this session to a private host (IPv4 loopback 127.0.0.0/8 or RFC1918: 10/8, 172.16/12, 192.168/16) that the OPERATOR owns and is authorized to test. This declaration ALONE does NOT grant the escape: the operator must ALSO set the BOB_LAB_TARGET_ACK environment variable on the MCP server (an operator-only control the agent cannot supply). Without both, the public-DNS gate rejects non-public targets. Cloud-metadata, link-local, IPv6, and .internal/.local hosts are never eligible. Recorded as an audit-graded artifact and implies allow_internal_hosts for this session; cannot be combined with block_internal_hosts.",
         "properties": {
           "private_targets": {
             "type": "boolean",
-            "description": "Must be true to attest a private target."
-          },
-          "ack": {
-            "type": "string",
-            "description": "Exact attestation token (verbatim): i-own-and-am-authorized-to-test-these-private-targets"
+            "description": "Must be true to declare a private-target session. Authorization is granted out-of-band by the operator via the BOB_LAB_TARGET_ACK server environment variable, not by any value in this call."
           }
         },
-        "required": ["private_targets", "ack"],
+        "required": ["private_targets"],
         "additionalProperties": false
       }
     },

--- a/test/lab-target-attest.test.js
+++ b/test/lab-target-attest.test.js
@@ -16,7 +16,9 @@ const path = require("path");
 const {
   LAB_TARGET_ACK_TOKEN,
   LAB_TARGET_ACK_ENV,
+  LAB_TARGET_HOST_ENV,
   operatorLabAckPresent,
+  operatorAuthorizedLabHost,
   labTargetEligibleHost,
   parseLabAuthorization,
   labTargetPermitted,
@@ -26,39 +28,48 @@ const { assertHttpScopeDomain, validateHttpScanScope } = require("../mcp/lib/sco
 const { isAuditGradedPath, labAuthorizationPath, sessionDir } = require("../mcp/lib/paths.js");
 
 // The model-suppliable INTENT — NO secret. Authorization comes from the operator
-// env ack, never from this object (the legacy `ack` field is ignored).
+// env vars, never from this object (the legacy `ack` field is ignored).
 const INTENT = Object.freeze({ private_targets: true });
+// Hosts the home-based success tests authorize (set in BOB_LAB_TARGET).
+const DEFAULT_HOSTS = "192.168.1.53,127.0.0.1,10.1.2.3,192.168.1.54";
 
+// Set/clear the operator env controls (consent ack + host binding) around fn.
+// ack:true sets BOB_LAB_TARGET_ACK to the token; hosts (string|null) sets/clears
+// BOB_LAB_TARGET. Both are restored afterward.
+function withLabEnv(fn, { ack = true, hosts = null } = {}) {
+  const prevAck = process.env[LAB_TARGET_ACK_ENV];
+  const prevHost = process.env[LAB_TARGET_HOST_ENV];
+  if (ack) process.env[LAB_TARGET_ACK_ENV] = LAB_TARGET_ACK_TOKEN;
+  else delete process.env[LAB_TARGET_ACK_ENV];
+  if (hosts) process.env[LAB_TARGET_HOST_ENV] = hosts;
+  else delete process.env[LAB_TARGET_HOST_ENV];
+  try {
+    return fn();
+  } finally {
+    if (prevAck === undefined) delete process.env[LAB_TARGET_ACK_ENV];
+    else process.env[LAB_TARGET_ACK_ENV] = prevAck;
+    if (prevHost === undefined) delete process.env[LAB_TARGET_HOST_ENV];
+    else process.env[LAB_TARGET_HOST_ENV] = prevHost;
+  }
+}
+
+// parseLabAuthorization is host-agnostic, so its tests only toggle the ack.
 function withLabAck(fn) {
-  const prev = process.env[LAB_TARGET_ACK_ENV];
-  process.env[LAB_TARGET_ACK_ENV] = LAB_TARGET_ACK_TOKEN;
-  try {
-    return fn();
-  } finally {
-    if (prev === undefined) delete process.env[LAB_TARGET_ACK_ENV];
-    else process.env[LAB_TARGET_ACK_ENV] = prev;
-  }
+  return withLabEnv(fn, { ack: true, hosts: null });
 }
-
 function withoutLabAck(fn) {
-  const prev = process.env[LAB_TARGET_ACK_ENV];
-  delete process.env[LAB_TARGET_ACK_ENV];
-  try {
-    return fn();
-  } finally {
-    if (prev !== undefined) process.env[LAB_TARGET_ACK_ENV] = prev;
-  }
+  return withLabEnv(fn, { ack: false, hosts: null });
 }
 
-// Lab-escape context: a temp HOME for the session root, and (by default) the
-// operator env ack set. Pass { ack: false } to exercise the no-operator path.
-function withTempHome(fn, { ack = true } = {}) {
+// Lab-escape context: a temp HOME for the session root, plus (by default) both
+// operator env controls set. Pass { ack: false } for the no-consent path or
+// { hosts: ... } to scope the host binding for that test.
+function withTempHome(fn, { ack = true, hosts = DEFAULT_HOSTS } = {}) {
   const previousHome = process.env.HOME;
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bob-lab-attest-"));
   process.env.HOME = tempHome;
-  const wrapper = ack ? withLabAck : withoutLabAck;
   try {
-    return wrapper(() => fn(tempHome));
+    return withLabEnv(() => fn(tempHome), { ack, hosts });
   } finally {
     if (previousHome === undefined) delete process.env.HOME;
     else process.env.HOME = previousHome;
@@ -134,18 +145,20 @@ test("parseLabAuthorization checks the operator env BEFORE reading attacker inpu
   });
 });
 
-test("labTargetPermitted requires eligibility AND the operator env ack", () => {
-  withLabAck(() => {
+test("labTargetPermitted requires eligibility AND the operator ack AND the host binding", () => {
+  withLabEnv(() => {
     assert.equal(labTargetPermitted("192.168.1.53", { authorization: INTENT }), true);
     assert.equal(labTargetPermitted("192.168.1.53", {}), false);
     // Eligible host but ineligible scope: blocked even with the env + intent.
     assert.equal(labTargetPermitted("169.254.169.254", { authorization: INTENT }), false);
     assert.equal(labTargetPermitted("8.8.8.8", { authorization: INTENT }), false);
-  });
-  // Without the operator env, an eligible host + intent is still refused.
-  withoutLabAck(() => {
+    // Eligible + ack present, but NOT the operator-named host → refused.
+    assert.equal(labTargetPermitted("10.0.0.9", { authorization: INTENT }), false);
+  }, { ack: true, hosts: "192.168.1.53" });
+  // Without the operator ack, an eligible + named host + intent is still refused.
+  withLabEnv(() => {
     assert.equal(labTargetPermitted("192.168.1.53", { authorization: INTENT }), false);
-  });
+  }, { ack: false, hosts: "192.168.1.53" });
 });
 
 test("default public-DNS gate is UNCHANGED without an attestation", () => {
@@ -178,6 +191,27 @@ test("opts-supplied attestation permits only eligible hosts (init bootstrap path
       /not a public DNS domain/,
     );
   }, { ack: false });
+});
+
+test("operator ack is bound to the BOB_LAB_TARGET host, not a process-wide grant", () => {
+  // Operator authorizes ONLY 192.168.1.53. While that ack is set, a prompt-injected
+  // agent must NOT be able to pivot the grant to a neighboring eligible host.
+  withTempHome(() => {
+    assert.equal(assertHttpScopeDomain("192.168.1.53", { labAuthorization: INTENT }), "192.168.1.53");
+    assert.equal(operatorAuthorizedLabHost("192.168.1.53"), true);
+    for (const neighbor of ["10.0.0.9", "192.168.1.99", "127.0.0.1", "172.16.0.1"]) {
+      assert.equal(operatorAuthorizedLabHost(neighbor), false, `${neighbor} must not be authorized`);
+      assert.throws(
+        () => assertHttpScopeDomain(neighbor, { labAuthorization: INTENT }),
+        /not a public DNS domain/,
+        `${neighbor} pivot must be refused`,
+      );
+    }
+  }, { hosts: "192.168.1.53" });
+  // Consent ack set but BOB_LAB_TARGET unset → no host is authorized at all.
+  withTempHome(() => {
+    assert.throws(() => assertHttpScopeDomain("192.168.1.53", { labAuthorization: INTENT }), /not a public DNS domain/);
+  }, { hosts: null });
 });
 
 test("validateHttpScanScope pins scope to the exact attested host", () => {

--- a/test/lab-target-attest.test.js
+++ b/test/lab-target-attest.test.js
@@ -249,10 +249,15 @@ test("attestation persists to an audit-graded artifact and is read back without 
     const sidecar = path.join(home, "hacker-bob-sessions", "192.168.1.53", "lab-authorization.json");
     assert.equal(fs.existsSync(sidecar), true);
     assert.equal(labAuthorizationPath("192.168.1.53"), sidecar);
-    // The persisted artifact records the env attestation, NOT a token.
+    // The persisted artifact records the env attestation, NOT a token, and is
+    // self-describing for post-incident audit: it names the scoped host and the
+    // operator's authorized-host set at mint time.
     const persisted = JSON.parse(fs.readFileSync(sidecar, "utf8"));
     assert.equal(persisted.ack_source, "operator_env");
     assert.equal(persisted.ack, undefined);
+    assert.equal(persisted.target_host, "192.168.1.53");
+    assert.ok(Array.isArray(persisted.authorized_hosts) && persisted.authorized_hosts.includes("192.168.1.53"),
+      "audit record must capture the operator-authorized hosts");
 
     // The scope kernel reads the persisted attestation with NO opts (the scan path).
     assert.equal(assertHttpScopeDomain("192.168.1.53"), "192.168.1.53");

--- a/test/lab-target-attest.test.js
+++ b/test/lab-target-attest.test.js
@@ -2,8 +2,10 @@
 
 // Operator-attested lab/private-target authorization. Proves the scope kernel's
 // public-DNS gate stays intact by default, and that the ONLY way past it for a
-// loopback/RFC1918 target is a valid, exact-token operator attestation —
-// fail-closed, narrow, host-pinned, and audit-graded against agent forgery.
+// loopback/RFC1918 target is an OPERATOR env attestation (BOB_LAB_TARGET_ACK)
+// PLUS a private_targets intent — fail-closed, narrow, host-pinned, and
+// audit-graded against agent forgery. The ack is an env var the model cannot
+// supply, so a prompt-injected evaluator cannot self-authorize a private target.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -13,6 +15,8 @@ const path = require("path");
 
 const {
   LAB_TARGET_ACK_TOKEN,
+  LAB_TARGET_ACK_ENV,
+  operatorLabAckPresent,
   labTargetEligibleHost,
   parseLabAuthorization,
   labTargetPermitted,
@@ -21,14 +25,40 @@ const {
 const { assertHttpScopeDomain, validateHttpScanScope } = require("../mcp/lib/scope.js");
 const { isAuditGradedPath, labAuthorizationPath, sessionDir } = require("../mcp/lib/paths.js");
 
-const GOOD = Object.freeze({ private_targets: true, ack: LAB_TARGET_ACK_TOKEN });
+// The model-suppliable INTENT — NO secret. Authorization comes from the operator
+// env ack, never from this object (the legacy `ack` field is ignored).
+const INTENT = Object.freeze({ private_targets: true });
 
-function withTempHome(fn) {
+function withLabAck(fn) {
+  const prev = process.env[LAB_TARGET_ACK_ENV];
+  process.env[LAB_TARGET_ACK_ENV] = LAB_TARGET_ACK_TOKEN;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[LAB_TARGET_ACK_ENV];
+    else process.env[LAB_TARGET_ACK_ENV] = prev;
+  }
+}
+
+function withoutLabAck(fn) {
+  const prev = process.env[LAB_TARGET_ACK_ENV];
+  delete process.env[LAB_TARGET_ACK_ENV];
+  try {
+    return fn();
+  } finally {
+    if (prev !== undefined) process.env[LAB_TARGET_ACK_ENV] = prev;
+  }
+}
+
+// Lab-escape context: a temp HOME for the session root, and (by default) the
+// operator env ack set. Pass { ack: false } to exercise the no-operator path.
+function withTempHome(fn, { ack = true } = {}) {
   const previousHome = process.env.HOME;
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "bob-lab-attest-"));
   process.env.HOME = tempHome;
+  const wrapper = ack ? withLabAck : withoutLabAck;
   try {
-    return fn(tempHome);
+    return wrapper(() => fn(tempHome));
   } finally {
     if (previousHome === undefined) delete process.env.HOME;
     else process.env.HOME = previousHome;
@@ -46,27 +76,76 @@ test("eligibility is narrow: loopback + RFC1918 IPv4 only", () => {
   }
 });
 
-test("parseLabAuthorization is fail-closed", () => {
-  assert.ok(parseLabAuthorization(GOOD));
-  assert.equal(parseLabAuthorization(GOOD).scope, "rfc1918_loopback_ipv4");
-  // Anything that is not an exact match returns null.
-  assert.equal(parseLabAuthorization({ private_targets: true, ack: "yes" }), null);
-  assert.equal(parseLabAuthorization({ private_targets: true, ack: `${LAB_TARGET_ACK_TOKEN} ` }), null);
-  assert.equal(parseLabAuthorization({ private_targets: false, ack: LAB_TARGET_ACK_TOKEN }), null);
-  assert.equal(parseLabAuthorization({ ack: LAB_TARGET_ACK_TOKEN }), null);
-  assert.equal(parseLabAuthorization({ private_targets: true }), null);
-  assert.equal(parseLabAuthorization(null), null);
-  assert.equal(parseLabAuthorization("i-own-it"), null);
-  assert.equal(parseLabAuthorization([GOOD]), null);
+test("parseLabAuthorization requires the operator env ack and is fail-closed", () => {
+  // THE STANDOUT: without the operator env, NO model-supplied input authorizes —
+  // not the intent alone, and not even the (formerly published) token passed as
+  // an argument. A model that can call bob_init_session cannot self-authorize.
+  withoutLabAck(() => {
+    assert.equal(operatorLabAckPresent(), false);
+    assert.equal(parseLabAuthorization(INTENT), null);
+    assert.equal(parseLabAuthorization({ private_targets: true, ack: LAB_TARGET_ACK_TOKEN }), null);
+  });
+  // With the operator env, the (non-secret) intent is honored and normalized.
+  withLabAck(() => {
+    assert.equal(operatorLabAckPresent(), true);
+    const parsed = parseLabAuthorization(INTENT);
+    assert.ok(parsed);
+    assert.equal(parsed.scope, "rfc1918_loopback_ipv4");
+    assert.equal(parsed.ack_source, "operator_env");
+    assert.equal(parsed.ack, undefined, "normalized authorization must not carry a token");
+    // Still fail-closed on bad shape even WITH the env set.
+    assert.equal(parseLabAuthorization({ private_targets: false }), null);
+    assert.equal(parseLabAuthorization({}), null);
+    assert.equal(parseLabAuthorization(null), null);
+    assert.equal(parseLabAuthorization("i-own-it"), null);
+    assert.equal(parseLabAuthorization([INTENT]), null);
+  });
+  // A wrong env value (typo/truncation) fails closed — exact match required.
+  const prev = process.env[LAB_TARGET_ACK_ENV];
+  process.env[LAB_TARGET_ACK_ENV] = `${LAB_TARGET_ACK_TOKEN} `;
+  try {
+    assert.equal(operatorLabAckPresent(), false);
+    assert.equal(parseLabAuthorization(INTENT), null);
+  } finally {
+    if (prev === undefined) delete process.env[LAB_TARGET_ACK_ENV];
+    else process.env[LAB_TARGET_ACK_ENV] = prev;
+  }
 });
 
-test("labTargetPermitted requires eligibility AND a valid attestation", () => {
-  assert.equal(labTargetPermitted("192.168.1.53", { authorization: GOOD }), true);
-  assert.equal(labTargetPermitted("192.168.1.53", { authorization: { private_targets: true, ack: "no" } }), false);
-  assert.equal(labTargetPermitted("192.168.1.53", {}), false);
-  // Eligible host but no attestation, or valid attestation but ineligible host.
-  assert.equal(labTargetPermitted("169.254.169.254", { authorization: GOOD }), false);
-  assert.equal(labTargetPermitted("8.8.8.8", { authorization: GOOD }), false);
+test("parseLabAuthorization checks the operator env BEFORE reading attacker input", () => {
+  // A hostile object whose private_targets getter tries to self-enable the env
+  // var as a read side-effect must NOT succeed: the env is read first and we
+  // return before the getter ever runs.
+  withoutLabAck(() => {
+    let getterFired = false;
+    const hostile = {
+      get private_targets() {
+        getterFired = true;
+        process.env[LAB_TARGET_ACK_ENV] = LAB_TARGET_ACK_TOKEN;
+        return true;
+      },
+    };
+    try {
+      assert.equal(parseLabAuthorization(hostile), null);
+      assert.equal(getterFired, false, "env must be checked before reading attacker input");
+    } finally {
+      delete process.env[LAB_TARGET_ACK_ENV];
+    }
+  });
+});
+
+test("labTargetPermitted requires eligibility AND the operator env ack", () => {
+  withLabAck(() => {
+    assert.equal(labTargetPermitted("192.168.1.53", { authorization: INTENT }), true);
+    assert.equal(labTargetPermitted("192.168.1.53", {}), false);
+    // Eligible host but ineligible scope: blocked even with the env + intent.
+    assert.equal(labTargetPermitted("169.254.169.254", { authorization: INTENT }), false);
+    assert.equal(labTargetPermitted("8.8.8.8", { authorization: INTENT }), false);
+  });
+  // Without the operator env, an eligible host + intent is still refused.
+  withoutLabAck(() => {
+    assert.equal(labTargetPermitted("192.168.1.53", { authorization: INTENT }), false);
+  });
 });
 
 test("default public-DNS gate is UNCHANGED without an attestation", () => {
@@ -81,30 +160,40 @@ test("default public-DNS gate is UNCHANGED without an attestation", () => {
 
 test("opts-supplied attestation permits only eligible hosts (init bootstrap path)", () => {
   withTempHome(() => {
-    assert.equal(assertHttpScopeDomain("192.168.1.53", { labAuthorization: GOOD }), "192.168.1.53");
-    assert.equal(assertHttpScopeDomain("127.0.0.1", { labAuthorization: GOOD }), "127.0.0.1");
+    assert.equal(assertHttpScopeDomain("192.168.1.53", { labAuthorization: INTENT }), "192.168.1.53");
+    assert.equal(assertHttpScopeDomain("127.0.0.1", { labAuthorization: INTENT }), "127.0.0.1");
     // Not eligible: blocked even WITH a valid attestation.
-    assert.throws(() => assertHttpScopeDomain("169.254.169.254", { labAuthorization: GOOD }), /not a public DNS domain/);
-    assert.throws(() => assertHttpScopeDomain("8.8.8.8", { labAuthorization: GOOD }), /not a public DNS domain/);
-    // Eligible host but invalid attestation: still rejected.
-    assert.throws(() => assertHttpScopeDomain("192.168.1.53", { labAuthorization: { private_targets: true, ack: "x" } }), /not a public DNS domain/);
+    assert.throws(() => assertHttpScopeDomain("169.254.169.254", { labAuthorization: INTENT }), /not a public DNS domain/);
+    assert.throws(() => assertHttpScopeDomain("8.8.8.8", { labAuthorization: INTENT }), /not a public DNS domain/);
+    // Eligible host but intent not asserted: still rejected.
+    assert.throws(() => assertHttpScopeDomain("192.168.1.53", { labAuthorization: { private_targets: false } }), /not a public DNS domain/);
   });
+  // THE STANDOUT, end-to-end: without the operator env, the SAME intent — and
+  // even the old published token passed as an argument — cannot scope a private
+  // host. A self-authorizing model is rejected by the public-DNS gate.
+  withTempHome(() => {
+    assert.throws(() => assertHttpScopeDomain("192.168.1.53", { labAuthorization: INTENT }), /not a public DNS domain/);
+    assert.throws(
+      () => assertHttpScopeDomain("192.168.1.53", { labAuthorization: { private_targets: true, ack: LAB_TARGET_ACK_TOKEN } }),
+      /not a public DNS domain/,
+    );
+  }, { ack: false });
 });
 
 test("validateHttpScanScope pins scope to the exact attested host", () => {
   withTempHome(() => {
-    const decision = validateHttpScanScope("http://192.168.1.53:8080/admin", "192.168.1.53", { labAuthorization: GOOD });
+    const decision = validateHttpScanScope("http://192.168.1.53:8080/admin", "192.168.1.53", { labAuthorization: INTENT });
     assert.equal(decision.scope_decision, "allowed");
     assert.equal(decision.reason, "lab_attested_private_target");
     assert.equal(decision.target_domain, "192.168.1.53");
     assert.equal(decision.registrable_domain, null);
     // An attested 192.168.1.53 session cannot pivot to any other private host.
     assert.throws(
-      () => validateHttpScanScope("http://10.0.0.9/x", "192.168.1.53", { labAuthorization: GOOD }),
+      () => validateHttpScanScope("http://10.0.0.9/x", "192.168.1.53", { labAuthorization: INTENT }),
       /outside attested lab target/,
     );
     assert.throws(
-      () => validateHttpScanScope("http://169.254.169.254/latest/meta-data/", "192.168.1.53", { labAuthorization: GOOD }),
+      () => validateHttpScanScope("http://169.254.169.254/latest/meta-data/", "192.168.1.53", { labAuthorization: INTENT }),
       /outside attested lab target/,
     );
   });
@@ -117,7 +206,7 @@ test("attestation persists to an audit-graded artifact and is read back without 
     const result = JSON.parse(initSession({
       target_domain: "192.168.1.53",
       target_url: "http://192.168.1.53/",
-      lab_authorization: GOOD,
+      lab_authorization: INTENT,
     }));
     assert.equal(result.created, true);
     // Lab authorization implies allow_internal_hosts (layer-2 egress off-block).
@@ -126,6 +215,10 @@ test("attestation persists to an audit-graded artifact and is read back without 
     const sidecar = path.join(home, "hacker-bob-sessions", "192.168.1.53", "lab-authorization.json");
     assert.equal(fs.existsSync(sidecar), true);
     assert.equal(labAuthorizationPath("192.168.1.53"), sidecar);
+    // The persisted artifact records the env attestation, NOT a token.
+    const persisted = JSON.parse(fs.readFileSync(sidecar, "utf8"));
+    assert.equal(persisted.ack_source, "operator_env");
+    assert.equal(persisted.ack, undefined);
 
     // The scope kernel reads the persisted attestation with NO opts (the scan path).
     assert.equal(assertHttpScopeDomain("192.168.1.53"), "192.168.1.53");
@@ -137,17 +230,30 @@ test("attestation persists to an audit-graded artifact and is read back without 
   });
 });
 
-test("labAuthorizationForTarget fails closed for a missing or forged sidecar", () => {
+test("labAuthorizationForTarget fails closed for a missing sidecar or absent operator env", () => {
+  // No session at all → null (even with the operator env).
   withTempHome(() => {
-    // No session at all.
     assert.equal(labAuthorizationForTarget("192.168.1.53"), null);
-    // Forged sidecar with a bad token → parsed to null.
+  });
+  // A present sidecar is NOT honored unless the operator env ack is set — the
+  // persisted file is an audit record, not a standalone grant. (Forgery of the
+  // file itself is separately prevented by the audit-graded write-guard.)
+  withTempHome(() => {
     const dir = sessionDir("10.1.2.3");
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(labAuthorizationPath("10.1.2.3"), JSON.stringify({ private_targets: true, ack: "forged" }));
+    fs.writeFileSync(labAuthorizationPath("10.1.2.3"), JSON.stringify({ private_targets: true, scope: "rfc1918_loopback_ipv4", ack_source: "operator_env" }));
+    // With the operator env set, the persisted attestation is honored…
+    assert.ok(labAuthorizationForTarget("10.1.2.3"));
+    assert.equal(assertHttpScopeDomain("10.1.2.3"), "10.1.2.3");
+  });
+  withTempHome(() => {
+    const dir = sessionDir("10.1.2.3");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(labAuthorizationPath("10.1.2.3"), JSON.stringify({ private_targets: true, scope: "rfc1918_loopback_ipv4", ack_source: "operator_env" }));
+    // …but WITHOUT it, the same file grants nothing.
     assert.equal(labAuthorizationForTarget("10.1.2.3"), null);
     assert.throws(() => assertHttpScopeDomain("10.1.2.3"), /not a public DNS domain/);
-  });
+  }, { ack: false });
 });
 
 test("lab_authorization cannot be combined with block_internal_hosts", () => {
@@ -157,7 +263,7 @@ test("lab_authorization cannot be combined with block_internal_hosts", () => {
       () => initSession({
         target_domain: "192.168.1.53",
         target_url: "http://192.168.1.53/",
-        lab_authorization: GOOD,
+        lab_authorization: INTENT,
         block_internal_hosts: true,
       }),
       /cannot be combined with block_internal_hosts/,
@@ -174,7 +280,7 @@ test("lab_authorization requires the default (direct) egress profile, not a prox
       () => initSession({
         target_domain: "192.168.1.53",
         target_url: "http://192.168.1.53/",
-        lab_authorization: GOOD,
+        lab_authorization: INTENT,
         egress_profile: "some-proxy",
       }),
       /requires the default \(direct\) egress profile/,
@@ -183,7 +289,7 @@ test("lab_authorization requires the default (direct) egress profile, not a prox
     const ok = initSession({
       target_domain: "192.168.1.54",
       target_url: "http://192.168.1.54/",
-      lab_authorization: GOOD,
+      lab_authorization: INTENT,
       egress_profile: "default",
     });
     assert.equal(JSON.parse(ok).created, true);


### PR DESCRIPTION
## Security fix: lab-target self-authorization

The `bob_init_session` `lab_authorization` escape — the only sanctioned way past the public-DNS scope gate, for operator-owned loopback/RFC1918 lab hosts — was gated by a hard-coded ack token (`i-own-and-am-authorized-to-test-these-private-targets`) that was **published verbatim in the tool schema**. A model that can call `bob_init_session` could read the token from its own schema, self-construct `lab_authorization`, and scope a session to a private IP (e.g. `192.168.1.53`, cloud-internal ranges) with **no operator action** — a self-authorization hole.

## Fix

The attestation now requires `BOB_LAB_TARGET_ACK` (set to the exact token) in the **MCP server's environment** — an operator-only control, since a running model cannot mutate the server process's environment even with shell access in its own process. Specifically:

- The tool argument carries only the **non-secret intent** (`private_targets: true`); the `ack` field and the token are **removed from the `bob_init_session` schema** (`additionalProperties: false`).
- `parseLabAuthorization` reads the env gate **before** any attacker-influenced field of the argument, so a hostile in-process getter can't set the env as a read side-effect.
- All three lab entry points (`assertHttpScopeDomain`, `validateHttpScanScope`, `labTargetPermitted`) route through this single env-gated chokepoint — no ungated path. The persisted `lab-authorization.json` remains audit-graded (write-guarded) and is re-validated against the env on every read.

## Operator path (unchanged capability, new control)

To scan a private lab host you own: `export BOB_LAB_TARGET_ACK=i-own-and-am-authorized-to-test-these-private-targets` before launching the MCP server, then pass `lab_authorization: { "private_targets": true }` to `bob_init_session`. Documented in `docs/FIRST_RUN.md`. Eligibility stays narrow (IPv4 loopback + RFC1918 only; metadata/link-local/IPv6/`.internal` never eligible), scope is pinned to the exact host, and the default (direct) egress profile is required.

## Verification

- **Adversarial red-team** across five channels (argument, persisted-file, chokepoint-bypass, env-gate integrity, eligibility/SSRF) — **no bypass** under the threat model (agent controls all tool arguments/JSON but cannot set the server env).
- Direct: env **unset** + the published token in the argument → rejected (`not a public DNS domain`); env **set** → accepted.
- Tests parameterized over the env states, incl. the getter-side-effect case and the no-env / wrong-env / forged-file paths. Full `npm test` green locally.
