### PR TITLE
ci(brutalist): track @v1 moving tag (fleet auto-update)

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -56,9 +56,10 @@ jobs:
         id: brutalist-review
         # Advisory reviewer only; CI remains the hard merge gate.
         continue-on-error: true
-        # Pinned to the immutable v1.15.0 commit SHA, not the mutable tag — this
-        # action receives credentials below, so it must not move.
-        uses: ejmockler/brutalist-mcp/packages/github-action@93b4ec30bf6987970432d7d53662aa28d390a9b0 # v1.15.0
+        # Tracks the moving @v1 tag — repointed to each release by the upstream
+        # move-tags automation — so this repo auto-updates. Trust root is the
+        # owner-controlled ejmockler/brutalist-mcp repo + release pipeline.
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1
         env:
           BRUTALIST_TIMEOUT: "600000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"


### PR DESCRIPTION
## What

Switch the brutalist review action pin from the immutable v1.15.0 commit SHA to the moving **`@v1`** tag, so this repo auto-updates to each new release. The upstream `move-tags` job repoints `@v1` / `@v1.MINOR` on every stable release; `@v1` currently resolves to **v1.15.1**.

## Tradeoff (deliberate)

This reverses the prior "credentialed action stays SHA-pinned" hardening — the action receives `github.token` + OAuth secrets and `@v1` is mutable. Accepted because the action, its release pipeline, and this repo share the **same owner**, so the trust root is unchanged, and fleet-wide auto-update is the goal. Re-pinning to a SHA is a one-line revert if ever needed.

No behavior change beyond auto-tracking; maxTurns stays 50 (v1.15.0+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to reference a semantic version tag instead of a pinned commit, enabling automatic version updates through upstream release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->