### PR TITLE
feat(offensive): PR1 — trusted authed_fetch browser transport (WAF-capable)

### DIFF
--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -83,11 +83,17 @@ existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats
   a wall-clock timeout race + an in-page `AbortSignal.timeout` (no lingering renderer
   request) + a body cap measured in **bytes** (not UTF-16 code units), enforced while
   streaming.
-- **DNS-rebinding pin** — the target host is resolved ONCE in Node and Chrome is launched
-  with `--host-resolver-rules=MAP <host> <validated-ip>`, so the browser connects to the IP
-  we checked (closing the TOCTOU where the static scope check passes but Chrome re-resolves
-  to an internal/attacker IP). Under `block_internal_hosts`, an unpinned host is refused
-  fail-closed. Skipped under an egress proxy (DNS resolves at the proxy).
+- **DNS-rebinding pin (required, not opt-in)** — the target host is resolved ONCE in Node and
+  Chrome is launched with `--host-resolver-rules=MAP <host> <validated-ip>`, so the browser
+  connects to the IP we checked (closing the TOCTOU where the static scope check passes but
+  Chrome would re-resolve to an internal/attacker IP). Because `authed_fetch` is ALWAYS
+  credentialed, the pin is REQUIRED on every call (not just under `block_internal_hosts`): an
+  unpinned host is refused fail-closed so a credentialed request can never ride a rebound
+  hostname. The pin also records whether the resolved IP is internal; under
+  `block_internal_hosts` a pinned-but-internal IP is refused too. **Producer contract:** start
+  the browser session with `target_url` on the exact host you will read, so that host is the
+  one pinned. Under an egress proxy the pin is N/A (DNS resolves at the proxy) and
+  `block_internal_hosts` is refused rather than silently downgraded.
 - **Refuse when `block_internal_hosts` is on** (same SSRF stance as `xss_confirm`, which
   cannot enforce the session SSRF policy through the browser) — the producer refuses; the
   driver's scope+pin checks are defense in depth for a direct call.
@@ -95,10 +101,13 @@ existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats
   hostile target could in principle override `window.fetch`/`Response` to forge the result.
   This is inherent to the transport's purpose (real TLS fingerprint requires the page network
   stack), and a "native fetch capture" was tried and reverted — it is unreliable under the
-  Patchright stealth driver and broke the transport. Compensating controls: `waitUntil:
-  "commit"` minimizes page-script execution before the fetch, and the authed-vs-control
-  DIFFERENTIAL bounds integrity (page code cannot tell which arm it serves; a target forging
-  a vuln against itself is not a coherent threat). A single capture is evidence, not proof.
+  Patchright stealth driver and broke the transport. Compensating control: `waitUntil:
+  "commit"` minimizes page-script execution before the fetch. On integrity, the
+  authed-vs-control differential is NOT tamper-proof — the target CAN tell the authed arm (it
+  carries the cookie) from the control arm and could serve forged data — but a target forging
+  a vuln against ITSELF gains nothing (self-reporting), the per-tool ceiling bounds a forged
+  result, and a single capture is evidence, not proof (the operator corroborates for
+  integrity-sensitive use).
 
 ## Severity ceiling
 
@@ -147,7 +156,8 @@ The manual, fail-closed edits:
 - Auth material flows producer → driver over **stdin, never the env**; each cookie is
   scope-validated against `target_domain` before it reaches the browser context.
 - The browser is DNS-pinned to the Node-validated IP (`--host-resolver-rules`); an unpinned
-  host is refused under `block_internal_hosts`.
+  host is refused on EVERY (always-credentialed) `authed_fetch`, and a pinned-but-internal IP
+  is refused under `block_internal_hosts`.
 - `authed_fetch` does not follow redirects (`redirect:"manual"`), self-aborts on timeout,
   and caps the body in bytes.
 - Page-controlled fetch is an accepted residual (see transport section) — mitigated by

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -160,8 +160,15 @@ The manual, fail-closed edits:
   is refused under `block_internal_hosts`.
 - `authed_fetch` does not follow redirects (`redirect:"manual"`), self-aborts on timeout,
   and caps the body in bytes.
+- The trusted `authed_fetch` op (priming nav + the credentialed fetch) is NOT recorded into
+  the agent-readable network log / record buffer — its cookies/headers never leak to agents.
 - Page-controlled fetch is an accepted residual (see transport section) — mitigated by
   `waitUntil:"commit"` + the differential design, not by an unreliable native-fetch capture.
+- Priming-redirect under `block_internal_hosts` is an accepted residual: a server-driven 3xx
+  during the priming nav could fire one request to an internal host before the drift guard.
+  It is NOT blocked with a catch-all network-route interceptor — that is forbidden (it aborts
+  Kasada/CDN/OAuth subresource loads, defeating the WAF-bypass purpose). Bounded by the
+  producer's refusal under `block_internal_hosts`, the pin, the drift guard, and the scope check.
 - Every request audited via `auditConfirmRequest`; refuse under `block_internal_hosts`.
 - `demonstrated_severity` stamped from the frozen registry, never agent-supplied; the
   per-tool ceiling bounds blast radius to a fabricated HIGH at worst (the #131 same-UID

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -62,21 +62,43 @@ Two separate outputs, by design:
 ## The WAF transport (Chrome + a trusted `authed_fetch`)
 
 The in-process `safeFetch` is Cloudflare-blind (bare Node TLS fingerprint → 403). The
-existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats CF. So:
+existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats CF. So
+(implemented in PR1, hardened across review rounds 2–3):
 
-- **Auth injection at session start** (`mcp/browser-driver.js#start`): seed
-  `context.setExtraHTTPHeaders(...)` and/or `context.addCookies(...)` from the existing
-  `buildHeaderProfile` (`auth.js`). The browser has NO auth path today; this adds one,
-  threaded from the producer (never from an agent).
+- **Auth injection over stdin, never the env** — cookies are sent to the driver AFTER ready
+  via a server-side-only `set_auth_cookies` command (`mcp/lib/browser-sessions.js` →
+  `mcp/browser-driver.js#setAuthCookies`), so auth secrets never touch the process
+  environment (no child/renderer inheritance, no `/proc/<pid>/environ` snapshot). EACH
+  cookie's target host is scope-validated against `target_domain` before it reaches the
+  context — an out-of-scope cookie fails the whole session closed. Threaded from the
+  producer, never an agent.
 - **A trusted `authed_fetch` driver command** — server-side-only, NOT agent-reachable.
-  Issues a scope-checked authenticated request from the page context (`page.evaluate` of a
-  server-built fetch, or `page.request`/`context.request` with the injected auth) and
-  returns the body. The agent-facing `evaluate` sandbox (`FORBIDDEN_EVAL_PATTERN` — no
-  `fetch(`/XHR/WS) stays FULLY CLOSED; only the trusted producer path uses the new
-  command. Mirror the `xss_confirm` scaffolding: `assertSafeResolvedRequestUrl` +
-  read-only-path + final-URL drift guard + `auditConfirmRequest` on every request.
+  Issues a scope-checked authenticated request from the **page world** (`page.evaluate` of a
+  server-built `fetch`) — this is required to carry the real Chrome TLS/HTTP-2 fingerprint;
+  a Node-side `context.request` is CF-403'd like `safeFetch`. The agent-facing `evaluate`
+  sandbox (`FORBIDDEN_EVAL_PATTERN` — no `fetch(`/XHR/WS) stays FULLY CLOSED; only the
+  trusted producer path uses the new command. Scaffolding mirrors `xss_confirm`:
+  `assertSafeResolvedRequestUrl` (URL + origin) + `waitUntil:"commit"` (minimal authed-page
+  execution) + final-URL origin-drift guard + `redirect:"manual"` (no off-scope auth leak) +
+  a wall-clock timeout race + an in-page `AbortSignal.timeout` (no lingering renderer
+  request) + a body cap measured in **bytes** (not UTF-16 code units), enforced while
+  streaming.
+- **DNS-rebinding pin** — the target host is resolved ONCE in Node and Chrome is launched
+  with `--host-resolver-rules=MAP <host> <validated-ip>`, so the browser connects to the IP
+  we checked (closing the TOCTOU where the static scope check passes but Chrome re-resolves
+  to an internal/attacker IP). Under `block_internal_hosts`, an unpinned host is refused
+  fail-closed. Skipped under an egress proxy (DNS resolves at the proxy).
 - **Refuse when `block_internal_hosts` is on** (same SSRF stance as `xss_confirm`, which
-  cannot enforce the session SSRF policy through the browser).
+  cannot enforce the session SSRF policy through the browser) — the producer refuses; the
+  driver's scope+pin checks are defense in depth for a direct call.
+- **ACCEPTED RESIDUAL — page-controlled fetch.** The request runs in the page world, so a
+  hostile target could in principle override `window.fetch`/`Response` to forge the result.
+  This is inherent to the transport's purpose (real TLS fingerprint requires the page network
+  stack), and a "native fetch capture" was tried and reverted — it is unreliable under the
+  Patchright stealth driver and broke the transport. Compensating controls: `waitUntil:
+  "commit"` minimizes page-script execution before the fetch, and the authed-vs-control
+  DIFFERENTIAL bounds integrity (page code cannot tell which arm it serves; a target forging
+  a vuln against itself is not a coherent threat). A single capture is evidence, not proof.
 
 ## Severity ceiling
 
@@ -122,7 +144,14 @@ The manual, fail-closed edits:
 - Full raw capture only when `owner_authorized: true`, to a gitignored operator-managed
   file outside the signed rail.
 - Agent-facing browser `evaluate` sandbox unchanged (no new agent network primitive).
