### PR TITLE
ci: enable agy critic + bump brutalist-mcp to 1.18.2

### DIFF
--- a/.github/brutalist-tools/package-lock.json
+++ b/.github/brutalist-tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/claude-code": "2.1.177",
-        "@brutalist/mcp": "1.15.0",
+        "@brutalist/mcp": "1.18.2",
         "@openai/codex": "0.139.0"
       }
     },
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@brutalist/mcp": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@brutalist/mcp/-/mcp-1.15.0.tgz",
-      "integrity": "sha512-qkCI9UkaUKiGZHFMRRyhl2DTmxkBU3yPWGztJBGbTjKVPYEm95BjJzYSvewRcHeW4B73s0TumFPzx5CA6udzbg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@brutalist/mcp/-/mcp-1.18.2.tgz",
+      "integrity": "sha512-IT7xq26+6y61IVTgyd/XzkLzWNBHtGAr78Xw87OB8pIBfsukGs4C7U5nR1sME/Jkwr4B6Sfr2VKokkGXIOxt0A==",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/.github/brutalist-tools/package.json
+++ b/.github/brutalist-tools/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@anthropic-ai/claude-code": "2.1.177",
-    "@brutalist/mcp": "1.15.0",
+    "@brutalist/mcp": "1.18.2",
     "@openai/codex": "0.139.0"
   },
   "overrides": {

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -50,9 +50,14 @@ jobs:
           curl -fsSL https://antigravity.google/cli/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.local/bin:$PATH"
-          command -v brutalist-mcp claude codex agy
+          # Check each critic independently — `command -v a b c` returns 0 if ANY
+          # resolves, so it would pass even with agy missing.
+          for bin in brutalist-mcp claude codex agy; do
+            command -v "$bin" >/dev/null || { echo "::error::missing critic binary: $bin"; exit 1; }
+          done
           claude --version
           codex --version
+          agy --version
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
@@ -67,7 +72,9 @@ jobs:
         env:
           BRUTALIST_TIMEOUT: "600000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
-          # Freeze agy's binary version for the run (stops self-update drift).
+          # Disable agy's in-run self-update (it self-updates from a us-central1
+          # endpoint mid-run). NOTE: this does NOT pin the installed version —
+          # install.sh above fetches the latest; this only stops drift WITHIN a run.
           AGY_CLI_DISABLE_AUTO_UPDATE: "1"
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -1,6 +1,6 @@
 name: Brutalist Review
 
-# Claude + Codex review on trusted maintainer PRs, posted as inline comments.
+# Claude + Codex + agy review on trusted maintainer PRs, posted as inline comments.
 # CODEX_AUTH is the full ~/.codex/auth.json stored as a GitHub Actions secret.
 # Refresh it with `codex login` + `gh secret set CODEX_AUTH` if auth fails.
 # The image_generation tool is disabled (codex#21952 gpt-image-2 bug).
@@ -35,7 +35,7 @@ jobs:
       - name: Install CLI critics
         working-directory: .github/brutalist-tools
         env:
-          EXPECTED_TOOLS_LOCK_SHA256: cd77cfa851688a9124b1771447512e19c371c64ea85c7a103bda6326c7274865
+          EXPECTED_TOOLS_LOCK_SHA256: 3f51525eacc6d4e8f96838ebc6eb32f92dfe8057f62ffe2c3133c5400b324294
         run: |
           actual="$(sha256sum package-lock.json | cut -d ' ' -f1)"
           if [ "$actual" != "$EXPECTED_TOOLS_LOCK_SHA256" ]; then
@@ -46,7 +46,11 @@ jobs:
           node node_modules/@anthropic-ai/claude-code/install.cjs
           export PATH="$PWD/node_modules/.bin:$PATH"
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          command -v brutalist-mcp claude codex
+          # agy (Antigravity) critic — installed via the upstream script (not npm).
+          curl -fsSL https://antigravity.google/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          command -v brutalist-mcp claude codex agy
           claude --version
           codex --version
           # codex: disable the broken built-in image_generation tool (gpt-image-2)
@@ -63,10 +67,13 @@ jobs:
         env:
           BRUTALIST_TIMEOUT: "600000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
+          # Freeze agy's binary version for the run (stops self-update drift).
+          AGY_CLI_DISABLE_AUTO_UPDATE: "1"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
           codex-auth: ${{ secrets.CODEX_AUTH }}
+          agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
       - name: Report advisory reviewer failure
         if: steps.brutalist-review.outcome == 'failure'


### PR DESCRIPTION
Re-enables the **agy** (Antigravity) critic now that `@brutalist/mcp@1.18.2` fixes the CI hang (agy `--print` blocked on stdin EOF; the orchestrator's Node pipe-spawn left agy's stdin open).

Changes:
- bump `.github/brutalist-tools` `@brutalist/mcp` `1.15.0 → 1.18.2` (+ regenerated lock + updated `EXPECTED_TOOLS_LOCK_SHA256`)
- install agy via the upstream script; add `agy` to the `command -v` check
- `AGY_CLI_DISABLE_AUTO_UPDATE=1` to freeze agy's binary version for the run
- pass `agy-oauth-token` (the `AGY_OAUTH_TOKEN` secret was refreshed — agy tokens rotate ~monthly)

**This PR's own brutalist review is the validation** — it should post a 3-critic review (claude + codex + **agy**).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development dependencies to latest stable versions, enhancing tooling compatibility and system performance.
  * Optimized GitHub Actions code review automation workflow by refining tooling integration, updating configuration parameters, and improving environment stability settings to strengthen the automated review infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->