### PR TITLE
ci(brutalist): allow RayyanZahid to trigger the advisory review

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -23,7 +23,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["vmihalis","ejmockler"]'), github.event.pull_request.user.login)
+      contains(fromJSON('["vmihalis","ejmockler","RayyanZahid"]'), github.event.pull_request.user.login)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## What

Adds `RayyanZahid` to the author allowlist in `.github/workflows/brutalist-review.yml` so the advisory Brutalist Review job runs on his PRs instead of skipping.

## Why

The brutalist job is gated to:
1. non-draft PRs, **and**
2. an in-repo head (`head.repo.full_name == github.repository`), **and**
3. author ∈ allowlist.

RayyanZahid is a repo collaborator who pushes branches directly into the repo, so his PRs satisfy (1) and (2) — e.g. #145, whose head is `vmihalis/hacker-bob`. Only the author allowlist (3) failed, so the job reported `skipped`. This adds him to (3).

## Trust note

This job is the credentialed one — it receives `ANTHROPIC_OAUTH_TOKEN` and `CODEX_AUTH` and runs PR-controlled setup steps. Adding an author to the allowlist widens who can trigger credentialed execution. The integrity controls on that step are unchanged: the brutalist-tools `package-lock.json` SHA pin and the immutable `ejmockler/brutalist-mcp@<sha>` action pin both remain.

## Effect on #145

After this merges to `main`, run `gh pr update-branch 145` to recompute its merge ref against the updated `main`; that re-triggers the `pull_request` event and brutalist will run on #145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Brutalist Review workflow configuration to expand the allowed maintainers list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->