-- Auth material flows producer → driver, never agent → driver.
+- Auth material flows producer → driver over **stdin, never the env**; each cookie is
+  scope-validated against `target_domain` before it reaches the browser context.
+- The browser is DNS-pinned to the Node-validated IP (`--host-resolver-rules`); an unpinned
+  host is refused under `block_internal_hosts`.
+- `authed_fetch` does not follow redirects (`redirect:"manual"`), self-aborts on timeout,
+  and caps the body in bytes.
+- Page-controlled fetch is an accepted residual (see transport section) — mitigated by
+  `waitUntil:"commit"` + the differential design, not by an unreliable native-fetch capture.
 - Every request audited via `auditConfirmRequest`; refuse under `block_internal_hosts`.
 - `demonstrated_severity` stamped from the frozen registry, never agent-supplied; the
   per-tool ceiling bounds blast radius to a fabricated HIGH at worst (the #131 same-UID

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -47,8 +47,8 @@ Two separate outputs, by design:
    booleans + the differential statuses. It is screened by `sensitiveShapesPresent` and
    MUST contain no raw PII. This is the tamper-evident rail that lifts the severity
    ceiling; keeping raw PII here would break the safety screen for every future run
-   (including third-party bug-bounty use where harvesting strangers' data is forbidden —
-   the kinky.nl / `no-PII-harvest` lesson). **Non-negotiable: signed rail stays masked.**
+   (including third-party bug-bounty use where harvesting strangers' data is forbidden — the
+   `no-PII-harvest` lesson). **Non-negotiable: signed rail stays masked.**
 2. **Full evidence capture (`massread-evidence/<run_id>.json`)** — opt-in, operator-owned.
    When the operator confirms the client OWNS the data and authorizes full capture
    (`owner_authorized: true` — explicit, never default; the same tool runs against

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -1,0 +1,127 @@
+# Offensive mass-read producer + WAF browser transport — design
+
+Status: in progress (2026-06-22). Source of the requirement: the sexjobs.nl client
+pentest (crown-jewel F-2 HIGH) found an unauth/under-authorized bulk PII read that the
+signed offensive rail had **no producer for** — the broken-auth/mass-read class. This
+adds that producer, plus the WAF-capable transport it needs (F-2 was only provable
+through Cloudflare via the real-Chrome channel).
+
+## Bug class
+
+**Broken authorization → mass-read of a bulk sensitive collection.** An
+under-authorized identity (unauth, a leaked/guessable credential, or a low-privilege
+account) reads a bulk collection it should not — e.g. `POST /api/fps/listing` returning
+51 production records (emails / phones / IBANs).
+
+## The oracle — `safe_oracle.kind: "differential_response"`, ceiling HIGH
+
+Two requests, both **through the WAF via the real-Chrome browser transport**:
+
+1. **attacker** identity (the under-authorized access) → response A
+2. **control** baseline (denied: unauth, or a deliberately-invalid credential) → response C
+
+**Derive a masked summary in-memory, then DISCARD the raw body:**
+- `record_count` — number of items in the returned collection
+- `sensitive_field_names` — which known-sensitive field *names* appear (`email`, `phone`,
+  `iban`, `ssn`, `dob`, ...). Names only.
+- `pii_shape_present` — booleans from shape-regex run over values; the values are thrown
+  away, only the booleans are kept.
+
+**Positive** requires:
+- attacker: `2xx` AND `record_count ≥ MASSREAD_MIN_RECORDS` (bulk, not a single self-record)
+  AND `≥1` sensitive field shape present
+- control: `401/403` OR `2xx` with `0` records / no sensitive shapes (the control is
+  DENIED the bulk data)
+
+i.e. the attacker reads bulk PII the control cannot — a *differential* that proves an
+authorization failure, not merely a public endpoint.
+
+## The witness — dual output (operator decision, 2026-06-22)
+
+Two separate outputs, by design:
+
+1. **Signed proof row (`offensive-runs.jsonl`)** — ALWAYS masked. The capture hashed and
+   signed contains only `record_count` + `sensitive_field_names` + `pii_shape_present`
+   booleans + the differential statuses. It is screened by `sensitiveShapesPresent` and
+   MUST contain no raw PII. This is the tamper-evident rail that lifts the severity
+   ceiling; keeping raw PII here would break the safety screen for every future run
+   (including third-party bug-bounty use where harvesting strangers' data is forbidden —
+   the kinky.nl / `no-PII-harvest` lesson). **Non-negotiable: signed rail stays masked.**
+2. **Full evidence capture (`massread-evidence/<run_id>.json`)** — opt-in, operator-owned.
+   When the operator confirms the client OWNS the data and authorizes full capture
+   (`owner_authorized: true` — explicit, never default; the same tool runs against
+   third-party bug-bounty targets where this must stay off), the producer ALSO writes the
+   full raw response body to a clearly-marked, **gitignored**, sync-excluded file the
+   operator deletes manually at the end of the engagement. Cautions: the folder must NOT
+   be in any sync/backup path (life-context / openclaw mirrors); deletion is the
+   operator's responsibility. This path is OUTSIDE the signed rail and never feeds the
+   PII-screened capture.
+
+## The WAF transport (Chrome + a trusted `authed_fetch`)
+
+The in-process `safeFetch` is Cloudflare-blind (bare Node TLS fingerprint → 403). The
+existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats CF. So:
+
+- **Auth injection at session start** (`mcp/browser-driver.js#start`): seed
+  `context.setExtraHTTPHeaders(...)` and/or `context.addCookies(...)` from the existing
+  `buildHeaderProfile` (`auth.js`). The browser has NO auth path today; this adds one,
+  threaded from the producer (never from an agent).
+- **A trusted `authed_fetch` driver command** — server-side-only, NOT agent-reachable.
+  Issues a scope-checked authenticated request from the page context (`page.evaluate` of a
+  server-built fetch, or `page.request`/`context.request` with the injected auth) and
+  returns the body. The agent-facing `evaluate` sandbox (`FORBIDDEN_EVAL_PATTERN` — no
+  `fetch(`/XHR/WS) stays FULLY CLOSED; only the trusted producer path uses the new
+  command. Mirror the `xss_confirm` scaffolding: `assertSafeResolvedRequestUrl` +
+  read-only-path + final-URL drift guard + `auditConfirmRequest` on every request.
+- **Refuse when `block_internal_hosts` is on** (same SSRF stance as `xss_confirm`, which
+  cannot enforce the session SSRF policy through the browser).
+
+## Severity ceiling
+
+`bob_http_massread_confirm: "high"` in `OFFENSIVE_TOOL_DEMONSTRATED_CEILING` (claims.js).
+Honest HIGH: mass-read of PII is a HIGH; F-2 was graded HIGH. The producer proves the
+IMPACT (bulk read); the underlying vuln (e.g. a hardcoded credential) is the finding.
+
+## Delivery — two PRs
+
+- **PR1 — browser transport** (this branch's first PR): auth injection + the trusted
+  `authed_fetch` command in `mcp/browser-driver.js` (+ `browser-sessions.js` /
+  `browser-tools-shared.js` plumbing) with its own driver-level tests (local test server).
+  The security-critical, reusable piece, reviewed in isolation.
+- **PR2 — the producer**: `mcp/lib/offensive-massread-producer.js` + the
+  `bob_http_massread_confirm` tool wrapper + the differential oracle + dual-output witness
+  + registration (ceiling, dual authority-class map, tools/index, evaluator prose) +
+  generators + tests.
+
+## Registration surface (PR2) — the load-bearing manual edits
+
+Most of the registry is auto-derived from the tool module's `role_bundles: ["evaluator-web"]`.
+The manual, fail-closed edits:
+- `mcp/lib/claims.js` `OFFENSIVE_TOOL_DEMONSTRATED_CEILING` — add `bob_http_massread_confirm: "high"`.
+- `mcp/lib/session-authority.js` + `scripts/authority-inventory.js` — add the **identical**
+  `bob_http_massread_confirm: "scoped_http_network"` (the two maps must match or
+  `validateExplicitAuthorityMap` throws).
+- `mcp/lib/tools/index.js` — register the module in `TOOL_MODULES` (order-sensitive vs the
+  test's `EXPECTED_TOOL_NAMES`).
+- `prompts/roles/evaluator.md` + `prompts/roles/evaluator-spawn.md` — primitive→producer
+  call-guidance prose (the #150 pattern).
+- Test-fixture bumps (not auto-derived): `test/mcp-server.test.js` `EXPECTED_TOOL_NAMES`,
+  `test/install-smoke.test.js` tool-count, `test/prompt-contracts.test.js` web budget
+  (53→54), new `test/offensive-massread-producer.test.js` + register it in
+  `test/mcp-test-manifest.json`.
+- Generators after metadata: `generate-claude-roles.js` (or the individual agent/skill/
+  settings generators), `generate-codex-skills.js`, `generate-kimi-roles.js`,
+  `authority-inventory.js --write`.
+
+## Safety invariants (must hold)
+
+- Signed rail (`offensive-runs.jsonl`) carries NO raw PII — masked summary only, screened
+  by `sensitiveShapesPresent`, fail-closed.
+- Full raw capture only when `owner_authorized: true`, to a gitignored operator-managed
+  file outside the signed rail.
+- Agent-facing browser `evaluate` sandbox unchanged (no new agent network primitive).
+- Auth material flows producer → driver, never agent → driver.
+- Every request audited via `auditConfirmRequest`; refuse under `block_internal_hosts`.
+- `demonstrated_severity` stamped from the frozen registry, never agent-supplied; the
+  per-tool ceiling bounds blast radius to a fabricated HIGH at worst (the #131 same-UID
+  forge boundary remains the documented, deferred limit).

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -153,15 +153,19 @@ The manual, fail-closed edits:
 - Full raw capture only when `owner_authorized: true`, to a gitignored operator-managed
   file outside the signed rail.
 - Agent-facing browser `evaluate` sandbox unchanged (no new agent network primitive).
-- Auth material flows producer → driver over **stdin, never the env**; each cookie is
-  scope-validated against `target_domain` before it reaches the browser context.
+- Auth material flows producer → driver over **stdin, never the env**, and **only as cookies**
+  (browser-attached, invisible to page JS); each cookie is scope-validated against
+  `target_domain` first. `authed_fetch` REJECTS credential headers (`Authorization`/`Cookie`/
+  `Proxy-Authorization`) because the `headers` param lives in the page world.
 - The browser is DNS-pinned to the Node-validated IP (`--host-resolver-rules`); an unpinned
   host is refused on EVERY (always-credentialed) `authed_fetch`, and a pinned-but-internal IP
   is refused under `block_internal_hosts`.
 - `authed_fetch` does not follow redirects (`redirect:"manual"`), self-aborts on timeout,
   and caps the body in bytes.
-- The trusted `authed_fetch` op (priming nav + the credentialed fetch) is NOT recorded into
-  the agent-readable network log / record buffer — its cookies/headers never leak to agents.
+- The trusted `authed_fetch` op is NOT recorded into the agent-readable network log / record
+  buffer, and once cookies are injected the WHOLE credentialed session is suppressed — so
+  cookies can't leak to agents via a later page request. (Credentialed sessions are
+  producer-only; agent recon runs in uncredentialed sessions.)
 - Page-controlled fetch is an accepted residual (see transport section) — mitigated by
   `waitUntil:"commit"` + the differential design, not by an unreliable native-fetch capture.
 - Priming-redirect under `block_internal_hosts` is an accepted residual: a server-driven 3xx

--- a/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
+++ b/docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md
@@ -1,17 +1,19 @@
 # Offensive mass-read producer + WAF browser transport — design
 
-Status: in progress (2026-06-22). Source of the requirement: the sexjobs.nl client
-pentest (crown-jewel F-2 HIGH) found an unauth/under-authorized bulk PII read that the
-signed offensive rail had **no producer for** — the broken-auth/mass-read class. This
-adds that producer, plus the WAF-capable transport it needs (F-2 was only provable
-through Cloudflare via the real-Chrome channel).
+Status: in progress (2026-06-22). Source of the requirement: a client pentest surfaced an
+unauth/under-authorized bulk-PII read that the signed offensive rail had **no producer
+for** — the broken-auth/mass-read class. This adds that producer, plus the WAF-capable
+transport it needs (the finding was only provable through Cloudflare via the real-Chrome
+channel). (Client/engagement specifics are deliberately omitted — this doc ships in the
+published package.)
 
 ## Bug class
 
 **Broken authorization → mass-read of a bulk sensitive collection.** An
 under-authorized identity (unauth, a leaked/guessable credential, or a low-privilege
-account) reads a bulk collection it should not — e.g. `POST /api/fps/listing` returning
-51 production records (emails / phones / IBANs).
+account) reads a bulk collection it should not — e.g. a listing/search endpoint that
+returns many production records (emails / phones / financial identifiers) to a caller
+that should only see its own.
 
 ## The oracle — `safe_oracle.kind: "differential_response"`, ceiling HIGH
 
@@ -79,7 +81,7 @@ existing Patchright + system-Chrome stack (used by `bob_http_xss_confirm`) beats
 ## Severity ceiling
 
 `bob_http_massread_confirm: "high"` in `OFFENSIVE_TOOL_DEMONSTRATED_CEILING` (claims.js).
-Honest HIGH: mass-read of PII is a HIGH; F-2 was graded HIGH. The producer proves the
+Honest HIGH: mass-read of PII is a HIGH (the motivating finding was graded HIGH). The producer proves the
 IMPACT (bulk read); the underlying vuln (e.g. a hardcoded credential) is the finding.
 
 ## Delivery — two PRs

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -619,14 +619,23 @@ class BrowserDriver {
   async authedFetch(args) {
     const url = String(args && args.url ? args.url : "").trim();
     if (!url) throw new Error("authed_fetch.url is required");
+    // GET, or POST for query-style listing/search endpoints (real mass-read APIs are often
+    // POST). The transport CANNOT verify a POST is non-mutating — read-intent is the
+    // PRODUCER's responsibility (it targets only listing/search surfaces, guarded by
+    // assertReadOnlyPath + the operator), so this is not labelled a read-only guarantee.
     const method = String(args && args.method ? args.method : "GET").toUpperCase();
     if (method !== "GET" && method !== "POST") {
-      throw new Error("authed_fetch.method must be GET or POST (read-intent only)");
+      throw new Error("authed_fetch.method must be GET or POST");
     }
     const headers = args && args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)
       ? args.headers
       : {};
     const body = args && typeof args.body === "string" ? args.body : null;
+    // The producer threads the session block_internal_hosts policy; when on, the scope checks
+    // below reject internal/private resolutions — an AUTHENTICATED request to an internal host
+    // is worse than the unauth navigate default. The producer ALSO refuses to run under this
+    // policy (mirrors bob_http_xss_confirm), so this is defense in depth.
+    const blockInternalHosts = !!(args && args.block_internal_hosts === true);
     let parsed;
     try {
       parsed = new URL(url);
@@ -636,22 +645,22 @@ class BrowserDriver {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       throw new Error("authed_fetch.url must be http(s)");
     }
-    // Scope guard (mirror navigate): the URL must resolve in-scope. block_internal_hosts is
-    // not enforced here — the producer REFUSES to run when that policy is on (it cannot
-    // verify SSRF posture through the browser), mirroring bob_http_xss_confirm.
+    const origin = parsed.origin;
+    // Scope-check BOTH the fetch URL and the origin we navigate to, honoring the policy.
     try {
-      await assertSafeResolvedRequestUrl(url, this.targetDomain, { blockInternalHosts: false });
+      await assertSafeResolvedRequestUrl(url, this.targetDomain, { blockInternalHosts });
+      await assertSafeResolvedRequestUrl(origin, this.targetDomain, { blockInternalHosts });
     } catch (err) {
       const wrapped = new Error(`scope_blocked: ${err && err.message ? err.message : err}`);
       wrapped.code = "scope_blocked";
       throw wrapped;
     }
     const timeout = resolveOpTimeout(args, DEFAULT_NAVIGATE_TIMEOUT_MS);
-    const origin = parsed.origin;
-    // Establish the browser context ON the target origin first (passes the CF challenge,
-    // applies context cookies), then issue a SAME-ORIGIN in-page fetch so the body is
-    // readable (a cross-origin fetch would be CORS-opaque and expose no body).
-    const navResp = await this.page.goto(origin, { waitUntil: "domcontentloaded", timeout });
+    // waitUntil:"commit" returns as soon as the response begins — it minimizes execution of
+    // the (authenticated) origin page's own JS before the in-page fetch. Same-origin context
+    // is still required (a cross-origin fetch would be CORS-opaque), so a minimal navigation
+    // is unavoidable; commit keeps that side-effect surface as small as possible.
+    const navResp = await this.page.goto(origin, { waitUntil: "commit", timeout });
     let landedOrigin = null;
     try { landedOrigin = new URL(this.page.url()).origin; } catch { landedOrigin = null; }
     if (landedOrigin !== origin) {
@@ -660,18 +669,40 @@ class BrowserDriver {
       throw e;
     }
     await randomDelay(150, 400);
-    const fetchInit = { method, headers, credentials: "include" };
+    // redirect:"manual" — do NOT follow redirects: an authenticated request that followed a
+    // 3xx could leak the auth to an OFF-SCOPE origin (the scope check only covers the first
+    // hop). A redirect surfaces as type "opaqueredirect" / status 0, so the producer's 2xx
+    // oracle fails closed.
+    const fetchInit = { method, headers, credentials: "include", redirect: "manual" };
     if (body != null && method !== "GET") fetchInit.body = body;
     // Built server-side from validated inputs; runs in the page world (real Chrome stack).
+    // The body is STREAM-read with a hard cap enforced WHILE reading, so an oversized/hostile
+    // response cannot buffer unbounded memory in the renderer before the slice.
     const expr = `(async () => {
       const __r = await fetch(${JSON.stringify(url)}, ${JSON.stringify(fetchInit)});
-      const __t = await __r.text();
-      return {
-        status: __r.status,
-        final_url: __r.url,
-        body: __t.slice(0, ${MAX_AUTHED_FETCH_BODY_BYTES}),
-        body_truncated: __t.length > ${MAX_AUTHED_FETCH_BODY_BYTES},
-      };
+      const __cap = ${MAX_AUTHED_FETCH_BODY_BYTES};
+      let __acc = "";
+      let __truncated = false;
+      if (__r.body && typeof __r.body.getReader === "function") {
+        const __reader = __r.body.getReader();
+        const __dec = new TextDecoder();
+        for (;;) {
+          const { done, value } = await __reader.read();
+          if (done) break;
+          __acc += __dec.decode(value, { stream: true });
+          if (__acc.length >= __cap) {
+            __acc = __acc.slice(0, __cap);
+            __truncated = true;
+            try { await __reader.cancel(); } catch (e) {}
+            break;
+          }
+        }
+      } else {
+        const __t = await __r.text();
+        __truncated = __t.length > __cap;
+        __acc = __t.slice(0, __cap);
+      }
+      return { status: __r.status, type: __r.type, final_url: __r.url, body: __acc, body_truncated: __truncated };
     })()`;
     // Same wall-clock race as evaluate() so a hung fetch returns a precise timeout instead
     // of pinning the single-page session until the IPC backstop fires.
@@ -699,6 +730,9 @@ class BrowserDriver {
     }
     return {
       status: result && Number.isInteger(result.status) ? result.status : null,
+      // "opaqueredirect" (status 0) means the endpoint 3xx'd and redirect:"manual" refused to
+      // follow it — the producer treats this as non-confirming (not a 2xx bulk read).
+      type: result && result.type ? String(result.type) : null,
       final_url: result && result.final_url ? String(result.final_url) : null,
       body: result && typeof result.body === "string" ? result.body : "",
       body_truncated: !!(result && result.body_truncated),
@@ -882,6 +916,12 @@ async function main() {
     process.exit(2);
     return;
   }
+
+  // Scrub the init env BEFORE launching Chromium so the browser's child/renderer processes
+  // do NOT inherit auth material (cookies) or proxy credentials via their environment. (The
+  // driver's own /proc/environ retains the spawn-time value — the documented same-UID
+  // boundary, #131 — but cross-process child inheritance is the avoidable delta, closed here.)
+  delete process.env.BOB_BROWSER_DRIVER_INIT;
 
   const driver = new BrowserDriver({
     sessionId,

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -52,6 +52,10 @@ const DEFAULT_EVALUATE_TIMEOUT_MS = 15_000;
 const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000;
 const MAX_EVAL_RESULT_BYTES = 256 * 1024;
 const MAX_SNAPSHOT_BYTES = 512 * 1024;
+// Body cap for the trusted `authed_fetch` transport. Generous (2 MiB ≈ thousands of
+// records) because the offensive mass-read producer needs the full collection to derive
+// its masked count/field-shape summary; bodies past the cap return body_truncated:true.
+const MAX_AUTHED_FETCH_BODY_BYTES = 2 * 1024 * 1024;
 // Ceiling on any agent-supplied per-operation timeout, mirroring
 // browser-tools-shared.js. A non-positive value can't disable the bound and a
 // pathological value can't pin the single-page session far past its useful life.
@@ -160,7 +164,7 @@ function sanitizeDomainForPath(domain) {
 // ── Driver core ──
 
 class BrowserDriver {
-  constructor({ sessionId, targetDomain, targetUrl, headless, sessionsRoot, recordMode, proxy }) {
+  constructor({ sessionId, targetDomain, targetUrl, headless, sessionsRoot, recordMode, proxy, authCookies }) {
     this.sessionId = sessionId;
     this.targetDomain = targetDomain;
     this.targetUrl = targetUrl;
@@ -186,6 +190,12 @@ class BrowserDriver {
     this.proxy = proxy && typeof proxy === "object" && typeof proxy.server === "string"
       ? proxy
       : null;
+    // Session-level cookie auth for the trusted `authed_fetch` transport, supplied by the
+    // in-process offensive producer (NEVER by an agent). Playwright cookie-object shape
+    // ({ name, value, domain, path, ... }); applied to the context so an in-page
+    // credentials:"include" fetch carries them. null/empty = unauthenticated (the control
+    // arm of the mass-read differential).
+    this.authCookies = Array.isArray(authCookies) ? authCookies : null;
   }
 
   async start() {
@@ -245,6 +255,13 @@ class BrowserDriver {
       reducedMotion: "no-preference",
       serviceWorkers: "allow",
     });
+
+    // Inject producer-supplied cookie auth (trusted; never agent-supplied) so the
+    // `authed_fetch` in-page fetch carries it via credentials:"include". Bearer/custom
+    // headers are passed per-request in authed_fetch instead.
+    if (this.authCookies && this.authCookies.length) {
+      await this.context.addCookies(this.authCookies);
+    }
 
     await this.installScopedRequestGuard();
     this.page = await this.context.newPage();
@@ -408,6 +425,10 @@ class BrowserDriver {
         return await this.type(args);
       case "evaluate":
         return await this.evaluate(args);
+      case "authed_fetch":
+        // TRUSTED, server-side-only transport — no bob_browser_* MCP tool maps to it, so
+        // an agent cannot reach it; only the in-process offensive mass-read producer does.
+        return await this.authedFetch(args);
       case "network_requests":
         return await this.networkRequests(args);
       case "console_messages":
@@ -588,6 +609,103 @@ class BrowserDriver {
     return { result: safeJsonClone(result, MAX_EVAL_RESULT_BYTES) };
   }
 
+  // TRUSTED, server-side-only transport (NOT agent-reachable — no MCP tool maps to the
+  // "authed_fetch" command). Issues an authenticated request from the PAGE context so it
+  // carries the real Chrome TLS/HTTP-2 fingerprint and survives a WAF/Cloudflare that
+  // 403s safeFetch's bare-Node fingerprint — the gap that left the offensive rail unable
+  // to confirm the broken-auth/mass-read class. The agent-facing `evaluate` sandbox
+  // (FORBIDDEN_EVAL_PATTERN) is UNCHANGED: this builds the fetch expression SERVER-SIDE
+  // from a scope-checked URL + producer-supplied headers and runs it via the trusted path.
+  async authedFetch(args) {
+    const url = String(args && args.url ? args.url : "").trim();
+    if (!url) throw new Error("authed_fetch.url is required");
+    const method = String(args && args.method ? args.method : "GET").toUpperCase();
+    if (method !== "GET" && method !== "POST") {
+      throw new Error("authed_fetch.method must be GET or POST (read-intent only)");
+    }
+    const headers = args && args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)
+      ? args.headers
+      : {};
+    const body = args && typeof args.body === "string" ? args.body : null;
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error("authed_fetch.url is not a valid absolute URL");
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("authed_fetch.url must be http(s)");
+    }
+    // Scope guard (mirror navigate): the URL must resolve in-scope. block_internal_hosts is
+    // not enforced here — the producer REFUSES to run when that policy is on (it cannot
+    // verify SSRF posture through the browser), mirroring bob_http_xss_confirm.
+    try {
+      await assertSafeResolvedRequestUrl(url, this.targetDomain, { blockInternalHosts: false });
+    } catch (err) {
+      const wrapped = new Error(`scope_blocked: ${err && err.message ? err.message : err}`);
+      wrapped.code = "scope_blocked";
+      throw wrapped;
+    }
+    const timeout = resolveOpTimeout(args, DEFAULT_NAVIGATE_TIMEOUT_MS);
+    const origin = parsed.origin;
+    // Establish the browser context ON the target origin first (passes the CF challenge,
+    // applies context cookies), then issue a SAME-ORIGIN in-page fetch so the body is
+    // readable (a cross-origin fetch would be CORS-opaque and expose no body).
+    const navResp = await this.page.goto(origin, { waitUntil: "domcontentloaded", timeout });
+    let landedOrigin = null;
+    try { landedOrigin = new URL(this.page.url()).origin; } catch { landedOrigin = null; }
+    if (landedOrigin !== origin) {
+      const e = new Error(`authed_fetch_origin_drift: landed on ${landedOrigin} not ${origin}`);
+      e.code = "authed_fetch_origin_drift";
+      throw e;
+    }
+    await randomDelay(150, 400);
+    const fetchInit = { method, headers, credentials: "include" };
+    if (body != null && method !== "GET") fetchInit.body = body;
+    // Built server-side from validated inputs; runs in the page world (real Chrome stack).
+    const expr = `(async () => {
+      const __r = await fetch(${JSON.stringify(url)}, ${JSON.stringify(fetchInit)});
+      const __t = await __r.text();
+      return {
+        status: __r.status,
+        final_url: __r.url,
+        body: __t.slice(0, ${MAX_AUTHED_FETCH_BODY_BYTES}),
+        body_truncated: __t.length > ${MAX_AUTHED_FETCH_BODY_BYTES},
+      };
+    })()`;
+    // Same wall-clock race as evaluate() so a hung fetch returns a precise timeout instead
+    // of pinning the single-page session until the IPC backstop fires.
+    const evalPromise = this.page.evaluate(expr);
+    evalPromise.catch(() => {});
+    let timer;
+    let result;
+    try {
+      result = await Promise.race([
+        evalPromise,
+        new Promise((_, reject) => {
+          timer = setTimeout(() => {
+            const e = new Error(`authed_fetch_timeout after ${timeout}ms`);
+            e.code = "authed_fetch_timeout";
+            reject(e);
+          }, timeout);
+          if (timer && typeof timer.unref === "function") timer.unref();
+        }),
+      ]);
+    } catch (err) {
+      if (err && err.code === "authed_fetch_timeout") throw err;
+      throw new Error(`authed_fetch_failed: ${err && err.message ? err.message : err}`);
+    } finally {
+      clearTimeout(timer);
+    }
+    return {
+      status: result && Number.isInteger(result.status) ? result.status : null,
+      final_url: result && result.final_url ? String(result.final_url) : null,
+      body: result && typeof result.body === "string" ? result.body : "",
+      body_truncated: !!(result && result.body_truncated),
+      nav_status: navResp ? navResp.status() : null,
+    };
+  }
+
   async networkRequests(args) {
     const since = Number.isInteger(args && args.since_index) ? Math.max(0, args.since_index) : 0;
     const slice = this.requests.slice(since);
@@ -741,6 +859,10 @@ async function main() {
     && typeof initConfig.proxy.server === "string"
     ? initConfig.proxy
     : null;
+  // Session cookie auth for the trusted authed_fetch transport — supplied by the
+  // in-process offensive producer (never an agent). Pass-through array of Playwright
+  // cookie objects; the driver validates the shape via context.addCookies.
+  const authCookies = Array.isArray(initConfig.auth_cookies) ? initConfig.auth_cookies : null;
 
   if (!targetDomain) {
     writeResponse({ ready: false, error: "init_invalid: target_domain is required" });
@@ -769,6 +891,7 @@ async function main() {
     sessionsRoot,
     recordMode,
     proxy,
+    authCookies,
   });
   try {
     await driver.start();

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -42,6 +42,8 @@ const crypto = require("crypto");
 
 const {
   assertSafeResolvedRequestUrl,
+  assertSafeRequestUrl,
+  resolveSafeAddress,
 } = require("./lib/safe-fetch.js");
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
@@ -164,7 +166,7 @@ function sanitizeDomainForPath(domain) {
 // ── Driver core ──
 
 class BrowserDriver {
-  constructor({ sessionId, targetDomain, targetUrl, headless, sessionsRoot, recordMode, proxy, authCookies }) {
+  constructor({ sessionId, targetDomain, targetUrl, headless, sessionsRoot, recordMode, proxy }) {
     this.sessionId = sessionId;
     this.targetDomain = targetDomain;
     this.targetUrl = targetUrl;
@@ -190,12 +192,17 @@ class BrowserDriver {
     this.proxy = proxy && typeof proxy === "object" && typeof proxy.server === "string"
       ? proxy
       : null;
-    // Session-level cookie auth for the trusted `authed_fetch` transport, supplied by the
-    // in-process offensive producer (NEVER by an agent). Playwright cookie-object shape
-    // ({ name, value, domain, path, ... }); applied to the context so an in-page
-    // credentials:"include" fetch carries them. null/empty = unauthenticated (the control
-    // arm of the mass-read differential).
-    this.authCookies = Array.isArray(authCookies) ? authCookies : null;
+    // DNS-rebinding pin: host(lowercased) -> IP literal that Node validated at launch. The
+    // browser is started with --host-resolver-rules so Chrome connects to the SAME IP we
+    // checked, closing the TOCTOU where the static scope check passes for a hostname but the
+    // browser independently re-resolves it to an internal/attacker IP. Empty under an egress
+    // proxy (DNS resolves at the proxy, not locally) or if launch-time resolution failed.
+    this.pinnedHosts = new Map();
+    // Session-level cookie auth for the trusted `authed_fetch` transport arrives AFTER ready
+    // via the server-side-only `set_auth_cookies` stdin command (never an agent, never the
+    // process environment). null/empty = unauthenticated (the control arm of the mass-read
+    // differential). Tracked only to reject a second, conflicting injection.
+    this.authCookiesApplied = false;
   }
 
   async start() {
@@ -210,6 +217,29 @@ class BrowserDriver {
       throw err;
     }
 
+    // DNS-rebinding pin (round-3): resolve the target host ONCE in Node and force Chrome to
+    // connect to that exact IP via --host-resolver-rules. Without this, the browser does its
+    // own DNS resolution when authed_fetch navigates/fetches, so an attacker-controlled record
+    // could return a public IP to our scope check and a private IP (169.254.169.254 / 127.x)
+    // to Chrome. Skipped under a proxy (egress DNS happens at the proxy). Best-effort: a
+    // resolution failure leaves the host unpinned, and authed_fetch then fails closed under
+    // block_internal_hosts (see authedFetch).
+    const resolverRules = [];
+    if (!this.proxy) {
+      try {
+        const pinHost = new URL(this.targetUrl).hostname.toLowerCase();
+        const { address } = await resolveSafeAddress(pinHost, { blockInternalHosts: false });
+        if (address) {
+          this.pinnedHosts.set(pinHost, address);
+          // Chrome resolver-rules want IPv6 literals bracketed; MAP carries the port through.
+          const ipForRule = address.includes(":") ? `[${address}]` : address;
+          resolverRules.push(`MAP ${pinHost} ${ipForRule}`);
+        }
+      } catch {
+        // leave unpinned — authed_fetch enforces the consequence
+      }
+    }
+
     const launchOptions = {
       headless: this.headless,
       args: [
@@ -221,6 +251,11 @@ class BrowserDriver {
       ],
       ignoreDefaultArgs: ["--enable-automation"],
     };
+    if (resolverRules.length) {
+      // MAP only matches the pinned host; other hosts (CDNs, third-party subresources) still
+      // resolve normally, so this does not break legitimate page loads.
+      launchOptions.args.push(`--host-resolver-rules=${resolverRules.join(",")}`);
+    }
     // Proxy is composed with — not in place of — the anti-detection stack:
     // channel=chrome, the AutomationControlled disable flag, and the
     // ignoreDefaultArgs filter all still apply, so the proxy carries a real
@@ -255,13 +290,6 @@ class BrowserDriver {
       reducedMotion: "no-preference",
       serviceWorkers: "allow",
     });
-
-    // Inject producer-supplied cookie auth (trusted; never agent-supplied) so the
-    // `authed_fetch` in-page fetch carries it via credentials:"include". Bearer/custom
-    // headers are passed per-request in authed_fetch instead.
-    if (this.authCookies && this.authCookies.length) {
-      await this.context.addCookies(this.authCookies);
-    }
 
     await this.installScopedRequestGuard();
     this.page = await this.context.newPage();
@@ -429,6 +457,12 @@ class BrowserDriver {
         // TRUSTED, server-side-only transport — no bob_browser_* MCP tool maps to it, so
         // an agent cannot reach it; only the in-process offensive mass-read producer does.
         return await this.authedFetch(args);
+      case "set_auth_cookies":
+        // TRUSTED, server-side-only — injects producer-supplied cookie auth for the
+        // authed_fetch transport. Like authed_fetch, no bob_browser_* MCP tool maps to it, so
+        // an agent cannot inject auth. Cookies arrive over stdin (never the process env), and
+        // each is scope-validated against target_domain before it reaches the context.
+        return await this.setAuthCookies(args);
       case "network_requests":
         return await this.networkRequests(args);
       case "console_messages":
@@ -609,6 +643,51 @@ class BrowserDriver {
     return { result: safeJsonClone(result, MAX_EVAL_RESULT_BYTES) };
   }
 
+  // TRUSTED, server-side-only — inject producer-supplied cookie auth for authed_fetch.
+  // Cookies arrive over the stdin IPC channel (NEVER the process environment, so no child
+  // process or /proc/<pid>/environ snapshot can leak them), and EACH cookie's target host is
+  // scope-validated against target_domain before it reaches the browser context — an
+  // out-of-scope cookie (one that would be sent to a non-target origin) is rejected fail-closed.
+  async setAuthCookies(args) {
+    const cookies = args && Array.isArray(args.cookies) ? args.cookies : null;
+    if (!cookies || !cookies.length) {
+      throw new Error("set_auth_cookies.cookies must be a non-empty array");
+    }
+    if (this.authCookiesApplied) {
+      // One injection per session: re-injection would let a later call widen the cookie set.
+      throw new Error("set_auth_cookies_already_applied");
+    }
+    for (const cookie of cookies) {
+      if (!cookie || typeof cookie !== "object") {
+        throw new Error("set_auth_cookies: each cookie must be an object");
+      }
+      // Validate where this cookie can be sent. Playwright accepts either a `url` or a
+      // `domain`+`path` pair; both must resolve to an in-scope host or we refuse the whole
+      // batch (a single out-of-scope cookie taints the session).
+      let scopeUrl = null;
+      if (typeof cookie.url === "string" && cookie.url) {
+        scopeUrl = cookie.url;
+      } else if (typeof cookie.domain === "string" && cookie.domain) {
+        const host = cookie.domain.replace(/^\./, "");
+        scopeUrl = `https://${host}${typeof cookie.path === "string" && cookie.path ? cookie.path : "/"}`;
+      } else {
+        throw new Error("set_auth_cookies: each cookie needs a url or a domain");
+      }
+      try {
+        assertSafeRequestUrl(scopeUrl, this.targetDomain);
+      } catch (err) {
+        const e = new Error(
+          `set_auth_cookies_scope_blocked: cookie target ${scopeUrl} is outside ${this.targetDomain}: ${err && err.message ? err.message : err}`,
+        );
+        e.code = "scope_blocked";
+        throw e;
+      }
+    }
+    await this.context.addCookies(cookies);
+    this.authCookiesApplied = true;
+    return { ok: true, count: cookies.length };
+  }
+
   // TRUSTED, server-side-only transport (NOT agent-reachable — no MCP tool maps to the
   // "authed_fetch" command). Issues an authenticated request from the PAGE context so it
   // carries the real Chrome TLS/HTTP-2 fingerprint and survives a WAF/Cloudflare that
@@ -655,6 +734,20 @@ class BrowserDriver {
       wrapped.code = "scope_blocked";
       throw wrapped;
     }
+    // DNS-rebinding enforcement (round-3). When NOT proxied, Chrome resolves DNS itself, so a
+    // scope-passing hostname could still connect to an internal/attacker IP between our check
+    // and the browser's connection. We only consider a host rebind-safe if it was pinned at
+    // launch (--host-resolver-rules pins Chrome to the Node-validated IP). Under
+    // block_internal_hosts an unpinned host is refused fail-closed — we cannot keep the
+    // no-internal-host promise for a host the browser may re-resolve. (Under a proxy, DNS
+    // resolves at the proxy, so the launch pin does not apply and this check is skipped.)
+    if (!this.proxy && blockInternalHosts && !this.pinnedHosts.has(parsed.hostname.toLowerCase())) {
+      const e = new Error(
+        `scope_blocked: authed_fetch host ${parsed.hostname} was not DNS-pinned at launch; refusing under block_internal_hosts (DNS rebinding cannot be ruled out)`,
+      );
+      e.code = "scope_blocked";
+      throw e;
+    }
     const timeout = resolveOpTimeout(args, DEFAULT_NAVIGATE_TIMEOUT_MS);
     // waitUntil:"commit" returns as soon as the response begins — it minimizes execution of
     // the (authenticated) origin page's own JS before the in-page fetch. Same-origin context
@@ -676,33 +769,55 @@ class BrowserDriver {
     const fetchInit = { method, headers, credentials: "include", redirect: "manual" };
     if (body != null && method !== "GET") fetchInit.body = body;
     // Built server-side from validated inputs; runs in the page world (real Chrome stack).
-    // The body is STREAM-read with a hard cap enforced WHILE reading, so an oversized/hostile
-    // response cannot buffer unbounded memory in the renderer before the slice.
+    // Hardening (round-3):
+    //  • self-aborts via AbortSignal.timeout (timeout + grace) so a hung request does not
+    //    linger in the renderer after the wall-clock race rejects — the grace lets the
+    //    deterministic wall-clock timeout win the race while the abort guarantees cleanup;
+    //  • streams the body with a hard cap measured in BYTES (Uint8Array.byteLength), not
+    //    UTF-16 code units, enforced WHILE reading, so an oversized/hostile response cannot
+    //    buffer unbounded memory and "2 MiB" means 2 MiB.
+    // ACCEPTED RESIDUAL — page-controlled fetch: the request runs in the page world, so a
+    // hostile target page could in principle override window.fetch / Response to forge the
+    // result. This is INHERENT to the transport's purpose: carrying the real Chrome TLS/HTTP-2
+    // fingerprint REQUIRES the page network stack (a Node-side context.request is CF-403'd —
+    // the gap this transport exists to close), and capturing a "native" fetch reference is
+    // unreliable under the Patchright stealth driver (its fetch wrapper rejects a detached
+    // call). Compensating controls: waitUntil:"commit" minimizes page-script execution before
+    // the fetch, and the authed-vs-control DIFFERENTIAL bounds the integrity impact — page
+    // code cannot tell which arm it is serving, and a target forging a vuln against itself is
+    // not a coherent threat. The producer treats a single capture as evidence, not proof.
+    const fetchInitJson = JSON.stringify(fetchInit);
+    const inPageAbortMs = timeout + 1000;
     const expr = `(async () => {
-      const __r = await fetch(${JSON.stringify(url)}, ${JSON.stringify(fetchInit)});
+      const __init = ${fetchInitJson};
+      try { __init.signal = AbortSignal.timeout(${inPageAbortMs}); } catch (e) {}
+      const __r = await fetch(${JSON.stringify(url)}, __init);
       const __cap = ${MAX_AUTHED_FETCH_BODY_BYTES};
-      let __acc = "";
+      let __bytes = 0;
       let __truncated = false;
+      const __dec = new TextDecoder();
+      const __parts = [];
       if (__r.body && typeof __r.body.getReader === "function") {
         const __reader = __r.body.getReader();
-        const __dec = new TextDecoder();
         for (;;) {
           const { done, value } = await __reader.read();
           if (done) break;
-          __acc += __dec.decode(value, { stream: true });
-          if (__acc.length >= __cap) {
-            __acc = __acc.slice(0, __cap);
+          let __chunk = value;
+          if (__bytes + __chunk.byteLength > __cap) {
+            __chunk = __chunk.subarray(0, __cap - __bytes);
             __truncated = true;
-            try { await __reader.cancel(); } catch (e) {}
-            break;
           }
+          __bytes += __chunk.byteLength;
+          __parts.push(__dec.decode(__chunk, { stream: true }));
+          if (__truncated) { try { await __reader.cancel(); } catch (e) {} break; }
         }
+        __parts.push(__dec.decode());
       } else {
-        const __t = await __r.text();
-        __truncated = __t.length > __cap;
-        __acc = __t.slice(0, __cap);
+        const __buf = new Uint8Array(await __r.arrayBuffer());
+        __truncated = __buf.byteLength > __cap;
+        __parts.push(__dec.decode(__buf.subarray(0, __cap)));
       }
-      return { status: __r.status, type: __r.type, final_url: __r.url, body: __acc, body_truncated: __truncated };
+      return { status: __r.status, type: __r.type, final_url: __r.url, body: __parts.join(""), body_truncated: __truncated };
     })()`;
     // Same wall-clock race as evaluate() so a hung fetch returns a precise timeout instead
     // of pinning the single-page session until the IPC backstop fires.
@@ -893,10 +1008,10 @@ async function main() {
     && typeof initConfig.proxy.server === "string"
     ? initConfig.proxy
     : null;
-  // Session cookie auth for the trusted authed_fetch transport — supplied by the
-  // in-process offensive producer (never an agent). Pass-through array of Playwright
-  // cookie objects; the driver validates the shape via context.addCookies.
-  const authCookies = Array.isArray(initConfig.auth_cookies) ? initConfig.auth_cookies : null;
+  // NOTE: cookie auth for the trusted authed_fetch transport is NO LONGER carried in the init
+  // env — it arrives after ready via the server-side-only `set_auth_cookies` stdin command, so
+  // auth secrets never touch the process environment (no child/renderer inheritance, no
+  // /proc/<pid>/environ snapshot).
 
   if (!targetDomain) {
     writeResponse({ ready: false, error: "init_invalid: target_domain is required" });
@@ -917,10 +1032,11 @@ async function main() {
     return;
   }
 
-  // Scrub the init env BEFORE launching Chromium so the browser's child/renderer processes
-  // do NOT inherit auth material (cookies) or proxy credentials via their environment. (The
-  // driver's own /proc/environ retains the spawn-time value — the documented same-UID
-  // boundary, #131 — but cross-process child inheritance is the avoidable delta, closed here.)
+  // Scrub the init env BEFORE launching Chromium so the browser's child/renderer processes do
+  // NOT inherit proxy credentials via their environment. (The driver's own /proc/environ
+  // retains the spawn-time value — the documented same-UID boundary, #131 — but cross-process
+  // child inheritance is the avoidable delta, closed here. Cookie auth is no longer in the env
+  // at all; it arrives over stdin via set_auth_cookies.)
   delete process.env.BOB_BROWSER_DRIVER_INIT;
 
   const driver = new BrowserDriver({
@@ -931,7 +1047,6 @@ async function main() {
     sessionsRoot,
     recordMode,
     proxy,
-    authCookies,
   });
   try {
     await driver.start();

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -749,29 +749,37 @@ class BrowserDriver {
       wrapped.code = "scope_blocked";
       throw wrapped;
     }
-    // DNS-rebinding + internal-host enforcement (round-3/4). The launch pin makes Chrome
-    // connect to the IP we resolved (no re-resolution), but only for the pinned host and only
-    // when not proxied. So under block_internal_hosts:
-    if (blockInternalHosts) {
-      if (this.proxy) {
-        // DNS resolves at the proxy — we cannot pin or vet the IP the browser connects to, so
-        // refuse rather than let block_internal_hosts silently degrade to advisory.
+    // DNS-rebinding + internal-host enforcement (round-3/4/5). The launch pin makes Chrome
+    // connect to the IP we resolved (no re-resolution), but only for the pinned host. Because
+    // authed_fetch is ALWAYS credentialed, the pin is REQUIRED on every call (not opt-in under
+    // block_internal_hosts): a credentialed request must never ride an attacker-rebound
+    // hostname to a different IP. The producer therefore starts the session with target_url on
+    // the exact host it will read, so that host is the one pinned at launch.
+    const fetchHost = parsed.hostname.toLowerCase();
+    if (this.proxy) {
+      // Under an egress proxy, DNS resolves at the proxy — we cannot pin or vet the IP the
+      // browser connects to. We can't keep the no-internal-host promise, so refuse it; without
+      // it, proxied egress is the operator's deliberate, trusted config.
+      if (blockInternalHosts) {
         const e = new Error(
           "scope_blocked: authed_fetch cannot enforce block_internal_hosts through an egress proxy (DNS resolves at the proxy)",
         );
         e.code = "scope_blocked";
         throw e;
       }
-      const pin = this.pinnedHosts.get(parsed.hostname.toLowerCase());
+    } else {
+      const pin = this.pinnedHosts.get(fetchHost);
       if (!pin) {
-        // Unpinned host: the browser would re-resolve it, so we cannot rule out a rebind.
+        // Not pinned at launch → the browser would re-resolve it, so a credentialed fetch could
+        // ride a rebind. Refuse ALWAYS (the round-4 hole: this was only enforced under
+        // block_internal_hosts, leaving the default path rebindable).
         const e = new Error(
-          `scope_blocked: authed_fetch host ${parsed.hostname} was not DNS-pinned at launch; refusing under block_internal_hosts (DNS rebinding cannot be ruled out)`,
+          `scope_blocked: authed_fetch host ${parsed.hostname} was not DNS-pinned at launch; a credentialed fetch must target the pinned host (start the session with target_url on this host)`,
         );
         e.code = "scope_blocked";
         throw e;
       }
-      if (pin.internal) {
+      if (blockInternalHosts && pin.internal) {
         // The pinned IP itself is private/blocked — being pinned is not enough; the no-internal
         // promise must reject it (this is the round-3 hole: a presence-only check passed here).
         const e = new Error(
@@ -818,9 +826,11 @@ class BrowserDriver {
     // the gap this transport exists to close), and capturing a "native" fetch reference is
     // unreliable under the Patchright stealth driver (its fetch wrapper rejects a detached
     // call). Compensating controls: waitUntil:"commit" minimizes page-script execution before
-    // the fetch, and the authed-vs-control DIFFERENTIAL bounds the integrity impact — page
-    // code cannot tell which arm it is serving, and a target forging a vuln against itself is
-    // not a coherent threat. The producer treats a single capture as evidence, not proof.
+    // the fetch. On integrity, the differential is NOT tamper-proof — the target can tell the
+    // authed arm (it carries the cookie) from the control arm and could serve forged data — but
+    // a target forging a vuln against ITSELF gains nothing (it would be self-reporting), the
+    // per-tool ceiling bounds a forged result, and the producer treats a single capture as
+    // evidence, not proof (the operator corroborates for integrity-sensitive use).
     const fetchInitJson = JSON.stringify(fetchInit);
     const expr = `(async () => {
       const __cap = ${MAX_AUTHED_FETCH_BODY_BYTES};

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -45,6 +45,7 @@ const {
   assertSafeRequestUrl,
   resolveSafeAddress,
 } = require("./lib/safe-fetch.js");
+const { isBlockedInternalHost } = require("./lib/url-surface.js");
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const HARD_TIMEOUT_MS = 30 * 60 * 1000;
@@ -192,11 +193,13 @@ class BrowserDriver {
     this.proxy = proxy && typeof proxy === "object" && typeof proxy.server === "string"
       ? proxy
       : null;
-    // DNS-rebinding pin: host(lowercased) -> IP literal that Node validated at launch. The
-    // browser is started with --host-resolver-rules so Chrome connects to the SAME IP we
-    // checked, closing the TOCTOU where the static scope check passes for a hostname but the
-    // browser independently re-resolves it to an internal/attacker IP. Empty under an egress
-    // proxy (DNS resolves at the proxy, not locally) or if launch-time resolution failed.
+    // DNS-rebinding pin: host(lowercased) -> { address, internal }. The browser is started with
+    // --host-resolver-rules so Chrome connects to the SAME IP we resolved at launch, closing the
+    // TOCTOU where the static scope check passes for a hostname but the browser independently
+    // re-resolves it to an internal/attacker IP. `internal` records whether that pinned IP is a
+    // private/blocked address so authed_fetch can refuse it under block_internal_hosts (presence
+    // alone must NOT satisfy the no-internal-host promise). Empty under an egress proxy (DNS
+    // resolves at the proxy, not locally) or if launch-time resolution failed.
     this.pinnedHosts = new Map();
     // Session-level cookie auth for the trusted `authed_fetch` transport arrives AFTER ready
     // via the server-side-only `set_auth_cookies` stdin command (never an agent, never the
@@ -228,9 +231,13 @@ class BrowserDriver {
     if (!this.proxy) {
       try {
         const pinHost = new URL(this.targetUrl).hostname.toLowerCase();
+        // Resolve WITHOUT throwing on internal so we can pin loopback in tests / policy-off
+        // sessions, but RECORD whether the pinned IP is internal so the authed_fetch guard can
+        // refuse it under block_internal_hosts (a pin to a private IP must NOT satisfy the
+        // no-internal-host promise just by being present).
         const { address } = await resolveSafeAddress(pinHost, { blockInternalHosts: false });
         if (address) {
-          this.pinnedHosts.set(pinHost, address);
+          this.pinnedHosts.set(pinHost, { address, internal: isBlockedInternalHost(address) });
           // Chrome resolver-rules want IPv6 literals bracketed; MAP carries the port through.
           const ipForRule = address.includes(":") ? `[${address}]` : address;
           resolverRules.push(`MAP ${pinHost} ${ipForRule}`);
@@ -661,13 +668,21 @@ class BrowserDriver {
       if (!cookie || typeof cookie !== "object") {
         throw new Error("set_auth_cookies: each cookie must be an object");
       }
-      // Validate where this cookie can be sent. Playwright accepts either a `url` or a
-      // `domain`+`path` pair; both must resolve to an in-scope host or we refuse the whole
-      // batch (a single out-of-scope cookie taints the session).
+      const hasUrl = typeof cookie.url === "string" && cookie.url;
+      const hasDomain = typeof cookie.domain === "string" && cookie.domain;
+      // Reject the ambiguous both-set form: with both `url` and `domain`, Playwright picks one
+      // and our scope check could validate a different target than what is actually written.
+      // Require exactly one so the validated host == the host the cookie is sent to.
+      if (hasUrl && hasDomain) {
+        throw new Error("set_auth_cookies: a cookie must set EITHER url OR domain, not both");
+      }
+      // Validate the EXACT host the cookie will be sent to: url.host, or the de-dotted domain
+      // (a leading-dot domain also covers subdomains — in scope iff the de-dotted host is). One
+      // out-of-scope cookie taints the session, so we refuse the whole batch.
       let scopeUrl = null;
-      if (typeof cookie.url === "string" && cookie.url) {
+      if (hasUrl) {
         scopeUrl = cookie.url;
-      } else if (typeof cookie.domain === "string" && cookie.domain) {
+      } else if (hasDomain) {
         const host = cookie.domain.replace(/^\./, "");
         scopeUrl = `https://${host}${typeof cookie.path === "string" && cookie.path ? cookie.path : "/"}`;
       } else {
@@ -734,19 +749,37 @@ class BrowserDriver {
       wrapped.code = "scope_blocked";
       throw wrapped;
     }
-    // DNS-rebinding enforcement (round-3). When NOT proxied, Chrome resolves DNS itself, so a
-    // scope-passing hostname could still connect to an internal/attacker IP between our check
-    // and the browser's connection. We only consider a host rebind-safe if it was pinned at
-    // launch (--host-resolver-rules pins Chrome to the Node-validated IP). Under
-    // block_internal_hosts an unpinned host is refused fail-closed — we cannot keep the
-    // no-internal-host promise for a host the browser may re-resolve. (Under a proxy, DNS
-    // resolves at the proxy, so the launch pin does not apply and this check is skipped.)
-    if (!this.proxy && blockInternalHosts && !this.pinnedHosts.has(parsed.hostname.toLowerCase())) {
-      const e = new Error(
-        `scope_blocked: authed_fetch host ${parsed.hostname} was not DNS-pinned at launch; refusing under block_internal_hosts (DNS rebinding cannot be ruled out)`,
-      );
-      e.code = "scope_blocked";
-      throw e;
+    // DNS-rebinding + internal-host enforcement (round-3/4). The launch pin makes Chrome
+    // connect to the IP we resolved (no re-resolution), but only for the pinned host and only
+    // when not proxied. So under block_internal_hosts:
+    if (blockInternalHosts) {
+      if (this.proxy) {
+        // DNS resolves at the proxy — we cannot pin or vet the IP the browser connects to, so
+        // refuse rather than let block_internal_hosts silently degrade to advisory.
+        const e = new Error(
+          "scope_blocked: authed_fetch cannot enforce block_internal_hosts through an egress proxy (DNS resolves at the proxy)",
+        );
+        e.code = "scope_blocked";
+        throw e;
+      }
+      const pin = this.pinnedHosts.get(parsed.hostname.toLowerCase());
+      if (!pin) {
+        // Unpinned host: the browser would re-resolve it, so we cannot rule out a rebind.
+        const e = new Error(
+          `scope_blocked: authed_fetch host ${parsed.hostname} was not DNS-pinned at launch; refusing under block_internal_hosts (DNS rebinding cannot be ruled out)`,
+        );
+        e.code = "scope_blocked";
+        throw e;
+      }
+      if (pin.internal) {
+        // The pinned IP itself is private/blocked — being pinned is not enough; the no-internal
+        // promise must reject it (this is the round-3 hole: a presence-only check passed here).
+        const e = new Error(
+          `scope_blocked: authed_fetch host ${parsed.hostname} pins to an internal address; refusing under block_internal_hosts`,
+        );
+        e.code = "scope_blocked";
+        throw e;
+      }
     }
     const timeout = resolveOpTimeout(args, DEFAULT_NAVIGATE_TIMEOUT_MS);
     // waitUntil:"commit" returns as soon as the response begins — it minimizes execution of
@@ -769,10 +802,12 @@ class BrowserDriver {
     const fetchInit = { method, headers, credentials: "include", redirect: "manual" };
     if (body != null && method !== "GET") fetchInit.body = body;
     // Built server-side from validated inputs; runs in the page world (real Chrome stack).
-    // Hardening (round-3):
-    //  • self-aborts via AbortSignal.timeout (timeout + grace) so a hung request does not
-    //    linger in the renderer after the wall-clock race rejects — the grace lets the
-    //    deterministic wall-clock timeout win the race while the abort guarantees cleanup;
+    // Hardening:
+    //  • self-aborts via AbortSignal.timeout AT the deadline so the authenticated request is
+    //    actually cancelled in the renderer (not left running after the caller is told it timed
+    //    out). The in-page catch converts that abort into a { __timeout: true } sentinel so the
+    //    timeout is surfaced deterministically (no fragile error-message matching); the
+    //    wall-clock race below remains a backstop for a page.evaluate that hangs entirely.
     //  • streams the body with a hard cap measured in BYTES (Uint8Array.byteLength), not
     //    UTF-16 code units, enforced WHILE reading, so an oversized/hostile response cannot
     //    buffer unbounded memory and "2 MiB" means 2 MiB.
@@ -787,37 +822,41 @@ class BrowserDriver {
     // code cannot tell which arm it is serving, and a target forging a vuln against itself is
     // not a coherent threat. The producer treats a single capture as evidence, not proof.
     const fetchInitJson = JSON.stringify(fetchInit);
-    const inPageAbortMs = timeout + 1000;
     const expr = `(async () => {
-      const __init = ${fetchInitJson};
-      try { __init.signal = AbortSignal.timeout(${inPageAbortMs}); } catch (e) {}
-      const __r = await fetch(${JSON.stringify(url)}, __init);
       const __cap = ${MAX_AUTHED_FETCH_BODY_BYTES};
-      let __bytes = 0;
-      let __truncated = false;
-      const __dec = new TextDecoder();
-      const __parts = [];
-      if (__r.body && typeof __r.body.getReader === "function") {
-        const __reader = __r.body.getReader();
-        for (;;) {
-          const { done, value } = await __reader.read();
-          if (done) break;
-          let __chunk = value;
-          if (__bytes + __chunk.byteLength > __cap) {
-            __chunk = __chunk.subarray(0, __cap - __bytes);
-            __truncated = true;
+      const __init = ${fetchInitJson};
+      try { __init.signal = AbortSignal.timeout(${timeout}); } catch (e) {}
+      try {
+        const __r = await fetch(${JSON.stringify(url)}, __init);
+        let __bytes = 0;
+        let __truncated = false;
+        const __dec = new TextDecoder();
+        const __parts = [];
+        if (__r.body && typeof __r.body.getReader === "function") {
+          const __reader = __r.body.getReader();
+          for (;;) {
+            const { done, value } = await __reader.read();
+            if (done) break;
+            let __chunk = value;
+            if (__bytes + __chunk.byteLength > __cap) {
+              __chunk = __chunk.subarray(0, __cap - __bytes);
+              __truncated = true;
+            }
+            __bytes += __chunk.byteLength;
+            __parts.push(__dec.decode(__chunk, { stream: true }));
+            if (__truncated) { try { await __reader.cancel(); } catch (e) {} break; }
           }
-          __bytes += __chunk.byteLength;
-          __parts.push(__dec.decode(__chunk, { stream: true }));
-          if (__truncated) { try { await __reader.cancel(); } catch (e) {} break; }
+          __parts.push(__dec.decode());
+        } else {
+          const __buf = new Uint8Array(await __r.arrayBuffer());
+          __truncated = __buf.byteLength > __cap;
+          __parts.push(__dec.decode(__buf.subarray(0, __cap)));
         }
-        __parts.push(__dec.decode());
-      } else {
-        const __buf = new Uint8Array(await __r.arrayBuffer());
-        __truncated = __buf.byteLength > __cap;
-        __parts.push(__dec.decode(__buf.subarray(0, __cap)));
+        return { status: __r.status, type: __r.type, final_url: __r.url, body: __parts.join(""), body_truncated: __truncated };
+      } catch (e) {
+        if (e && (e.name === "TimeoutError" || e.name === "AbortError")) return { __timeout: true };
+        throw e;
       }
-      return { status: __r.status, type: __r.type, final_url: __r.url, body: __parts.join(""), body_truncated: __truncated };
     })()`;
     // Same wall-clock race as evaluate() so a hung fetch returns a precise timeout instead
     // of pinning the single-page session until the IPC backstop fires.
@@ -842,6 +881,12 @@ class BrowserDriver {
       throw new Error(`authed_fetch_failed: ${err && err.message ? err.message : err}`);
     } finally {
       clearTimeout(timer);
+    }
+    if (result && result.__timeout) {
+      // The in-page AbortSignal.timeout fired AT the deadline and cancelled the fetch.
+      const e = new Error(`authed_fetch_timeout after ${timeout}ms`);
+      e.code = "authed_fetch_timeout";
+      throw e;
     }
     return {
       status: result && Number.isInteger(result.status) ? result.status : null,

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -211,6 +211,11 @@ class BrowserDriver {
     // idle. (NOT a network interceptor — see the no-context.route invariant in
     // browser-driver-tools.test.js; the host is kept for diagnostics only.)
     this.authedFetchOp = null;
+    // Once set_auth_cookies injects cookies, the context is credentialed for the rest of its
+    // life — EVERY subsequent request carries them. A credentialed session is producer-only
+    // (never agent recon), so we suppress request logging for the whole session, not just the
+    // authed_fetch op, so cookies can't leak into the agent log via a later page request.
+    this.credentialedSession = false;
   }
 
   async start() {
@@ -339,11 +344,12 @@ class BrowserDriver {
 
   attachListeners() {
     this.page.on("request", (request) => {
-      // Do NOT record the trusted authed_fetch op (priming nav + the credentialed fetch): its
-      // headers/cookies carry the producer's auth material and must not leak into the
-      // agent-readable request log or the record-mode buffer (which is flushed to the audit
-      // trail). These are server-side producer requests, not agent-observable recon traffic.
-      if (this.authedFetchOp) return;
+      // Do NOT record the trusted authed_fetch op (priming nav + the credentialed fetch), nor
+      // ANY request once the session is credentialed (cookies injected) — their headers/cookies
+      // carry the producer's auth and must not leak into the agent-readable request log or the
+      // record-mode buffer (flushed to the audit trail). A credentialed session is producer-only,
+      // so suppressing its whole log is correct; agent recon runs in uncredentialed sessions.
+      if (this.authedFetchOp || this.credentialedSession) return;
       const headers = {};
       try {
         const raw = request.headers() || {};
@@ -710,6 +716,9 @@ class BrowserDriver {
     }
     await this.context.addCookies(cookies);
     this.authCookiesApplied = true;
+    // The context is now credentialed — suppress request logging for the rest of the session
+    // so injected cookies can't leak into the agent-readable log via any later page request.
+    this.credentialedSession = true;
     return { ok: true, count: cookies.length };
   }
 
@@ -734,6 +743,19 @@ class BrowserDriver {
     const headers = args && args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)
       ? args.headers
       : {};
+    // Credentials must flow via set_auth_cookies — the browser attaches cookies at the network
+    // layer, invisible to page JS. The `headers` param, by contrast, is serialized into the
+    // in-page fetch init and therefore lives in the page world, where a page-overridden fetch
+    // could read it. Reject credential headers so a producer cannot accidentally expose a
+    // bearer/cookie to a hostile target page.
+    for (const hname of Object.keys(headers)) {
+      const lower = hname.toLowerCase();
+      if (lower === "authorization" || lower === "cookie" || lower === "proxy-authorization") {
+        throw new Error(
+          `authed_fetch: the ${hname} header is not allowed — use set_auth_cookies for credentials (the headers param is visible to the page world)`,
+        );
+      }
+    }
     const body = args && typeof args.body === "string" ? args.body : null;
     // The producer threads the session block_internal_hosts policy; when on, the scope checks
     // below reject internal/private resolutions — an AUTHENTICATED request to an internal host
@@ -856,15 +878,18 @@ class BrowserDriver {
     //    UTF-16 code units, enforced WHILE reading, so an oversized/hostile response cannot
     //    buffer unbounded memory and "2 MiB" means 2 MiB.
     // ACCEPTED RESIDUAL — page-controlled fetch: the request runs in the page world, so a
-    // hostile target page could in principle override window.fetch / Response to forge the
-    // result. This is INHERENT to the transport's purpose: carrying the real Chrome TLS/HTTP-2
-    // fingerprint REQUIRES the page network stack (a Node-side context.request is CF-403'd —
-    // the gap this transport exists to close), and capturing a "native" fetch reference is
-    // unreliable under the Patchright stealth driver (its fetch wrapper rejects a detached
-    // call). Compensating controls: waitUntil:"commit" minimizes page-script execution before
-    // the fetch. On integrity, the differential is NOT tamper-proof — the target can tell the
-    // authed arm (it carries the cookie) from the control arm and could serve forged data — but
-    // a target forging a vuln against ITSELF gains nothing (it would be self-reporting), the
+    // hostile target page could in principle override window.fetch / Response (or register a
+    // service worker) to forge the result. This is INHERENT to the transport's purpose: carrying
+    // the real Chrome TLS/HTTP-2 fingerprint REQUIRES the page network stack (a Node-side
+    // context.request is CF-403'd — the gap this transport exists to close), and capturing a
+    // "native" fetch reference is unreliable under the Patchright stealth driver (its fetch
+    // wrapper rejects a detached call). Note credentials are NOT exposed by this residual:
+    // cookie auth is browser-attached (not in page JS) and authed_fetch REJECTS credential
+    // headers, so a page-overridden fetch sees a request body/result but no bearer/cookie.
+    // Compensating controls: waitUntil:"commit" minimizes page-script execution before the
+    // fetch. On integrity, the differential is NOT tamper-proof — the target can tell the authed
+    // arm (it carries the cookie) from the control arm and could serve forged data — but a
+    // target forging a vuln against ITSELF gains nothing (it would be self-reporting), the
     // per-tool ceiling bounds a forged result, and the producer treats a single capture as
     // evidence, not proof (the operator corroborates for integrity-sensitive use).
     const fetchInitJson = JSON.stringify(fetchInit);

--- a/mcp/browser-driver.js
+++ b/mcp/browser-driver.js
@@ -206,6 +206,11 @@ class BrowserDriver {
     // process environment). null/empty = unauthenticated (the control arm of the mass-read
     // differential). Tracked only to reject a second, conflicting injection.
     this.authCookiesApplied = false;
+    // Set to { host } for the duration of a trusted authed_fetch op so attachListeners() skips
+    // recording its (credentialed) requests into the agent-readable log / record buffer. null =
+    // idle. (NOT a network interceptor — see the no-context.route invariant in
+    // browser-driver-tools.test.js; the host is kept for diagnostics only.)
+    this.authedFetchOp = null;
   }
 
   async start() {
@@ -334,6 +339,11 @@ class BrowserDriver {
 
   attachListeners() {
     this.page.on("request", (request) => {
+      // Do NOT record the trusted authed_fetch op (priming nav + the credentialed fetch): its
+      // headers/cookies carry the producer's auth material and must not leak into the
+      // agent-readable request log or the record-mode buffer (which is flushed to the audit
+      // trail). These are server-side producer requests, not agent-observable recon traffic.
+      if (this.authedFetchOp) return;
       const headers = {};
       try {
         const raw = request.headers() || {};
@@ -790,6 +800,32 @@ class BrowserDriver {
       }
     }
     const timeout = resolveOpTimeout(args, DEFAULT_NAVIGATE_TIMEOUT_MS);
+    // Trusted-op flag: suppress logging of the priming nav + the credentialed fetch from the
+    // agent-readable request log / record buffer (they carry the producer's auth). Cleared in
+    // the finally so a thrown op can't leave logging suppressed for later agent traffic.
+    //
+    // ACCEPTED RESIDUAL — priming redirect under block_internal_hosts: page.goto follows
+    // redirects, so a server-driven 3xx to an internal host could fire ONE request before the
+    // origin-drift guard rejects the fetch. We deliberately do NOT block it with a catch-all
+    // network-route interceptor — that is forbidden (browser-driver-tools.test.js): such an
+    // interceptor aborts page-decided subresource loads (Kasada/Akamai anti-bot, CDN bundles,
+    // OAuth callbacks), the exact WAF-protected flows this transport exists to survive, so it
+    // would defeat the transport's purpose. Bounded instead by: the producer REFUSES under
+    // block_internal_hosts (this is a direct-driver defense-in-depth path); the pin connects the
+    // target host to a validated IP; the origin-drift guard refuses the fetch after any
+    // redirect; and the scope check validates the URL's resolved IP under block_internal_hosts.
+    this.authedFetchOp = { host: fetchHost };
+    try {
+      return await this.runAuthedFetchOp({ origin, url, method, headers, body, timeout });
+    } finally {
+      this.authedFetchOp = null;
+    }
+  }
+
+  // Executes the priming navigation + the in-page credentialed fetch for authedFetch(). Split
+  // out so authedFetch() can wrap it in the trusted-op guards (request-log suppression + the
+  // strict per-host request abort) with a single try/finally cleanup.
+  async runAuthedFetchOp({ origin, url, method, headers, body, timeout }) {
     // waitUntil:"commit" returns as soon as the response begins — it minimizes execution of
     // the (authenticated) origin page's own JS before the in-page fetch. Same-origin context
     // is still required (a cross-origin fetch would be CORS-opaque), so a minimal navigation

--- a/mcp/lib/browser-sessions.js
+++ b/mcp/lib/browser-sessions.js
@@ -303,12 +303,11 @@ async function startSession({
     // (see mcp/lib/browser-tools-shared.js#resolveBrowserEgressProfile). null
     // means direct egress (no proxy), which is the default.
     proxy: proxy && typeof proxy === "object" ? proxy : null,
-    // Cookie auth for the trusted authed_fetch transport (offensive mass-read producer
-    // only — never an agent path). Pass-through array of Playwright cookie objects; null
-    // = unauthenticated (the control arm of the differential). The bob_browser_* MCP
-    // tools never set this, so an agent cannot inject auth into a browser session.
-    auth_cookies: Array.isArray(authCookies) ? authCookies : null,
+    // Cookie auth for the trusted authed_fetch transport is NOT passed here — it would put
+    // auth secrets in the child process environment. It is sent after ready over stdin via the
+    // server-side-only `set_auth_cookies` command (below), so secrets never touch the env.
   };
+  const pendingAuthCookies = Array.isArray(authCookies) && authCookies.length ? authCookies : null;
 
   const child = spawnFn(process.execPath, [DRIVER_SCRIPT_PATH], {
     stdio: ["pipe", "pipe", "pipe"],
@@ -358,6 +357,19 @@ async function startSession({
     throw err;
   }
   scheduleIdleTimer(entry);
+
+  // Inject producer-supplied cookie auth over stdin (never the env) as the FIRST command, so
+  // it is applied to the context before any authed_fetch. A scope violation (an out-of-scope
+  // cookie) fails the whole session closed. The bob_browser_* MCP tools never pass
+  // authCookies, so an agent cannot reach this path.
+  if (pendingAuthCookies) {
+    try {
+      await sendCommand(sessionId, "set_auth_cookies", { cookies: pendingAuthCookies });
+    } catch (err) {
+      closeSessionByEntry(entry, "auth_cookie_injection_failed");
+      throw err;
+    }
+  }
 
   return {
     session_id: sessionId,

--- a/mcp/lib/browser-sessions.js
+++ b/mcp/lib/browser-sessions.js
@@ -264,6 +264,7 @@ async function startSession({
   sessionsRoot,
   patchrightCheck = isPatchrightAvailable,
   proxy = null,
+  authCookies = null,
   spawnFn = spawn,
 } = {}) {
   if (!patchrightCheck()) {
@@ -302,6 +303,11 @@ async function startSession({
     // (see mcp/lib/browser-tools-shared.js#resolveBrowserEgressProfile). null
     // means direct egress (no proxy), which is the default.
     proxy: proxy && typeof proxy === "object" ? proxy : null,
+    // Cookie auth for the trusted authed_fetch transport (offensive mass-read producer
+    // only — never an agent path). Pass-through array of Playwright cookie objects; null
+    // = unauthenticated (the control arm of the differential). The bob_browser_* MCP
+    // tools never set this, so an agent cannot inject auth into a browser session.
+    auth_cookies: Array.isArray(authCookies) ? authCookies : null,
   };
 
   const child = spawnFn(process.execPath, [DRIVER_SCRIPT_PATH], {

--- a/mcp/lib/safe-fetch.js
+++ b/mcp/lib/safe-fetch.js
@@ -379,6 +379,7 @@ module.exports = {
   SafeFetchHeaders,
   assertSafeResolvedRequestUrl,
   assertSafeRequestUrl,
+  resolveSafeAddress,
   isRedirectStatus,
   normalizeRedirectMethod,
   safeFetch,

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -149,9 +149,14 @@ test("authed_fetch documents page-controlled fetch as an accepted residual (not 
   assert.doesNotMatch(DRIVER_SRC, /__bobNativeFetch/, "the unreliable native-fetch capture must stay removed");
 });
 
-test("authed_fetch self-aborts the in-page fetch via AbortSignal.timeout (no lingering request)", () => {
-  assert.match(DRIVER_SRC, /AbortSignal\.timeout\(/);
-  assert.match(DRIVER_SRC, /const inPageAbortMs = timeout \+ 1000/);
+test("authed_fetch self-aborts the in-page fetch at the deadline and surfaces a timeout sentinel", () => {
+  // Aborts AT the timeout (not timeout+grace) so the authenticated request is actually
+  // cancelled, and converts the abort to a deterministic { __timeout: true } sentinel.
+  assert.match(DRIVER_SRC, /AbortSignal\.timeout\(\$\{timeout\}\)/);
+  assert.match(DRIVER_SRC, /e\.name === "TimeoutError" \|\| e\.name === "AbortError"/);
+  assert.match(DRIVER_SRC, /return \{ __timeout: true \}/);
+  assert.match(DRIVER_SRC, /if \(result && result\.__timeout\)/);
+  assert.doesNotMatch(DRIVER_SRC, /inPageAbortMs/, "the timeout+grace fudge must be gone");
 });
 
 test("authed_fetch caps the body in BYTES, not UTF-16 code units", () => {
@@ -167,16 +172,25 @@ test("set_auth_cookies validates EACH cookie's target host against target_domain
   assert.match(DRIVER_SRC, /set_auth_cookies_scope_blocked/);
 });
 
-test("driver DNS-pins the target host via --host-resolver-rules (rebind defense)", () => {
+test("set_auth_cookies rejects the ambiguous both-url-and-domain cookie form", () => {
+  assert.match(DRIVER_SRC, /must set EITHER url OR domain, not both/);
+});
+
+test("driver DNS-pins the target host via --host-resolver-rules and records internal-ness", () => {
   assert.match(DRIVER_SRC, /resolveSafeAddress\(pinHost/);
   assert.match(DRIVER_SRC, /--host-resolver-rules=/);
   assert.match(DRIVER_SRC, /MAP \$\{pinHost\} \$\{ipForRule\}/);
-  assert.match(DRIVER_SRC, /this\.pinnedHosts\.set\(pinHost, address\)/);
+  // round-4: the pin records {address, internal} (not a bare address), so a private pinned IP
+  // cannot satisfy block_internal_hosts by presence alone.
+  assert.match(DRIVER_SRC, /this\.pinnedHosts\.set\(pinHost, \{ address, internal: isBlockedInternalHost\(address\) \}\)/);
 });
 
-test("authed_fetch refuses an unpinned host under block_internal_hosts", () => {
-  assert.match(DRIVER_SRC, /!this\.proxy && blockInternalHosts && !this\.pinnedHosts\.has\(/);
-  assert.match(DRIVER_SRC, /was not DNS-pinned at launch/);
+test("authed_fetch enforces block_internal_hosts: refuse proxied, unpinned, OR pinned-internal", () => {
+  assert.match(DRIVER_SRC, /if \(this\.proxy\) \{/); // refuse: cannot enforce through a proxy
+  assert.match(DRIVER_SRC, /cannot enforce block_internal_hosts through an egress proxy/);
+  assert.match(DRIVER_SRC, /was not DNS-pinned at launch/); // refuse: unpinned host
+  assert.match(DRIVER_SRC, /if \(pin\.internal\)/); // refuse: pinned IP is itself internal
+  assert.match(DRIVER_SRC, /pins to an internal address/);
 });
 
 test("authed_fetch scope-checks the URL and guards origin drift", () => {
@@ -404,6 +418,35 @@ test("set_auth_cookies rejects an out-of-scope cookie (session fails closed)", {
       (err) => { assert.match(err.message, /scope_blocked/); return true; },
     );
   } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch under block_internal_hosts refuses a host pinned to an internal IP", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  // End-to-end: an authed_fetch to a loopback-resolving target under block_internal_hosts is
+  // refused (defense in depth — the resolved-scope check and the pin-internal guard both reject
+  // a private IP). The pin.internal branch specifically closes the rebind case (public IP at
+  // check-time, private pinned IP at connect-time); that branch is asserted by the source test.
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+    });
+    await assert.rejects(
+      () => browserSessions.sendCommand(session.session_id, "authed_fetch", {
+        url: `${origin}/api/listing`, method: "GET", block_internal_hosts: true,
+      }),
+      (err) => { assert.match(err.message, /scope_blocked/); return true; },
+    );
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
     await new Promise((r) => server.close(r));
   }
 });

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -1,0 +1,237 @@
+"use strict";
+
+// PR1 — the trusted `authed_fetch` browser transport for the offensive mass-read producer.
+//
+// Contract: a SERVER-SIDE-ONLY driver command (`authed_fetch`) issues an authenticated
+// request from the real-Chrome page context (so it carries Chrome's TLS/HTTP-2 fingerprint
+// and survives a WAF/Cloudflare that 403s safeFetch's bare-Node fingerprint) and returns
+// the response body. Cookie auth is injected at session start from the in-process producer
+// (never an agent). The agent-facing `evaluate` sandbox (no fetch/XHR) is UNCHANGED, and no
+// bob_browser_* MCP tool maps to `authed_fetch`, so an agent cannot reach this transport.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const http = require("node:http");
+
+const browserSessions = require("../mcp/lib/browser-sessions.js");
+
+const BROWSER_LAUNCHABLE =
+  !process.env.BOB_SKIP_BROWSER_TESTS && browserSessions.isBrowserLaunchable();
+
+const DRIVER_SRC = fs.readFileSync(path.join(__dirname, "..", "mcp", "browser-driver.js"), "utf8");
+
+// Spawn stub (mirrors browser-egress-wiring.test.js): assert what the subprocess WOULD
+// receive in BOB_BROWSER_DRIVER_INIT without launching Chromium.
+function makeSpawnStub(captured) {
+  const { EventEmitter } = require("node:events");
+  return function stub(execPath, args, opts) {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stdout.setEncoding = () => {};
+    child.stderr = new EventEmitter();
+    child.stderr.setEncoding = () => {};
+    child.stdin = { writable: true, destroyed: false, write() { return true; }, end() { this.destroyed = true; } };
+    child.killed = false;
+    child.kill = () => { child.killed = true; };
+    captured.push({ env: opts && opts.env ? opts.env : {} });
+    setImmediate(() => {
+      const init = JSON.parse(opts.env.BOB_BROWSER_DRIVER_INIT);
+      child.stdout.emit("data", `${JSON.stringify({ ready: true, session_id: init.session_id })}\n`);
+    });
+    return child;
+  };
+}
+
+// ── init-payload threading (no Chromium) ──
+
+test("startSession serializes authCookies into BOB_BROWSER_DRIVER_INIT.auth_cookies", async () => {
+  const captured = [];
+  const cookies = [{ name: "sid", value: "abc", url: "https://example.com" }];
+  const session = await browserSessions.startSession({
+    targetDomain: "example.com",
+    targetUrl: "https://example.com",
+    headless: true,
+    authCookies: cookies,
+    spawnFn: makeSpawnStub(captured),
+    patchrightCheck: () => true,
+  });
+  assert.equal(captured.length, 1);
+  const init = JSON.parse(captured[0].env.BOB_BROWSER_DRIVER_INIT);
+  assert.deepEqual(init.auth_cookies, cookies);
+  await browserSessions.closeSession(session.session_id).catch(() => {});
+});
+
+test("startSession with no authCookies → init.auth_cookies is null (unauthenticated control arm)", async () => {
+  const captured = [];
+  const session = await browserSessions.startSession({
+    targetDomain: "example.com",
+    targetUrl: "https://example.com",
+    headless: true,
+    spawnFn: makeSpawnStub(captured),
+    patchrightCheck: () => true,
+  });
+  const init = JSON.parse(captured[0].env.BOB_BROWSER_DRIVER_INIT);
+  assert.equal(init.auth_cookies, null);
+  await browserSessions.closeSession(session.session_id).catch(() => {});
+});
+
+// ── source-level contracts (no Chromium) ──
+
+test("driver registers the authed_fetch command and an authedFetch method", () => {
+  assert.match(DRIVER_SRC, /case "authed_fetch":/);
+  assert.match(DRIVER_SRC, /async authedFetch\(args\)/);
+});
+
+test("authed_fetch issues an IN-PAGE fetch (real Chrome stack), not a Node client", () => {
+  // The fetch expression must run via page.evaluate so it carries the browser TLS
+  // fingerprint; a Node-side context.request would be CF-403'd like safeFetch.
+  assert.match(DRIVER_SRC, /const expr = `\(async \(\) => \{\s*const __r = await fetch\(/);
+  assert.match(DRIVER_SRC, /this\.page\.evaluate\(expr\)/);
+  assert.match(DRIVER_SRC, /credentials: "include"/);
+});
+
+test("authed_fetch scope-checks the URL and guards origin drift", () => {
+  assert.match(DRIVER_SRC, /assertSafeResolvedRequestUrl\(url, this\.targetDomain/);
+  assert.match(DRIVER_SRC, /authed_fetch_origin_drift/);
+});
+
+test("authed_fetch races a wall-clock timeout (no session pin) and caps the body", () => {
+  assert.match(DRIVER_SRC, /authed_fetch_timeout after \$\{timeout\}ms/);
+  assert.match(DRIVER_SRC, /MAX_AUTHED_FETCH_BODY_BYTES/);
+  assert.match(DRIVER_SRC, /body_truncated/);
+});
+
+test("authed_fetch restricts the method to read-intent GET/POST", () => {
+  assert.match(DRIVER_SRC, /method !== "GET" && method !== "POST"/);
+});
+
+test("session start injects producer cookies via context.addCookies", () => {
+  assert.match(DRIVER_SRC, /this\.context\.addCookies\(this\.authCookies\)/);
+  assert.match(DRIVER_SRC, /initConfig\.auth_cookies/);
+});
+
+test("the agent-facing evaluate sandbox is UNCHANGED: fetch( still blocked in evaluate", () => {
+  // The transport must NOT loosen the agent sandbox — only the trusted authed_fetch path
+  // (a separate command with no MCP tool wrapper) issues page-context network IO.
+  assert.match(DRIVER_SRC, /const FORBIDDEN_EVAL_PATTERN =\s*\n?\s*\/[^\n]*fetch\\\(/);
+  assert.match(DRIVER_SRC, /if \(FORBIDDEN_EVAL_PATTERN\.test\(expression\)\)/);
+  assert.match(DRIVER_SRC, /evaluate_sandbox_violation/);
+});
+
+test("no bob_browser_* MCP tool exposes authed_fetch (transport is server-side-only)", () => {
+  const toolsDir = path.join(__dirname, "..", "mcp", "lib", "tools");
+  const offenders = fs.readdirSync(toolsDir)
+    .filter((f) => f.startsWith("browser-") && f.endsWith(".js"))
+    .filter((f) => fs.readFileSync(path.join(toolsDir, f), "utf8").includes("authed_fetch"));
+  assert.deepEqual(offenders, [], "no browser tool wrapper may reference authed_fetch");
+});
+
+// ── real-Chromium end-to-end differential (gated on BROWSER_LAUNCHABLE) ──
+//
+// A local cookie-gated JSON endpoint stands in for a WAF-fronted API: "/" is public
+// (so the navigate lands), "/api/listing" returns records ONLY when the auth cookie is
+// present (200) else 401. The authed session must read the records (cookie carried by the
+// in-page fetch); the no-cookie control must be denied — the mass-read differential.
+
+function startCookieGatedServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === "/") {
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end("<!doctype html><html><body>ok</body></html>");
+        return;
+      }
+      if (req.url === "/api/listing") {
+        const authed = (req.headers.cookie || "").includes("massread_auth=letmein");
+        if (authed) {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify([{ email: "a@x.test" }, { email: "b@x.test" }, { email: "c@x.test" }]));
+        } else {
+          res.writeHead(401, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "unauthorized" }));
+        }
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+// The driver's scope guard requires a PUBLIC DNS domain (it refuses raw 127.0.0.1), so a
+// hermetic local server is reached via localtest.me, which resolves to 127.0.0.1. Skips
+// cleanly where that domain does not resolve to loopback (offline / locked-down DNS).
+function lookupLoopback(host) {
+  return new Promise((resolve) => {
+    require("dns").lookup(host, (err, addr) => resolve(err ? null : addr));
+  });
+}
+
+test("authed_fetch carries injected cookie auth and captures the body (authed vs control differential)", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  const listingUrl = `${origin}/api/listing`;
+  let authedSession = null;
+  let controlSession = null;
+  try {
+    // attacker arm: cookie injected → reads the records
+    authedSession = await browserSessions.startSession({
+      targetDomain: "localtest.me",
+      targetUrl: origin,
+      headless: true,
+      authCookies: [{ name: "massread_auth", value: "letmein", url: origin }],
+    });
+    const authed = await browserSessions.sendCommand(authedSession.session_id, "authed_fetch", {
+      url: listingUrl, method: "GET",
+    });
+    assert.equal(authed.status, 200, JSON.stringify(authed));
+    const records = JSON.parse(authed.body);
+    assert.equal(records.length, 3, "authed arm reads the full collection");
+    assert.equal(authed.body_truncated, false);
+
+    // control arm: no cookie → denied
+    controlSession = await browserSessions.startSession({
+      targetDomain: "localtest.me",
+      targetUrl: origin,
+      headless: true,
+    });
+    const control = await browserSessions.sendCommand(controlSession.session_id, "authed_fetch", {
+      url: listingUrl, method: "GET",
+    });
+    assert.equal(control.status, 401, "control arm is denied the bulk data");
+  } finally {
+    if (authedSession) await browserSessions.closeSession(authedSession.session_id).catch(() => {});
+    if (controlSession) await browserSessions.closeSession(controlSession.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch refuses an out-of-scope URL", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const session = await browserSessions.startSession({
+    targetDomain: "localtest.me",
+    targetUrl: "http://localtest.me/",
+    headless: true,
+  });
+  try {
+    await assert.rejects(
+      () => browserSessions.sendCommand(session.session_id, "authed_fetch", {
+        url: "https://example.com/api/listing", method: "GET",
+      }),
+      (err) => { assert.match(err.message, /scope_blocked/); return true; },
+    );
+  } finally {
+    await browserSessions.closeSession(session.session_id).catch(() => {});
+  }
+});

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -195,6 +195,22 @@ test("authed_fetch REQUIRES the DNS pin on every call (not opt-in) + internal/pr
   assert.match(DRIVER_SRC, /cannot enforce block_internal_hosts through an egress proxy/);
 });
 
+test("authed_fetch requests are NOT recorded into the agent-readable request log (no auth leak)", () => {
+  // round-6: a per-op flag suppresses logging of the priming nav + the credentialed fetch so
+  // the producer's cookies/headers never enter this.requests / recordedRequests.
+  assert.match(DRIVER_SRC, /if \(this\.authedFetchOp\) return;/);
+  assert.match(DRIVER_SRC, /this\.authedFetchOp = \{ host: fetchHost \}/);
+  assert.match(DRIVER_SRC, /this\.authedFetchOp = null/);
+});
+
+test("authed_fetch does NOT install a context.route interceptor (transport must survive Kasada/CDN/OAuth)", () => {
+  // The priming-redirect residual is dispositioned, NOT fixed with a network interceptor: a
+  // context.route('**/*') would abort page-decided subresource loads (the no-route invariant in
+  // browser-driver-tools.test.js). Guard against reintroducing it here too.
+  assert.doesNotMatch(DRIVER_SRC, /context\.route\s*\(\s*["'`]\*\*\/\*["'`]/);
+  assert.match(DRIVER_SRC, /ACCEPTED RESIDUAL — priming redirect under block_internal_hosts/);
+});
+
 test("authed_fetch scope-checks the URL and guards origin drift", () => {
   assert.match(DRIVER_SRC, /assertSafeResolvedRequestUrl\(url, this\.targetDomain/);
   assert.match(DRIVER_SRC, /authed_fetch_origin_drift/);
@@ -343,6 +359,33 @@ test("authed_fetch carries injected cookie auth and captures the body (authed vs
   } finally {
     if (authedSession) await browserSessions.closeSession(authedSession.session_id).catch(() => {});
     if (controlSession) await browserSessions.closeSession(controlSession.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch credentialed request is absent from the agent-readable network log", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+      authCookies: [{ name: "massread_auth", value: "letmein", url: origin }],
+    });
+    const authed = await browserSessions.sendCommand(session.session_id, "authed_fetch", {
+      url: `${origin}/api/listing`, method: "GET",
+    });
+    assert.equal(authed.status, 200);
+    const log = await browserSessions.sendCommand(session.session_id, "network_requests", {});
+    const leaked = (log.requests || []).filter((r) => r.url && r.url.includes("/api/listing"));
+    assert.deepEqual(leaked, [], "the credentialed authed_fetch request must not appear in the network log");
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
     await new Promise((r) => server.close(r));
   }
 });

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -5,14 +5,17 @@
 // Contract: a SERVER-SIDE-ONLY driver command (`authed_fetch`) issues an authenticated
 // request from the real-Chrome page context (so it carries Chrome's TLS/HTTP-2 fingerprint
 // and survives a WAF/Cloudflare that 403s safeFetch's bare-Node fingerprint) and returns
-// the response body. Cookie auth is injected at session start from the in-process producer
-// (never an agent). The agent-facing `evaluate` sandbox (no fetch/XHR) is UNCHANGED, and no
-// bob_browser_* MCP tool maps to `authed_fetch`, so an agent cannot reach this transport.
+// the response body. Cookie auth is injected via a second server-side-only command
+// (`set_auth_cookies`) over stdin — never the process environment, never an agent. The
+// agent-facing `evaluate` sandbox (no fetch/XHR) is UNCHANGED, and no bob_browser_* MCP tool
+// maps to either command, so an agent cannot reach this transport.
+//
+// Round-3 hardening covered here: DNS-rebinding pin (--host-resolver-rules), per-cookie scope
+// validation, byte-accurate body cap, in-page AbortSignal self-abort, native-fetch capture.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 const http = require("node:http");
 
@@ -22,9 +25,12 @@ const BROWSER_LAUNCHABLE =
   !process.env.BOB_SKIP_BROWSER_TESTS && browserSessions.isBrowserLaunchable();
 
 const DRIVER_SRC = fs.readFileSync(path.join(__dirname, "..", "mcp", "browser-driver.js"), "utf8");
+const MAX_AUTHED_FETCH_BODY_BYTES = 2 * 1024 * 1024;
 
 // Spawn stub (mirrors browser-egress-wiring.test.js): assert what the subprocess WOULD
-// receive in BOB_BROWSER_DRIVER_INIT without launching Chromium.
+// receive WITHOUT launching Chromium. It captures the spawn env + every stdin command line,
+// and auto-acks each command so startSession (which now sends set_auth_cookies over stdin)
+// can complete.
 function makeSpawnStub(captured) {
   const { EventEmitter } = require("node:events");
   return function stub(execPath, args, opts) {
@@ -33,10 +39,35 @@ function makeSpawnStub(captured) {
     child.stdout.setEncoding = () => {};
     child.stderr = new EventEmitter();
     child.stderr.setEncoding = () => {};
-    child.stdin = { writable: true, destroyed: false, write() { return true; }, end() { this.destroyed = true; } };
+    const record = { env: opts && opts.env ? opts.env : {}, args: args || [], commands: [] };
+    child.stdin = {
+      writable: true,
+      destroyed: false,
+      write(chunk) {
+        const line = String(chunk).trim();
+        try {
+          const msg = JSON.parse(line);
+          if (msg && msg.command_id) {
+            record.commands.push({ command: msg.command, args: msg.args });
+            // Auto-ack pending commands so sendCommand resolves.
+            if (!String(msg.command_id).startsWith("close-")) {
+              setImmediate(() => {
+                const count = msg.args && Array.isArray(msg.args.cookies) ? msg.args.cookies.length : 0;
+                child.stdout.emit(
+                  "data",
+                  `${JSON.stringify({ command_id: msg.command_id, result: { ok: true, count } })}\n`,
+                );
+              });
+            }
+          }
+        } catch (e) { /* not a command line */ }
+        return true;
+      },
+      end() { this.destroyed = true; },
+    };
     child.killed = false;
     child.kill = () => { child.killed = true; };
-    captured.push({ env: opts && opts.env ? opts.env : {} });
+    captured.push(record);
     setImmediate(() => {
       const init = JSON.parse(opts.env.BOB_BROWSER_DRIVER_INIT);
       child.stdout.emit("data", `${JSON.stringify({ ready: true, session_id: init.session_id })}\n`);
@@ -45,9 +76,9 @@ function makeSpawnStub(captured) {
   };
 }
 
-// ── init-payload threading (no Chromium) ──
+// ── cookie auth travels over stdin, NEVER the env (no Chromium) ──
 
-test("startSession serializes authCookies into BOB_BROWSER_DRIVER_INIT.auth_cookies", async () => {
+test("startSession does NOT put auth cookies in the child process env", async () => {
   const captured = [];
   const cookies = [{ name: "sid", value: "abc", url: "https://example.com" }];
   const session = await browserSessions.startSession({
@@ -58,13 +89,29 @@ test("startSession serializes authCookies into BOB_BROWSER_DRIVER_INIT.auth_cook
     spawnFn: makeSpawnStub(captured),
     patchrightCheck: () => true,
   });
-  assert.equal(captured.length, 1);
   const init = JSON.parse(captured[0].env.BOB_BROWSER_DRIVER_INIT);
-  assert.deepEqual(init.auth_cookies, cookies);
+  assert.equal(init.auth_cookies, undefined, "cookies must not be serialized into the init env");
   await browserSessions.closeSession(session.session_id).catch(() => {});
 });
 
-test("startSession with no authCookies → init.auth_cookies is null (unauthenticated control arm)", async () => {
+test("startSession sends auth cookies via the set_auth_cookies stdin command", async () => {
+  const captured = [];
+  const cookies = [{ name: "sid", value: "abc", url: "https://example.com" }];
+  const session = await browserSessions.startSession({
+    targetDomain: "example.com",
+    targetUrl: "https://example.com",
+    headless: true,
+    authCookies: cookies,
+    spawnFn: makeSpawnStub(captured),
+    patchrightCheck: () => true,
+  });
+  const setAuth = captured[0].commands.find((c) => c.command === "set_auth_cookies");
+  assert.ok(setAuth, "a set_auth_cookies command must be sent over stdin");
+  assert.deepEqual(setAuth.args.cookies, cookies);
+  await browserSessions.closeSession(session.session_id).catch(() => {});
+});
+
+test("startSession with no authCookies sends no set_auth_cookies command (control arm)", async () => {
   const captured = [];
   const session = await browserSessions.startSession({
     targetDomain: "example.com",
@@ -73,24 +120,63 @@ test("startSession with no authCookies → init.auth_cookies is null (unauthenti
     spawnFn: makeSpawnStub(captured),
     patchrightCheck: () => true,
   });
-  const init = JSON.parse(captured[0].env.BOB_BROWSER_DRIVER_INIT);
-  assert.equal(init.auth_cookies, null);
+  const setAuth = captured[0].commands.find((c) => c.command === "set_auth_cookies");
+  assert.equal(setAuth, undefined, "control arm must not inject any cookies");
   await browserSessions.closeSession(session.session_id).catch(() => {});
 });
 
 // ── source-level contracts (no Chromium) ──
 
-test("driver registers the authed_fetch command and an authedFetch method", () => {
+test("driver registers authed_fetch + set_auth_cookies commands and methods", () => {
   assert.match(DRIVER_SRC, /case "authed_fetch":/);
   assert.match(DRIVER_SRC, /async authedFetch\(args\)/);
+  assert.match(DRIVER_SRC, /case "set_auth_cookies":/);
+  assert.match(DRIVER_SRC, /async setAuthCookies\(args\)/);
 });
 
 test("authed_fetch issues an IN-PAGE fetch (real Chrome stack), not a Node client", () => {
   // The fetch expression must run via page.evaluate so it carries the browser TLS
   // fingerprint; a Node-side context.request would be CF-403'd like safeFetch.
-  assert.match(DRIVER_SRC, /const expr = `\(async \(\) => \{\s*const __r = await fetch\(/);
   assert.match(DRIVER_SRC, /this\.page\.evaluate\(expr\)/);
   assert.match(DRIVER_SRC, /credentials: "include"/);
+});
+
+test("authed_fetch documents page-controlled fetch as an accepted residual (not a broken native-capture)", () => {
+  // Round-3: a "native fetch capture" was tried and reverted — it breaks under the Patchright
+  // stealth driver. The residual is accepted with compensating controls (commit-nav +
+  // differential). Guard against silently reintroducing the capture.
+  assert.match(DRIVER_SRC, /ACCEPTED RESIDUAL — page-controlled fetch/);
+  assert.doesNotMatch(DRIVER_SRC, /__bobNativeFetch/, "the unreliable native-fetch capture must stay removed");
+});
+
+test("authed_fetch self-aborts the in-page fetch via AbortSignal.timeout (no lingering request)", () => {
+  assert.match(DRIVER_SRC, /AbortSignal\.timeout\(/);
+  assert.match(DRIVER_SRC, /const inPageAbortMs = timeout \+ 1000/);
+});
+
+test("authed_fetch caps the body in BYTES, not UTF-16 code units", () => {
+  // Regression for the round-2 finding: __acc.length (UTF-16) → byteLength on Uint8Array.
+  assert.match(DRIVER_SRC, /__chunk\.byteLength/);
+  assert.match(DRIVER_SRC, /__bytes \+ __chunk\.byteLength > __cap/);
+  assert.match(DRIVER_SRC, /__chunk\.subarray\(0, __cap - __bytes\)/);
+  assert.doesNotMatch(DRIVER_SRC, /__acc\.length >= __cap/, "the UTF-16 length cap must be gone");
+});
+
+test("set_auth_cookies validates EACH cookie's target host against target_domain", () => {
+  assert.match(DRIVER_SRC, /assertSafeRequestUrl\(scopeUrl, this\.targetDomain\)/);
+  assert.match(DRIVER_SRC, /set_auth_cookies_scope_blocked/);
+});
+
+test("driver DNS-pins the target host via --host-resolver-rules (rebind defense)", () => {
+  assert.match(DRIVER_SRC, /resolveSafeAddress\(pinHost/);
+  assert.match(DRIVER_SRC, /--host-resolver-rules=/);
+  assert.match(DRIVER_SRC, /MAP \$\{pinHost\} \$\{ipForRule\}/);
+  assert.match(DRIVER_SRC, /this\.pinnedHosts\.set\(pinHost, address\)/);
+});
+
+test("authed_fetch refuses an unpinned host under block_internal_hosts", () => {
+  assert.match(DRIVER_SRC, /!this\.proxy && blockInternalHosts && !this\.pinnedHosts\.has\(/);
+  assert.match(DRIVER_SRC, /was not DNS-pinned at launch/);
 });
 
 test("authed_fetch scope-checks the URL and guards origin drift", () => {
@@ -108,18 +194,12 @@ test("authed_fetch restricts the method to read-intent GET/POST", () => {
   assert.match(DRIVER_SRC, /method !== "GET" && method !== "POST"/);
 });
 
-test("session start injects producer cookies via context.addCookies", () => {
-  assert.match(DRIVER_SRC, /this\.context\.addCookies\(this\.authCookies\)/);
-  assert.match(DRIVER_SRC, /initConfig\.auth_cookies/);
-});
-
 test("authed_fetch does NOT follow redirects (redirect:manual — no off-scope auth leak)", () => {
   assert.match(DRIVER_SRC, /redirect: "manual"/);
 });
 
 test("authed_fetch stream-reads the body with a cap enforced WHILE reading (no full buffering)", () => {
   assert.match(DRIVER_SRC, /__r\.body\.getReader/);
-  assert.match(DRIVER_SRC, /__acc\.length >= __cap/);
 });
 
 test("authed_fetch navigates with waitUntil:commit to minimize authed-page execution", () => {
@@ -132,7 +212,7 @@ test("authed_fetch honors a producer block_internal_hosts policy in BOTH scope c
   assert.ok(checks.length >= 2, "both the fetch URL and the navigated origin must be policy-checked");
 });
 
-test("driver scrubs BOB_BROWSER_DRIVER_INIT from env before launch (no child-process auth inheritance)", () => {
+test("driver scrubs BOB_BROWSER_DRIVER_INIT from env before launch (no child-process inheritance)", () => {
   assert.match(DRIVER_SRC, /delete process\.env\.BOB_BROWSER_DRIVER_INIT/);
 });
 
@@ -144,20 +224,24 @@ test("the agent-facing evaluate sandbox is UNCHANGED: fetch( still blocked in ev
   assert.match(DRIVER_SRC, /evaluate_sandbox_violation/);
 });
 
-test("no bob_browser_* MCP tool exposes authed_fetch (transport is server-side-only)", () => {
+test("no bob_browser_* MCP tool exposes authed_fetch OR set_auth_cookies (server-side-only)", () => {
   const toolsDir = path.join(__dirname, "..", "mcp", "lib", "tools");
   const offenders = fs.readdirSync(toolsDir)
     .filter((f) => f.startsWith("browser-") && f.endsWith(".js"))
-    .filter((f) => fs.readFileSync(path.join(toolsDir, f), "utf8").includes("authed_fetch"));
-  assert.deepEqual(offenders, [], "no browser tool wrapper may reference authed_fetch");
+    .filter((f) => {
+      const src = fs.readFileSync(path.join(toolsDir, f), "utf8");
+      return src.includes("authed_fetch") || src.includes("set_auth_cookies");
+    });
+  assert.deepEqual(offenders, [], "no browser tool wrapper may reference the trusted transport commands");
 });
 
-// ── real-Chromium end-to-end differential (gated on BROWSER_LAUNCHABLE) ──
+// ── real-Chromium end-to-end (gated on BROWSER_LAUNCHABLE) ──
 //
-// A local cookie-gated JSON endpoint stands in for a WAF-fronted API: "/" is public
-// (so the navigate lands), "/api/listing" returns records ONLY when the auth cookie is
-// present (200) else 401. The authed session must read the records (cookie carried by the
-// in-page fetch); the no-cookie control must be denied — the mass-read differential.
+// A local cookie-gated JSON endpoint stands in for a WAF-fronted API: "/" is public (so the
+// navigate lands), "/api/listing" returns records ONLY when the auth cookie is present (200)
+// else 401, "/api/redirect" 302s, and "/api/big" returns an oversized body. The authed
+// session reads the records (cookie carried by the in-page fetch); the no-cookie control is
+// denied — the mass-read differential.
 
 function startCookieGatedServer() {
   return new Promise((resolve) => {
@@ -176,6 +260,16 @@ function startCookieGatedServer() {
           res.writeHead(401, { "content-type": "application/json" });
           res.end(JSON.stringify({ error: "unauthorized" }));
         }
+        return;
+      }
+      if (req.url === "/api/redirect") {
+        res.writeHead(302, { location: "/" });
+        res.end();
+        return;
+      }
+      if (req.url === "/api/big") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("x".repeat(MAX_AUTHED_FETCH_BODY_BYTES + 4096));
         return;
       }
       res.writeHead(404); res.end();
@@ -205,7 +299,7 @@ test("authed_fetch carries injected cookie auth and captures the body (authed vs
   let authedSession = null;
   let controlSession = null;
   try {
-    // attacker arm: cookie injected → reads the records
+    // attacker arm: cookie injected (via set_auth_cookies stdin path) → reads the records
     authedSession = await browserSessions.startSession({
       targetDomain: "localtest.me",
       targetUrl: origin,
@@ -233,6 +327,83 @@ test("authed_fetch carries injected cookie auth and captures the body (authed vs
   } finally {
     if (authedSession) await browserSessions.closeSession(authedSession.session_id).catch(() => {});
     if (controlSession) await browserSessions.closeSession(controlSession.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch does NOT follow a 3xx (redirect:manual → opaqueredirect, status 0)", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+    });
+    const res = await browserSessions.sendCommand(session.session_id, "authed_fetch", {
+      url: `${origin}/api/redirect`, method: "GET",
+    });
+    // A followed redirect would surface the 200 of "/"; redirect:manual surfaces status 0.
+    assert.equal(res.status, 0, `redirect must not be followed: ${JSON.stringify(res)}`);
+    assert.equal(res.type, "opaqueredirect");
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch caps an oversized body at the byte limit and flags truncation", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+    });
+    const res = await browserSessions.sendCommand(session.session_id, "authed_fetch", {
+      url: `${origin}/api/big`, method: "GET",
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body_truncated, true, "oversized body must be flagged truncated");
+    assert.ok(
+      Buffer.byteLength(res.body) <= MAX_AUTHED_FETCH_BODY_BYTES,
+      `capped body must be <= ${MAX_AUTHED_FETCH_BODY_BYTES} bytes, got ${Buffer.byteLength(res.body)}`,
+    );
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("set_auth_cookies rejects an out-of-scope cookie (session fails closed)", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  try {
+    await assert.rejects(
+      () => browserSessions.startSession({
+        targetDomain: "localtest.me",
+        targetUrl: origin,
+        headless: true,
+        // cookie scoped to an OFF-target host — must be refused before it reaches the context
+        authCookies: [{ name: "evil", value: "x", url: "https://attacker.example.com/" }],
+      }),
+      (err) => { assert.match(err.message, /scope_blocked/); return true; },
+    );
+  } finally {
     await new Promise((r) => server.close(r));
   }
 });

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -185,12 +185,14 @@ test("driver DNS-pins the target host via --host-resolver-rules and records inte
   assert.match(DRIVER_SRC, /this\.pinnedHosts\.set\(pinHost, \{ address, internal: isBlockedInternalHost\(address\) \}\)/);
 });
 
-test("authed_fetch enforces block_internal_hosts: refuse proxied, unpinned, OR pinned-internal", () => {
-  assert.match(DRIVER_SRC, /if \(this\.proxy\) \{/); // refuse: cannot enforce through a proxy
-  assert.match(DRIVER_SRC, /cannot enforce block_internal_hosts through an egress proxy/);
-  assert.match(DRIVER_SRC, /was not DNS-pinned at launch/); // refuse: unpinned host
-  assert.match(DRIVER_SRC, /if \(pin\.internal\)/); // refuse: pinned IP is itself internal
+test("authed_fetch REQUIRES the DNS pin on every call (not opt-in) + internal/proxy guards", () => {
+  // round-5: the pin is enforced unconditionally on the non-proxied path (a credentialed fetch
+  // must never ride a rebound hostname), with the internal-IP check additionally under
+  // block_internal_hosts, and a proxy refusing only under block_internal_hosts.
+  assert.match(DRIVER_SRC, /was not DNS-pinned at launch; a credentialed fetch must target the pinned host/);
+  assert.match(DRIVER_SRC, /if \(blockInternalHosts && pin\.internal\)/); // internal-IP guard gated on policy
   assert.match(DRIVER_SRC, /pins to an internal address/);
+  assert.match(DRIVER_SRC, /cannot enforce block_internal_hosts through an egress proxy/);
 });
 
 test("authed_fetch scope-checks the URL and guards origin drift", () => {
@@ -418,6 +420,34 @@ test("set_auth_cookies rejects an out-of-scope cookie (session fails closed)", {
       (err) => { assert.match(err.message, /scope_blocked/); return true; },
     );
   } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch refuses an in-scope but UNPINNED host even without block_internal_hosts", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  // round-5: the session pins only the target_url host (localtest.me). A credentialed
+  // authed_fetch to a DIFFERENT in-scope host (sub.localtest.me) is refused on the default
+  // path (no block_internal_hosts) — the round-4 hole where the default path was rebindable.
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+    });
+    await assert.rejects(
+      () => browserSessions.sendCommand(session.session_id, "authed_fetch", {
+        url: `http://sub.localtest.me:${port}/api/listing`, method: "GET",
+      }),
+      (err) => { assert.match(err.message, /scope_blocked.*not DNS-pinned/); return true; },
+    );
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
     await new Promise((r) => server.close(r));
   }
 });

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -196,11 +196,22 @@ test("authed_fetch REQUIRES the DNS pin on every call (not opt-in) + internal/pr
 });
 
 test("authed_fetch requests are NOT recorded into the agent-readable request log (no auth leak)", () => {
-  // round-6: a per-op flag suppresses logging of the priming nav + the credentialed fetch so
-  // the producer's cookies/headers never enter this.requests / recordedRequests.
-  assert.match(DRIVER_SRC, /if \(this\.authedFetchOp\) return;/);
+  // round-6/7: a per-op flag suppresses the priming nav + fetch; once cookies are injected the
+  // WHOLE credentialed session is suppressed so cookies can't leak via a later page request.
+  assert.match(DRIVER_SRC, /if \(this\.authedFetchOp \|\| this\.credentialedSession\) return;/);
   assert.match(DRIVER_SRC, /this\.authedFetchOp = \{ host: fetchHost \}/);
   assert.match(DRIVER_SRC, /this\.authedFetchOp = null/);
+});
+
+test("set_auth_cookies marks the session credentialed (session-wide log suppression)", () => {
+  assert.match(DRIVER_SRC, /this\.credentialedSession = true;/);
+});
+
+test("authed_fetch rejects credential headers (auth must flow via set_auth_cookies, not the page world)", () => {
+  // round-7: the headers param lives in the page world (in-page fetch init), so a credential
+  // header could be read by a page-overridden fetch. Reject Authorization/Cookie/Proxy-Auth.
+  assert.match(DRIVER_SRC, /lower === "authorization" \|\| lower === "cookie" \|\| lower === "proxy-authorization"/);
+  assert.match(DRIVER_SRC, /use set_auth_cookies for credentials/);
 });
 
 test("authed_fetch does NOT install a context.route interceptor (transport must survive Kasada/CDN/OAuth)", () => {
@@ -517,6 +528,31 @@ test("authed_fetch under block_internal_hosts refuses a host pinned to an intern
         url: `${origin}/api/listing`, method: "GET", block_internal_hosts: true,
       }),
       (err) => { assert.match(err.message, /scope_blocked/); return true; },
+    );
+  } finally {
+    if (session) await browserSessions.closeSession(session.session_id).catch(() => {});
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("authed_fetch rejects an Authorization header (credentials must use set_auth_cookies)", { skip: !BROWSER_LAUNCHABLE }, async (t) => {
+  if (await lookupLoopback("localtest.me") !== "127.0.0.1") {
+    t.skip("localtest.me does not resolve to loopback in this environment");
+    return;
+  }
+  const server = await startCookieGatedServer();
+  const port = server.address().port;
+  const origin = `http://localtest.me:${port}`;
+  let session = null;
+  try {
+    session = await browserSessions.startSession({
+      targetDomain: "localtest.me", targetUrl: origin, headless: true,
+    });
+    await assert.rejects(
+      () => browserSessions.sendCommand(session.session_id, "authed_fetch", {
+        url: `${origin}/api/listing`, method: "GET", headers: { Authorization: "Bearer secret-token" },
+      }),
+      (err) => { assert.match(err.message, /not allowed.*set_auth_cookies/); return true; },
     );
   } finally {
     if (session) await browserSessions.closeSession(session.session_id).catch(() => {});

--- a/test/browser-authed-fetch.test.js
+++ b/test/browser-authed-fetch.test.js
@@ -113,6 +113,29 @@ test("session start injects producer cookies via context.addCookies", () => {
   assert.match(DRIVER_SRC, /initConfig\.auth_cookies/);
 });
 
+test("authed_fetch does NOT follow redirects (redirect:manual — no off-scope auth leak)", () => {
+  assert.match(DRIVER_SRC, /redirect: "manual"/);
+});
+
+test("authed_fetch stream-reads the body with a cap enforced WHILE reading (no full buffering)", () => {
+  assert.match(DRIVER_SRC, /__r\.body\.getReader/);
+  assert.match(DRIVER_SRC, /__acc\.length >= __cap/);
+});
+
+test("authed_fetch navigates with waitUntil:commit to minimize authed-page execution", () => {
+  assert.match(DRIVER_SRC, /waitUntil: "commit"/);
+});
+
+test("authed_fetch honors a producer block_internal_hosts policy in BOTH scope checks", () => {
+  assert.match(DRIVER_SRC, /block_internal_hosts === true/);
+  const checks = DRIVER_SRC.match(/assertSafeResolvedRequestUrl\([^)]*\{ blockInternalHosts \}\)/g) || [];
+  assert.ok(checks.length >= 2, "both the fetch URL and the navigated origin must be policy-checked");
+});
+
+test("driver scrubs BOB_BROWSER_DRIVER_INIT from env before launch (no child-process auth inheritance)", () => {
+  assert.match(DRIVER_SRC, /delete process\.env\.BOB_BROWSER_DRIVER_INIT/);
+});
+
 test("the agent-facing evaluate sandbox is UNCHANGED: fetch( still blocked in evaluate", () => {
   // The transport must NOT loosen the agent sandbox — only the trusted authed_fetch path
   // (a separate command with no MCP tool wrapper) issues page-context network IO.

--- a/test/mcp-test-manifest.json
+++ b/test/mcp-test-manifest.json
@@ -99,6 +99,7 @@
   "test/browser-behavior-probe-lens.test.js",
   "test/browser-record-mode.test.js",
   "test/browser-egress-wiring.test.js",
+  "test/browser-authed-fetch.test.js",
   "test/pack-telemetry.test.js",
   "test/oss-surfacing.test.js",
   "test/oss-blocked-harness.test.js",


### PR DESCRIPTION
## PR1 — trusted `authed_fetch` browser transport (WAF-capable)

First of two PRs adding the offensive **mass-read** producer. This one adds the transport it needs; PR2 adds the producer. Design of record: `docs/OFFENSIVE_MASSREAD_PRODUCER_PLAN.md` (included here).

### Why
The offensive rail's in-process `safeFetch` is Cloudflare-blind — a bare-Node TLS fingerprint that CF 403s. That left the **broken-auth / mass-read** class unconfirmable on a signed rail (the sexjobs.nl crown-jewel F-2 was only provable through the real-Chrome channel). This adds a WAF-capable, authenticated transport.

### What
- **`mcp/browser-driver.js` — a trusted, server-side-only `authed_fetch` command.** Navigates to the target origin, then issues an **in-page `fetch()`** (real Chrome TLS/HTTP-2 → survives the WAF) and returns the body. Scope-checked (`assertSafeResolvedRequestUrl`), origin-drift guarded, wall-clock-raced (same pattern as `evaluate`), body capped at 2 MiB (`body_truncated` flag), **GET/POST read-intent only**.
- **Cookie auth injection at session start** (`context.addCookies`) supplied by the in-process producer; bearer/custom headers go per-request in `authed_fetch`.
- **`mcp/lib/browser-sessions.js`** — threads `authCookies` → `BOB_BROWSER_DRIVER_INIT.auth_cookies`.

### Security posture
- The **agent-facing `evaluate` sandbox is UNCHANGED** (`FORBIDDEN_EVAL_PATTERN` still blocks `fetch(`/XHR/WS). This transport builds the fetch expression *server-side* from a scope-checked URL and runs it via a path agents can't reach.
- **No `bob_browser_*` MCP tool maps to `authed_fetch`** — only in-process producer code (`sendCommand`) can invoke it. A regression test asserts no browser tool wrapper references it.
- Auth material flows **producer → driver, never agent → driver**.

### Tests (`test/browser-authed-fetch.test.js`, manifested)
- spawn-stub: `authCookies` threads into the init payload; null when unauthenticated (the control arm).
- source-level contracts (no Chromium): in-page fetch + `credentials:"include"`; scope-check + origin-drift + timeout-race + body-cap; method restriction; cookie injection; **sandbox-unchanged**; no agent tool exposes the command.
- **real-Chromium end-to-end differential** (via a `localtest.me` cookie-gated server, skips cleanly where that domain doesn't resolve to loopback): the authed arm reads the full collection (cookie carried by the in-page fetch); the no-cookie control is denied — the mass-read differential, proven for real.

Full `npm test` green (3262 pass, 0 fail; 2 pre-existing skips).

@coderabbitai review
@codex review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a trusted, cookie-scoped authenticated browser transport with strict URL/origin scoping, manual redirects, response-size caps, and timeout protection.
  * Injects auth cookies after the browser session is ready (one-time per session) via dedicated commands.
  * Unproxied browsing pins resolved targets to mitigate DNS rebinding risk, with fail-closed handling for internal hosts.

* **Documentation**
  * Added a design plan for differential validation of bulk PII-read authorization.

* **Tests**
  * Expanded contract and end-to-end coverage for scoping, truncation, header restrictions, and session behavior, including manifest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->