### PR TITLE
fix(offensive): mass-read v2 single-subject gate counts records, not identifier keys (live-validation finding)

### DIFF
--- a/mcp/lib/offensive-massread-producer.js
+++ b/mcp/lib/offensive-massread-producer.js
@@ -641,7 +641,8 @@ function subjectIdentifierSet(bodyText) {
   // extractRecords-selected subset: a /me's OWN top-level identifier must be seen even when the body ALSO
   // embeds a recognized child collection (`{email, items:[...]}` — extractRecords would pick `items` and miss
   // the top-level email, bot-review #N), and a wrapper / object-map's nested subjects must all be counted
-  // (#M / CodeRabbit). Used in the victim arm for membership (does X contain victimKey) + distinctSubjectCount.
+  // (#M / CodeRabbit). Used in the victim arm for the own-identity + anon-leak MEMBERSHIP tests only (does this
+  // body contain victimKey); the single-subject COUNT and the attacker OVERLAP each use their own walk below.
   let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS; // whole-body, bounded
   const visit = (node, depth) => {
     if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
@@ -666,25 +667,95 @@ function subjectIdentifierSet(bodyText) {
   return out;
 }
 
-// Distinct-SUBJECT count for the v2 single-subject gate: the MAX, over each subject-identifier SHAPE
-// (email / ssn — the shapes ~1:1 with a person), of the distinct normalized VALUES of that shape anywhere in
-// the body. ONE person's /me carries at most one of each shape, so a single subject → 1; a multi-subject scope
-// (an array of members, an object-map of users, a team wrapper) carries 2+ distinct EMAILS → >= 2. This is the
-// right measure — shape-agnostic to the container (bot-review #L/#M/#N + CodeRabbit object-map): a RECORD count
-// over-counts a /me with a self-owned child collection and under-counts an unrecognized wrapper / object-map,
-// while a KEY count over-counts one person's email+ssn. Residual (documented, exotic + SAFE-leaning): two people
-// with DISJOINT shapes and <= 1 of each (an email-only subject + an ssn-only subject) would read as 1 — bounded
-// by the operator pointing victim_surface_id at a real single-subject /me + the verification/grader.
+// The SUBJECT identifiers found WITHIN the extracted bulk RECORDS only (NOT top-level metadata) — the v2
+// attacker OVERLAP. attackerReadsVictim must prove the attacker actually READ the victim AS A RECORD in the
+// bulk collection, not merely that the victim's email was echoed in a response METADATA field. Codex P1:
+// `{requested_by_email: victim, data:[{email:other1},{email:other2}]}` — the attacker read other1/other2,
+// NOT the victim, yet a whole-body subjectIdentifierSet would find the victim email in `requested_by_email`
+// and falsely sign attacker_read_victim_subject. Each record is one subject's row, so a serialize-extract
+// WITHIN a record is fine. extractRecords returns [] for a non-collection body → empty set → no false overlap
+// (fail closed; the v1 base gate already requires a real >= MIN-record collection, so this is never empty on a
+// proven bulk read).
+function recordBoundSubjectIdentifierSet(bodyText) {
+  const out = new Set();
+  if (typeof bodyText !== "string" || bodyText.length === 0) return out;
+  let parsed;
+  try { parsed = JSON.parse(bodyText); } catch { return out; }
+  const records = extractRecords(parsed);
+  let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS;
+  const scanLimit = Math.min(records.length, MASSREAD_PII_SCAN_RECORDS);
+  const visit = (node, depth) => {
+    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
+    if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
+    for (const key of Object.keys(node)) {
+      if (nodeBudget <= 0) return;
+      nodeBudget -= 1;
+      const value = node[key];
+      if (bucketForFieldName(key)) {
+        for (const m of piiMatchesInValue(piiValueText(value))) {
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) out.add(`${m.shape}:${m.norm}`);
+        }
+      }
+      if (value && typeof value === "object") visit(value, depth + 1);
+    }
+  };
+  for (let i = 0; i < scanLimit; i += 1) visit(records[i], 0);
+  return out;
+}
+
+// Distinct-SUBJECT count for the v2 single-subject gate — the number of distinct PEOPLE a body exposes, by
+// UNION-FIND over normalized subject-identifier values (email / ssn) with OBJECT-NODE grouping: identifiers
+// that are DIRECT SCALAR field values of the SAME object node belong to ONE subject (a /me's own `{email, ssn}`
+// siblings), while identifiers in DIFFERENT object nodes are DIFFERENT subjects unless they share a value.
+// This is the principled measure across EVERY container shape — neither the prior max-per-shape (false HIGH on
+// two disjoint-shape people `{email:a}`+`{ssn:b}` → 1, Codex P1) nor a record count (over-counts a /me with a
+// self-owned child collection #N, under-counts an unrecognized wrapper #M / object-map) gets all cases right:
+//   • `{email,ssn}` (one /me) → both DIRECT scalars of the root node → union → 1 subject;
+//   • `[{email:a},{email:b}]` / `{members:[…]}` (#M) / `{u1:{…},u2:{…}}` (object-map) → each person is a
+//     SEPARATE object node → 2+ subjects (works whether or not the container key is recognized/sensitive);
+//   • `{email, items:[{sku}…]}` (#N self-owned child collection) → items carry no identifier → 1 subject;
+//   • `{email:a}` and `{ssn:b}` two disjoint people in separate nodes → 2 subjects (Codex P1 fixed).
+// SCALAR-ONLY direct extraction is deliberate: a sensitively-NAMED container key whose VALUE is an object /
+// array (`{contacts:[{email:a},{email:b}]}`) must NOT serialize-and-merge its children into the parent node
+// (that would mint a false HIGH) — those children are their own nodes, reached by recursion. Residual
+// (documented, SAFE-leaning → at worst a missed HIGH that stays MEDIUM, never a false HIGH): one subject whose
+// identifiers are SPLIT across nested objects (`{email, profile:{ssn}}`) reads as 2, and a structured-field /
+// array-of-scalars identifier (`{email:{value:"a@x"}}`, `{emails:["a@x","b@x"]}`) is not counted as this node's
+// own subject — both err toward REJECTING the single-subject gate (the run falls back to the v1 MEDIUM).
 function distinctSubjectCount(bodyText) {
-  const ids = subjectIdentifierSet(bodyText); // `${shape}:${norm}` keys (email/ssn), recursed + normalized
-  const perShape = new Map();
-  for (const k of ids) {
-    const shape = k.slice(0, k.indexOf(":"));
-    perShape.set(shape, (perShape.get(shape) || 0) + 1);
-  }
-  let max = 0;
-  for (const c of perShape.values()) if (c > max) max = c;
-  return max;
+  if (typeof bodyText !== "string" || bodyText.length === 0) return 0;
+  let parsed;
+  try { parsed = JSON.parse(bodyText); } catch { return 0; }
+  const parent = new Map();
+  const findRoot = (x) => { let r = x; while (parent.get(r) !== r) r = parent.get(r); let c = x; while (parent.get(c) !== r) { const n = parent.get(c); parent.set(c, r); c = n; } return r; };
+  const ensure = (x) => { if (!parent.has(x)) parent.set(x, x); };
+  const union = (a, b) => { ensure(a); ensure(b); const ra = findRoot(a); const rb = findRoot(b); if (ra !== rb) parent.set(ra, rb); };
+  let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS; // whole-body, bounded
+  const visit = (node, depth) => {
+    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
+    if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
+    const direct = []; // THIS object node's OWN subject identifiers (scalar field values only)
+    for (const key of Object.keys(node)) {
+      if (nodeBudget <= 0) return;
+      nodeBudget -= 1;
+      const value = node[key];
+      const isScalar = value == null || typeof value !== "object";
+      if (isScalar && bucketForFieldName(key)) {
+        for (const m of piiMatchesInValue(piiValueText(value))) {
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) direct.push(`${m.shape}:${m.norm}`);
+        }
+      }
+      if (value && typeof value === "object") visit(value, depth + 1); // children are their own nodes
+    }
+    if (direct.length > 0) { // this node's identifiers → one subject; cross-node merges happen by shared value
+      ensure(direct[0]);
+      for (let k = 1; k < direct.length; k += 1) union(direct[0], direct[k]);
+    }
+  };
+  visit(parsed, 0);
+  const roots = new Set();
+  for (const v of parent.keys()) roots.add(findRoot(v));
+  return roots.size;
 }
 
 // The control-denial PREDICATE, factored out so the v1 LISTING control AND the v2 anon-VICTIM control
@@ -1232,8 +1303,11 @@ async function massreadConfirm(args = {}, { driver = null } = {}) {
             // anon must not see the victim's identity in EITHER structured fields or RAW denial text (#F).
             const anonSeesVictimIdentity = subjectIdentifierSet(anonVictim.body).has(victimKey)
               || subjectIdentifiersInRawText(anonVictim.body).has(victimKey);
-            // The anchored overlap: the attacker's bulk read contains the victim's KNOWN identity.
-            const attackerReadsVictim = subjectIdentifierSet(attacker.body).has(victimKey);
+            // The anchored overlap: the attacker's bulk read contains the victim's KNOWN identity — RECORD-bound
+            // (not whole-body), so the victim must appear as a bulk RECORD the attacker READ, not merely echoed in
+            // response metadata like `requested_by_email` (Codex P1: that would sign attacker_read_victim_subject
+            // falsely even though the attacker read only OTHER subjects' rows).
+            const attackerReadsVictim = recordBoundSubjectIdentifierSet(attacker.body).has(victimKey);
             const proven = victimReadsOwnIdentity && victimScopeSingleSubject
               && anonVictimDenied && !anonSeesVictimIdentity && attackerReadsVictim;
             victimDiag.victim_status = victim.status;

--- a/mcp/lib/offensive-massread-producer.js
+++ b/mcp/lib/offensive-massread-producer.js
@@ -637,47 +637,54 @@ function subjectIdentifierSet(bodyText) {
   if (typeof bodyText !== "string" || bodyText.length === 0) return out;
   let parsed;
   try { parsed = JSON.parse(bodyText); } catch { return out; }
-  const records = extractRecords(parsed);
-  const scan = records.length > 0 ? records : (isPlainObject(parsed) ? [parsed] : []);
-  const scanLimit = Math.min(scan.length, MASSREAD_PII_SCAN_RECORDS);
-  for (let i = 0; i < scanLimit; i += 1) {
-    let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD;
-    const visit = (node, depth) => {
-      if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH) return;
-      if (Array.isArray(node)) {
-        for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); }
-        return;
-      }
-      for (const key of Object.keys(node)) {
-        if (nodeBudget <= 0) return;
-        nodeBudget -= 1;
-        const value = node[key];
-        if (bucketForFieldName(key)) {
-          const valueText = piiValueText(value);
-          for (const m of (valueText ? piiMatchesInValue(valueText) : [])) {
-            if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) out.add(`${m.shape}:${m.norm}`);
-          }
+  // Scan the ENTIRE body (top-level fields + nested objects + every collection element), NOT an
+  // extractRecords-selected subset: a /me's OWN top-level identifier must be seen even when the body ALSO
+  // embeds a recognized child collection (`{email, items:[...]}` — extractRecords would pick `items` and miss
+  // the top-level email, bot-review #N), and a wrapper / object-map's nested subjects must all be counted
+  // (#M / CodeRabbit). Used in the victim arm for membership (does X contain victimKey) + distinctSubjectCount.
+  let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS; // whole-body, bounded
+  const visit = (node, depth) => {
+    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
+    if (Array.isArray(node)) {
+      for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); }
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (nodeBudget <= 0) return;
+      nodeBudget -= 1;
+      const value = node[key];
+      if (bucketForFieldName(key)) {
+        const valueText = piiValueText(value);
+        for (const m of (valueText ? piiMatchesInValue(valueText) : [])) {
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) out.add(`${m.shape}:${m.norm}`);
         }
-        if (value && typeof value === "object") visit(value, depth + 1);
       }
-    };
-    visit(scan[i], 0);
-  }
+      if (value && typeof value === "object") visit(value, depth + 1);
+    }
+  };
+  visit(parsed, 0);
   return out;
 }
 
-// The number of RECORDS (≈ people) a body represents — a multi-element collection's element count, or 1 for a
-// top-level singleton object (a /me). Used for the v2 single-subject gate: "the victim's own scope is ONE
-// record, not a multi-subject org/team listing" (bot-review #L). Counting RECORDS — not distinct identifier
-// KEYS — is what's correct: one person's record legitimately carries SEVERAL subject-identifier shapes (an
-// email AND an ssn), so a key-count would wrongly flag a normal /me as multi-subject (live-validation finding).
-function recordCountOf(bodyText) {
-  if (typeof bodyText !== "string" || bodyText.length === 0) return 0;
-  let parsed;
-  try { parsed = JSON.parse(bodyText); } catch { return 0; }
-  const records = extractRecords(parsed);
-  if (records.length > 0) return records.length;
-  return isPlainObject(parsed) ? 1 : 0; // a top-level singleton object is ONE record
+// Distinct-SUBJECT count for the v2 single-subject gate: the MAX, over each subject-identifier SHAPE
+// (email / ssn — the shapes ~1:1 with a person), of the distinct normalized VALUES of that shape anywhere in
+// the body. ONE person's /me carries at most one of each shape, so a single subject → 1; a multi-subject scope
+// (an array of members, an object-map of users, a team wrapper) carries 2+ distinct EMAILS → >= 2. This is the
+// right measure — shape-agnostic to the container (bot-review #L/#M/#N + CodeRabbit object-map): a RECORD count
+// over-counts a /me with a self-owned child collection and under-counts an unrecognized wrapper / object-map,
+// while a KEY count over-counts one person's email+ssn. Residual (documented, exotic + SAFE-leaning): two people
+// with DISJOINT shapes and <= 1 of each (an email-only subject + an ssn-only subject) would read as 1 — bounded
+// by the operator pointing victim_surface_id at a real single-subject /me + the verification/grader.
+function distinctSubjectCount(bodyText) {
+  const ids = subjectIdentifierSet(bodyText); // `${shape}:${norm}` keys (email/ssn), recursed + normalized
+  const perShape = new Map();
+  for (const k of ids) {
+    const shape = k.slice(0, k.indexOf(":"));
+    perShape.set(shape, (perShape.get(shape) || 0) + 1);
+  }
+  let max = 0;
+  for (const c of perShape.values()) if (c > max) max = c;
+  return max;
 }
 
 // The control-denial PREDICATE, factored out so the v1 LISTING control AND the v2 anon-VICTIM control
@@ -1212,12 +1219,12 @@ async function massreadConfirm(args = {}, { driver = null } = {}) {
             // The victim arm must read its OWN known identity from this scope.
             const victimReadsOwnIdentity = victimSubjects.has(victimKey);
             // …AND the scope must be SINGLE-SUBJECT (the victim's own /me), not a multi-subject team/org/
-            // listing endpoint that merely INCLUDES the victim among others (bot-review #L). On a shared
+            // listing/map that merely INCLUDES the victim among others (bot-review #L/#M/#N). On a shared
             // multi-subject scope the victim does not OWN the other subjects' data, so "victim_read_own_
-            // private_scope" would be untruthful. Count RECORDS (people), NOT identifier keys: one person's
-            // /me record carries several identifier shapes (email AND ssn), so a key-count wrongly rejected a
-            // normal /me as multi-subject (live-validation finding) — a single record (or singleton) is one subject.
-            const victimScopeSingleSubject = recordCountOf(victim.body) === 1;
+            // private_scope" would be untruthful. distinctSubjectCount === 1: exactly one subject (one person's
+            // email, plus optionally their own ssn) — a multi-person array / object-map / wrapper carries 2+
+            // distinct emails and is rejected; a /me with email+ssn or a self-owned child collection stays 1.
+            const victimScopeSingleSubject = distinctSubjectCount(victim.body) === 1;
             const anonVictimSummary = deriveMaskedSummary(anonVictim.body);
             const anonVictimDenied = controlIsCleanDenial(
               anonVictimSummary, anonVictim, controlReadsAnyPii(anonVictimSummary, anonVictim.body),

--- a/mcp/lib/offensive-massread-producer.js
+++ b/mcp/lib/offensive-massread-producer.js
@@ -666,6 +666,20 @@ function subjectIdentifierSet(bodyText) {
   return out;
 }
 
+// The number of RECORDS (≈ people) a body represents — a multi-element collection's element count, or 1 for a
+// top-level singleton object (a /me). Used for the v2 single-subject gate: "the victim's own scope is ONE
+// record, not a multi-subject org/team listing" (bot-review #L). Counting RECORDS — not distinct identifier
+// KEYS — is what's correct: one person's record legitimately carries SEVERAL subject-identifier shapes (an
+// email AND an ssn), so a key-count would wrongly flag a normal /me as multi-subject (live-validation finding).
+function recordCountOf(bodyText) {
+  if (typeof bodyText !== "string" || bodyText.length === 0) return 0;
+  let parsed;
+  try { parsed = JSON.parse(bodyText); } catch { return 0; }
+  const records = extractRecords(parsed);
+  if (records.length > 0) return records.length;
+  return isPlainObject(parsed) ? 1 : 0; // a top-level singleton object is ONE record
+}
+
 // The control-denial PREDICATE, factored out so the v1 LISTING control AND the v2 anon-VICTIM control
 // score denial through ONE battle-tested path (no drift between two copies of a security check). Split
 // into the two questions the inline v1 block asks (kept byte-identical):
@@ -1200,8 +1214,10 @@ async function massreadConfirm(args = {}, { driver = null } = {}) {
             // …AND the scope must be SINGLE-SUBJECT (the victim's own /me), not a multi-subject team/org/
             // listing endpoint that merely INCLUDES the victim among others (bot-review #L). On a shared
             // multi-subject scope the victim does not OWN the other subjects' data, so "victim_read_own_
-            // private_scope" would be untruthful; require exactly one distinct subject so the leg is honest.
-            const victimScopeSingleSubject = victimSubjects.size === 1;
+            // private_scope" would be untruthful. Count RECORDS (people), NOT identifier keys: one person's
+            // /me record carries several identifier shapes (email AND ssn), so a key-count wrongly rejected a
+            // normal /me as multi-subject (live-validation finding) — a single record (or singleton) is one subject.
+            const victimScopeSingleSubject = recordCountOf(victim.body) === 1;
             const anonVictimSummary = deriveMaskedSummary(anonVictim.body);
             const anonVictimDenied = controlIsCleanDenial(
               anonVictimSummary, anonVictim, controlReadsAnyPii(anonVictimSummary, anonVictim.body),

--- a/mcp/lib/offensive-massread-producer.js
+++ b/mcp/lib/offensive-massread-producer.js
@@ -667,23 +667,27 @@ function subjectIdentifierSet(bodyText) {
   return out;
 }
 
-// The SUBJECT identifiers found WITHIN the extracted bulk RECORDS only (NOT top-level metadata) — the v2
-// attacker OVERLAP. attackerReadsVictim must prove the attacker actually READ the victim AS A RECORD in the
-// bulk collection, not merely that the victim's email was echoed in a response METADATA field. Codex P1:
-// `{requested_by_email: victim, data:[{email:other1},{email:other2}]}` — the attacker read other1/other2,
-// NOT the victim, yet a whole-body subjectIdentifierSet would find the victim email in `requested_by_email`
-// and falsely sign attacker_read_victim_subject. Each record is one subject's row, so a serialize-extract
-// WITHIN a record is fine. extractRecords returns [] for a non-collection body → empty set → no false overlap
-// (fail closed; the v1 base gate already requires a real >= MIN-record collection, so this is never empty on a
-// proven bulk read).
-function recordBoundSubjectIdentifierSet(bodyText) {
-  const out = new Set();
-  if (typeof bodyText !== "string" || bodyText.length === 0) return out;
+// Did the attacker read the victim AS A RECORD'S OWN SUBJECT (the v2 OVERLAP)? Record-bound is not enough —
+// it must be SUBJECT-bound (Codex P1 / CodeRabbit): a bulk row's sensitively-named fields include the row's
+// own identity (`email`) AND relational METADATA naming OTHER principals (`viewer_email`, `requested_by_email`,
+// `teammate_email` = who requested / is viewing / relates to the row). Matching the victim in ANY sensitive
+// field would sign attacker_read_victim_subject on `{email: other1, viewer_email: victim}` even though the
+// attacker read OTHER1's record, not the victim's. We bind to the row's own subject WITHOUT parsing field-name
+// semantics, via CROSS-RECORD VARIANCE: per field-NAME, collect the distinct normalized subject-identifier
+// values across all records; a field whose values VARY (>= 2 distinct) is a SUBJECT field (it identifies each
+// row's own principal), while a field CONSTANT across records is shared metadata (one requester/viewer stamped
+// on every row). The victim overlaps iff victimKey is a value of some VARYING field. (Top-level metadata is
+// already excluded by scanning extractRecords records only; this additionally excludes IN-ROW metadata.) The
+// base gate requires >= MIN DISTINCT subjects, so the row's subject field necessarily varies and a genuine
+// victim-subject is caught; a fail-closed empty/non-collection body yields no overlap.
+function attackerReadVictimSubject(bodyText, victimKey) {
+  if (typeof bodyText !== "string" || bodyText.length === 0) return false;
   let parsed;
-  try { parsed = JSON.parse(bodyText); } catch { return out; }
+  try { parsed = JSON.parse(bodyText); } catch { return false; }
   const records = extractRecords(parsed);
   let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS;
   const scanLimit = Math.min(records.length, MASSREAD_PII_SCAN_RECORDS);
+  const byField = new Map(); // field NAME → Set of `${shape}:${norm}` values seen in that field across records
   const visit = (node, depth) => {
     if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
     if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
@@ -693,69 +697,70 @@ function recordBoundSubjectIdentifierSet(bodyText) {
       const value = node[key];
       if (bucketForFieldName(key)) {
         for (const m of piiMatchesInValue(piiValueText(value))) {
-          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) out.add(`${m.shape}:${m.norm}`);
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) {
+            if (!byField.has(key)) byField.set(key, new Set());
+            byField.get(key).add(`${m.shape}:${m.norm}`);
+          }
         }
       }
       if (value && typeof value === "object") visit(value, depth + 1);
     }
   };
   for (let i = 0; i < scanLimit; i += 1) visit(records[i], 0);
-  return out;
+  for (const vals of byField.values()) {
+    if (vals.size >= 2 && vals.has(victimKey)) return true; // victimKey is a value of a VARYING (subject) field
+  }
+  return false;
 }
 
-// Distinct-SUBJECT count for the v2 single-subject gate — the number of distinct PEOPLE a body exposes, by
-// UNION-FIND over normalized subject-identifier values (email / ssn) with OBJECT-NODE grouping: identifiers
-// that are DIRECT SCALAR field values of the SAME object node belong to ONE subject (a /me's own `{email, ssn}`
-// siblings), while identifiers in DIFFERENT object nodes are DIFFERENT subjects unless they share a value.
-// This is the principled measure across EVERY container shape — neither the prior max-per-shape (false HIGH on
-// two disjoint-shape people `{email:a}`+`{ssn:b}` → 1, Codex P1) nor a record count (over-counts a /me with a
-// self-owned child collection #N, under-counts an unrecognized wrapper #M / object-map) gets all cases right:
-//   • `{email,ssn}` (one /me) → both DIRECT scalars of the root node → union → 1 subject;
-//   • `[{email:a},{email:b}]` / `{members:[…]}` (#M) / `{u1:{…},u2:{…}}` (object-map) → each person is a
-//     SEPARATE object node → 2+ subjects (works whether or not the container key is recognized/sensitive);
-//   • `{email, items:[{sku}…]}` (#N self-owned child collection) → items carry no identifier → 1 subject;
-//   • `{email:a}` and `{ssn:b}` two disjoint people in separate nodes → 2 subjects (Codex P1 fixed).
-// SCALAR-ONLY direct extraction is deliberate: a sensitively-NAMED container key whose VALUE is an object /
-// array (`{contacts:[{email:a},{email:b}]}`) must NOT serialize-and-merge its children into the parent node
-// (that would mint a false HIGH) — those children are their own nodes, reached by recursion. Residual
-// (documented, SAFE-leaning → at worst a missed HIGH that stays MEDIUM, never a false HIGH): one subject whose
-// identifiers are SPLIT across nested objects (`{email, profile:{ssn}}`) reads as 2, and a structured-field /
-// array-of-scalars identifier (`{email:{value:"a@x"}}`, `{emails:["a@x","b@x"]}`) is not counted as this node's
-// own subject — both err toward REJECTING the single-subject gate (the run falls back to the v1 MEDIUM).
+// Distinct-SUBJECT count for the v2 single-subject gate — the number of distinct PEOPLE a body exposes. Per
+// OBJECT NODE, count the distinct normalized VALUES of each subject-identifier SHAPE (email / ssn) among that
+// node's sensitively-named fields, and credit the node the MAX over shapes; SUM that across all nodes. Two
+// principles combine:
+//   • MAX-over-shape WITHIN a node — one person carries at most one of each shape, so `{email, ssn}` → max(1
+//     email, 1 ssn) = 1 (the live-validation /me, HIGH), but two DISTINCT same-shape values in sibling fields
+//     `{email:victim, teammate_email:other}` → 2 emails → 2 (Codex P1 752: a node can hold MULTIPLE people).
+//   • SUM ACROSS nodes — each object node is its own subject scope: `[{email:a},{email:b}]` / `{members:[…]}`
+//     (#M) / `{u1:{…},u2:{…}}` (object-map) → separate nodes → 2+; `{email, items:[{sku}…]}` (#N) → items carry
+//     no identifier → 1; `{email:a}` and `{ssn:b}` in separate nodes → 2 (Codex P1 round-2).
+// Object/array VALUES of a sensitive key ARE serialized-extracted (NOT skipped) so `{email:victim,
+// secondary_email:[other]}` counts both (Codex P1 743); under max-per-shape this is SAFE — a multi-subject
+// container reads as >= 2 (→ MEDIUM), never collapsing to a false-HIGH 1. Residual (documented, SAFE-leaning →
+// at worst a missed HIGH that stays MEDIUM, never a false HIGH): one subject SPLIT across separate nested
+// objects (`{email, profile:{ssn}}`) or carrying multiple distinct same-shape values (primary+recovery email)
+// reads as 2 → falls back to the v1 MEDIUM. The one err-toward-HIGH case — two DIFFERENT people's DIFFERENT
+// shapes fused into one FLAT object (`{email:alice, ssn:bobs}`) → max(1,1)=1 — is not a realistic API record
+// shape and is bounded by the synthetic-victim anchor + 3-round verification + grader.
 function distinctSubjectCount(bodyText) {
   if (typeof bodyText !== "string" || bodyText.length === 0) return 0;
   let parsed;
   try { parsed = JSON.parse(bodyText); } catch { return 0; }
-  const parent = new Map();
-  const findRoot = (x) => { let r = x; while (parent.get(r) !== r) r = parent.get(r); let c = x; while (parent.get(c) !== r) { const n = parent.get(c); parent.set(c, r); c = n; } return r; };
-  const ensure = (x) => { if (!parent.has(x)) parent.set(x, x); };
-  const union = (a, b) => { ensure(a); ensure(b); const ra = findRoot(a); const rb = findRoot(b); if (ra !== rb) parent.set(ra, rb); };
   let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS; // whole-body, bounded
+  let total = 0;
   const visit = (node, depth) => {
     if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
     if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
-    const direct = []; // THIS object node's OWN subject identifiers (scalar field values only)
+    const perShape = new Map(); // shape → Set of this node's distinct normalized values for that shape
     for (const key of Object.keys(node)) {
       if (nodeBudget <= 0) return;
       nodeBudget -= 1;
       const value = node[key];
-      const isScalar = value == null || typeof value !== "object";
-      if (isScalar && bucketForFieldName(key)) {
+      if (bucketForFieldName(key)) {
         for (const m of piiMatchesInValue(piiValueText(value))) {
-          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) direct.push(`${m.shape}:${m.norm}`);
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) {
+            if (!perShape.has(m.shape)) perShape.set(m.shape, new Set());
+            perShape.get(m.shape).add(m.norm);
+          }
         }
       }
       if (value && typeof value === "object") visit(value, depth + 1); // children are their own nodes
     }
-    if (direct.length > 0) { // this node's identifiers → one subject; cross-node merges happen by shared value
-      ensure(direct[0]);
-      for (let k = 1; k < direct.length; k += 1) union(direct[0], direct[k]);
-    }
+    let nodeMax = 0;
+    for (const vals of perShape.values()) if (vals.size > nodeMax) nodeMax = vals.size;
+    total += nodeMax;
   };
   visit(parsed, 0);
-  const roots = new Set();
-  for (const v of parent.keys()) roots.add(findRoot(v));
-  return roots.size;
+  return total;
 }
 
 // The control-denial PREDICATE, factored out so the v1 LISTING control AND the v2 anon-VICTIM control
@@ -1303,11 +1308,11 @@ async function massreadConfirm(args = {}, { driver = null } = {}) {
             // anon must not see the victim's identity in EITHER structured fields or RAW denial text (#F).
             const anonSeesVictimIdentity = subjectIdentifierSet(anonVictim.body).has(victimKey)
               || subjectIdentifiersInRawText(anonVictim.body).has(victimKey);
-            // The anchored overlap: the attacker's bulk read contains the victim's KNOWN identity — RECORD-bound
-            // (not whole-body), so the victim must appear as a bulk RECORD the attacker READ, not merely echoed in
-            // response metadata like `requested_by_email` (Codex P1: that would sign attacker_read_victim_subject
-            // falsely even though the attacker read only OTHER subjects' rows).
-            const attackerReadsVictim = recordBoundSubjectIdentifierSet(attacker.body).has(victimKey);
+            // The anchored overlap: the attacker's bulk read contains the victim as a RECORD'S OWN SUBJECT —
+            // SUBJECT-bound (not merely record-bound), so a victim identity echoed in row/top-level METADATA
+            // (`requested_by_email` / `viewer_email`) does NOT count; only the victim appearing as a value of a
+            // VARYING subject field signs attacker_read_victim_subject (Codex P1 / CodeRabbit).
+            const attackerReadsVictim = attackerReadVictimSubject(attacker.body, victimKey);
             const proven = victimReadsOwnIdentity && victimScopeSingleSubject
               && anonVictimDenied && !anonSeesVictimIdentity && attackerReadsVictim;
             victimDiag.victim_status = victim.status;

--- a/mcp/lib/offensive-massread-producer.js
+++ b/mcp/lib/offensive-massread-producer.js
@@ -667,27 +667,17 @@ function subjectIdentifierSet(bodyText) {
   return out;
 }
 
-// Did the attacker read the victim AS A RECORD'S OWN SUBJECT (the v2 OVERLAP)? Record-bound is not enough —
-// it must be SUBJECT-bound (Codex P1 / CodeRabbit): a bulk row's sensitively-named fields include the row's
-// own identity (`email`) AND relational METADATA naming OTHER principals (`viewer_email`, `requested_by_email`,
-// `teammate_email` = who requested / is viewing / relates to the row). Matching the victim in ANY sensitive
-// field would sign attacker_read_victim_subject on `{email: other1, viewer_email: victim}` even though the
-// attacker read OTHER1's record, not the victim's. We bind to the row's own subject WITHOUT parsing field-name
-// semantics, via CROSS-RECORD VARIANCE: per field-NAME, collect the distinct normalized subject-identifier
-// values across all records; a field whose values VARY (>= 2 distinct) is a SUBJECT field (it identifies each
-// row's own principal), while a field CONSTANT across records is shared metadata (one requester/viewer stamped
-// on every row). The victim overlaps iff victimKey is a value of some VARYING field. (Top-level metadata is
-// already excluded by scanning extractRecords records only; this additionally excludes IN-ROW metadata.) The
-// base gate requires >= MIN DISTINCT subjects, so the row's subject field necessarily varies and a genuine
-// victim-subject is caught; a fail-closed empty/non-collection body yields no overlap.
-function attackerReadVictimSubject(bodyText, victimKey) {
-  if (typeof bodyText !== "string" || bodyText.length === 0) return false;
+// The field PROPERTY-KEY names under which victimKey appears in the victim's OWN /me — the victim's subject
+// field(s). The /me is the victim reading ITSELF, so whatever key holds victimKey there IS the subject-identity
+// key for this principal (`email`, or a nested `…email`). Used to bind the attacker overlap to the SAME kind of
+// field, so a bulk row's RELATIONAL metadata under a DIFFERENT property key (`viewer_email`, `manager_email`,
+// `requested_by_email`) cannot pose as the victim's record (Codex P1 711). Returns the bare leaf KEY names.
+function victimSubjectLeafNames(victimBodyText, victimKey) {
+  const out = new Set();
+  if (typeof victimBodyText !== "string" || victimBodyText.length === 0) return out;
   let parsed;
-  try { parsed = JSON.parse(bodyText); } catch { return false; }
-  const records = extractRecords(parsed);
+  try { parsed = JSON.parse(victimBodyText); } catch { return out; }
   let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS;
-  const scanLimit = Math.min(records.length, MASSREAD_PII_SCAN_RECORDS);
-  const byField = new Map(); // field NAME → Set of `${shape}:${norm}` values seen in that field across records
   const visit = (node, depth) => {
     if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
     if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
@@ -697,18 +687,65 @@ function attackerReadVictimSubject(bodyText, victimKey) {
       const value = node[key];
       if (bucketForFieldName(key)) {
         for (const m of piiMatchesInValue(piiValueText(value))) {
-          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) {
-            if (!byField.has(key)) byField.set(key, new Set());
-            byField.get(key).add(`${m.shape}:${m.norm}`);
-          }
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape) && `${m.shape}:${m.norm}` === victimKey) out.add(key);
         }
       }
       if (value && typeof value === "object") visit(value, depth + 1);
     }
   };
-  for (let i = 0; i < scanLimit; i += 1) visit(records[i], 0);
-  for (const vals of byField.values()) {
-    if (vals.size >= 2 && vals.has(victimKey)) return true; // victimKey is a value of a VARYING (subject) field
+  visit(parsed, 0);
+  return out;
+}
+
+// Did the attacker read the victim AS A RECORD'S OWN SUBJECT (the v2 OVERLAP)? Record-bound is not enough — it
+// must be SUBJECT-bound (Codex P1 / CodeRabbit): a bulk row's sensitively-named fields include the row's own
+// identity (`email`) AND relational METADATA naming OTHER principals (`viewer_email` = who is viewing,
+// `requested_by_email` = who requested). Two independent guards bind to the row's OWN subject WITHOUT a
+// field-name denylist:
+//   (1) CROSS-RECORD VARIANCE, per FULL PATH — a path whose values VARY (>= 2 distinct) across records is a
+//       SUBJECT field (it identifies each row's principal); a CONSTANT path is shared metadata stamped on every
+//       row. Keying by full path (not bare leaf) keeps a nested metadata path `viewer.email` separate from the
+//       row subject `email` (Codex P1 702).
+//   (2) FIELD-CONSISTENCY with the victim's OWN /me — the matching path's leaf KEY must be one under which the
+//       victim's own /me carried victimKey (victimSubjectLeafNames). So a metadata field under a DIFFERENT key
+//       (`manager_email`, `referred_by_email`) that merely VARIES per row cannot pose as the subject (Codex P1
+//       711), while the victim's genuine subject field (`email`, possibly nested differently in the listing
+//       than in /me) still matches on its leaf key.
+// The victim overlaps iff victimKey is a value of a VARYING path whose leaf key ∈ the victim's /me subject keys.
+// The base gate already requires >= MIN DISTINCT subjects (the subject field necessarily varies), so a genuine
+// victim-subject is caught; empty/non-collection body or unknown victim subject field → fail closed (no overlap).
+function attackerReadVictimSubject(victimBodyText, attackerBodyText, victimKey) {
+  const subjectLeaves = victimSubjectLeafNames(victimBodyText, victimKey);
+  if (subjectLeaves.size === 0) return false; // victim's own subject field unknown → cannot bind → fail closed
+  if (typeof attackerBodyText !== "string" || attackerBodyText.length === 0) return false;
+  let parsed;
+  try { parsed = JSON.parse(attackerBodyText); } catch { return false; }
+  const records = extractRecords(parsed);
+  let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS;
+  const scanLimit = Math.min(records.length, MASSREAD_PII_SCAN_RECORDS);
+  const byPath = new Map(); // full path → { leaf, values: Set of `${shape}:${norm}` across records }
+  const visit = (node, depth, path) => {
+    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
+    if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1, path); } return; }
+    for (const key of Object.keys(node)) {
+      if (nodeBudget <= 0) return;
+      nodeBudget -= 1;
+      const value = node[key];
+      const childPath = path ? `${path}.${key}` : key;
+      if (bucketForFieldName(key)) {
+        for (const m of piiMatchesInValue(piiValueText(value))) {
+          if (SUBJECT_IDENTIFIER_SHAPES.has(m.shape)) {
+            if (!byPath.has(childPath)) byPath.set(childPath, { leaf: key, values: new Set() });
+            byPath.get(childPath).values.add(`${m.shape}:${m.norm}`);
+          }
+        }
+      }
+      if (value && typeof value === "object") visit(value, depth + 1, childPath);
+    }
+  };
+  for (let i = 0; i < scanLimit; i += 1) visit(records[i], 0, "");
+  for (const { leaf, values } of byPath.values()) {
+    if (values.size >= 2 && subjectLeaves.has(leaf) && values.has(victimKey)) return true;
   }
   return false;
 }
@@ -728,21 +765,30 @@ function attackerReadVictimSubject(bodyText, victimKey) {
 // container reads as >= 2 (→ MEDIUM), never collapsing to a false-HIGH 1. Residual (documented, SAFE-leaning →
 // at worst a missed HIGH that stays MEDIUM, never a false HIGH): one subject SPLIT across separate nested
 // objects (`{email, profile:{ssn}}`) or carrying multiple distinct same-shape values (primary+recovery email)
-// reads as 2 → falls back to the v1 MEDIUM. The one err-toward-HIGH case — two DIFFERENT people's DIFFERENT
-// shapes fused into one FLAT object (`{email:alice, ssn:bobs}`) → max(1,1)=1 — is not a realistic API record
-// shape and is bounded by the synthetic-victim anchor + 3-round verification + grader.
+// reads as 2 → falls back to the v1 MEDIUM. Two err-toward-HIGH residuals remain, both requiring the victim's
+// OWN /me to embed ANOTHER REAL principal's identifier in a sibling field — impossible for the SYNTHETIC,
+// freshly-minted victim (a brand-new account has no spouse / dependent / teammate data), and otherwise bounded
+// by the operator pointing victim_surface_id at a real /me + 3-round verification + grader: (a) two DIFFERENT
+// people's SAME shape is caught (max counts 2 emails), but two people's DIFFERENT shapes fused into one FLAT
+// object (`{email:victim, spouse_ssn:other}` / `{email:alice, ssn:bobs}`) → max(1,1)=1 (Codex P1 760 — a bare
+// `ssn` sibling is indistinguishable from the victim's OWN ssn without field-name semantics, which would be an
+// incomplete denylist; the robust future upgrade is canary-injection like the IDOR producer). If the bounded
+// node BUDGET is exhausted mid-walk, FAIL CLOSED (return >= 2) so an only-partially-scanned large scope is never
+// accepted as single-subject (CodeRabbit).
 function distinctSubjectCount(bodyText) {
   if (typeof bodyText !== "string" || bodyText.length === 0) return 0;
   let parsed;
   try { parsed = JSON.parse(bodyText); } catch { return 0; }
   let nodeBudget = MASSREAD_MAX_NODES_PER_RECORD * MASSREAD_PII_SCAN_RECORDS; // whole-body, bounded
+  let budgetExhausted = false;
   let total = 0;
   const visit = (node, depth) => {
-    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH || nodeBudget <= 0) return;
-    if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) return; visit(item, depth + 1); } return; }
+    if (node == null || typeof node !== "object" || depth > MASSREAD_MAX_RECORD_DEPTH) return;
+    if (nodeBudget <= 0) { budgetExhausted = true; return; }
+    if (Array.isArray(node)) { for (const item of node) { if (nodeBudget <= 0) { budgetExhausted = true; return; } visit(item, depth + 1); } return; }
     const perShape = new Map(); // shape → Set of this node's distinct normalized values for that shape
     for (const key of Object.keys(node)) {
-      if (nodeBudget <= 0) return;
+      if (nodeBudget <= 0) { budgetExhausted = true; return; }
       nodeBudget -= 1;
       const value = node[key];
       if (bucketForFieldName(key)) {
@@ -760,6 +806,7 @@ function distinctSubjectCount(bodyText) {
     total += nodeMax;
   };
   visit(parsed, 0);
+  if (budgetExhausted) return Math.max(total, 2); // fail closed: a partial walk must never read as single-subject
   return total;
 }
 
@@ -1310,9 +1357,10 @@ async function massreadConfirm(args = {}, { driver = null } = {}) {
               || subjectIdentifiersInRawText(anonVictim.body).has(victimKey);
             // The anchored overlap: the attacker's bulk read contains the victim as a RECORD'S OWN SUBJECT —
             // SUBJECT-bound (not merely record-bound), so a victim identity echoed in row/top-level METADATA
-            // (`requested_by_email` / `viewer_email`) does NOT count; only the victim appearing as a value of a
-            // VARYING subject field signs attacker_read_victim_subject (Codex P1 / CodeRabbit).
-            const attackerReadsVictim = attackerReadVictimSubject(attacker.body, victimKey);
+            // (`requested_by_email` / `viewer_email` / `manager_email`) does NOT count. Bound by cross-record
+            // VARIANCE (varying path = subject, constant = metadata) AND FIELD-CONSISTENCY with the victim's own
+            // /me subject key (so a varying metadata field under a different key cannot pose as the subject).
+            const attackerReadsVictim = attackerReadVictimSubject(victim.body, attacker.body, victimKey);
             const proven = victimReadsOwnIdentity && victimScopeSingleSubject
               && anonVictimDenied && !anonSeesVictimIdentity && attackerReadsVictim;
             victimDiag.victim_status = victim.status;

--- a/test/offensive-massread-producer.test.js
+++ b/test/offensive-massread-producer.test.js
@@ -1578,10 +1578,11 @@ test("v2 → MEDIUM (#L): a multi-subject victim scope (org/team listing incl. t
   assert.equal(result.demonstrated_severity, "medium");
 }));
 
-test("v2 HIGH: a /me carrying MULTIPLE identifier shapes for ONE person (email+ssn) is single-subject (record-count, not key-count)", () => withTempHome(async () => {
-  // LIVE-VALIDATION regression: the single-subject gate must count RECORDS (people), not distinct identifier
-  // KEYS. A real /me returns one person with several identifier shapes (email AND ssn) — a key-count saw 2
-  // and wrongly declined "victim_scope_multi_subject"; a record-count sees ONE record → the victim's own /me.
+test("v2 HIGH: a /me carrying MULTIPLE identifier shapes for ONE person (email+ssn) is single-subject (distinct-subject count, not key-count)", () => withTempHome(async () => {
+  // LIVE-VALIDATION regression: the single-subject gate counts distinct SUBJECTS (max distinct values per
+  // subject shape), NOT distinct identifier KEYS. One person's /me carries several shapes (email AND ssn) → a
+  // key-count saw 2 and wrongly declined "victim_scope_multi_subject"; distinctSubjectCount sees 1 (one email,
+  // one ssn) → the victim's own /me. (Found by the first live fire; all prior unit tests used email-only bodies.)
   const domain = uniqueDomain();
   setupV2Session(domain);
   const victim = { status: 200, body: JSON.stringify({ id: 1, email: CANARY_EMAIL, ssn: "111-22-9000", phone: "+1-202-555-0150" }), final_url: null, body_truncated: false };
@@ -1589,6 +1590,44 @@ test("v2 HIGH: a /me carrying MULTIPLE identifier shapes for ONE person (email+s
   const result = await runV2(domain, { driver });
   assert.equal(result.cross_tenant_proven, true, JSON.stringify(result));
   assert.equal(result.victim_elevation, "cross_principal_break_proven");
+  assert.equal(result.demonstrated_severity, "high");
+}));
+
+test("v2 → MEDIUM (#M): a singleton WRAPPER around a multi-subject collection (unrecognized key) is NOT single-subject", () => withTempHome(async () => {
+  // {members:[{email:victim},{email:other}]} — `members` isn't a recognized collection key, so a record-count
+  // would see ONE top-level object and falsely pass. distinctSubjectCount sees 2 distinct EMAILS → rejected.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ team_id: 7, members: [{ email: CANARY_EMAIL }, { email: "teammate@canary.example.test" }] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, false);
+  assert.equal(result.victim_elevation, "victim_scope_multi_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 → MEDIUM (CodeRabbit): an OBJECT-MAP of multiple subjects (no array) is NOT single-subject", () => withTempHome(async () => {
+  // {user1:{email:victim}, user2:{email:other}} — an object map, not an array; a record-count of top-level
+  // objects would pass. distinctSubjectCount sees 2 distinct emails → rejected.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ user1: { email: CANARY_EMAIL }, user2: { email: "other@canary.example.test" } }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, false);
+  assert.equal(result.victim_elevation, "victim_scope_multi_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 HIGH (#N): a /me with a SELF-OWNED child collection (no extra subjects) stays single-subject", () => withTempHome(async () => {
+  // {email:victim, items:[...]} — `items` IS a recognized collection key, so a record-count would return the
+  // child length and falsely decline. The child items carry NO subject identifiers → distinctSubjectCount 1 → HIGH.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ id: 1, email: CANARY_EMAIL, items: [{ sku: "A1", qty: 2 }, { sku: "B2", qty: 1 }, { sku: "C3", qty: 5 }] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, true, JSON.stringify(result));
   assert.equal(result.demonstrated_severity, "high");
 }));
 

--- a/test/offensive-massread-producer.test.js
+++ b/test/offensive-massread-producer.test.js
@@ -1690,16 +1690,37 @@ test("v2 → MEDIUM (Codex P1): another subject's identifier in a NON-SCALAR sen
   assert.equal(result.demonstrated_severity, "medium");
 }));
 
-test("v2 → MEDIUM (Codex P1/CodeRabbit): the victim only as IN-ROW METADATA (viewer_email constant) is not the row's subject", () => withTempHome(async () => {
-  // The attacker's bulk rows are about OTHER subjects (`email` varies: other1, other2). The victim's email sits
-  // only in a CONSTANT relational-metadata field (`viewer_email`) — it names who is viewing, not the row's
-  // subject. Subject-binding via cross-record variance: the victim is not a value of any VARYING field → no
-  // overlap → MEDIUM (a record-bound any-sensitive-field match would have falsely signed HIGH).
+test("v2 → MEDIUM (Codex P1/CodeRabbit): the victim only as IN-ROW METADATA (viewer_email constant across records) is not the row's subject", () => withTempHome(async () => {
+  // The attacker's bulk rows are about OTHER subjects (`email` varies: other1/2/3). The victim's email sits only
+  // in `viewer_email`, CONSTANT across the rows that carry it — it names who is viewing, not a row's subject.
+  // Subject-binding (cross-record variance + field-consistency): the victim is not a value of any VARYING
+  // subject field → no overlap → MEDIUM (a record-bound any-sensitive-field match would have falsely signed
+  // HIGH). The third row (no viewer_email) keeps base distinct subjects >= MIN despite the shared metadata value.
   const domain = uniqueDomain();
   setupV2Session(domain);
   const attacker = { status: 200, body: JSON.stringify({ data: [
     { id: 1, email: "other1@canary.example.test", viewer_email: CANARY_EMAIL },
-    { id: 2, email: "other2@canary.example.test" },
+    { id: 2, email: "other2@canary.example.test", viewer_email: CANARY_EMAIL },
+    { id: 3, email: "other3@canary.example.test" },
+  ] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ attacker });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.confirmed, true, JSON.stringify(result));
+  assert.equal(result.cross_tenant_proven, false);
+  assert.equal(result.victim_elevation, "attacker_did_not_read_victim_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 → MEDIUM (Codex P1): a VARYING relational-metadata field (manager_email) is not a subject field — the victim as a manager does not overlap", () => withTempHome(async () => {
+  // `manager_email` VARIES per row (different managers), so a variance-only test would treat it as a subject
+  // field and sign HIGH if the victim is one manager. Field-consistency rejects it: the victim's own /me carries
+  // its identity under `email`, not `manager_email`, so a match under `manager_email` is metadata, not the row's
+  // subject. The victim is NOT in the `email` (real subject) values → no overlap → MEDIUM.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const attacker = { status: 200, body: JSON.stringify({ data: [
+    { id: 1, email: "other1@canary.example.test", manager_email: CANARY_EMAIL },
+    { id: 2, email: "other2@canary.example.test", manager_email: "boss2@canary.example.test" },
   ] }), final_url: null, body_truncated: false };
   const { driver } = makeV2Driver({ attacker });
   const result = await runV2(domain, { driver });

--- a/test/offensive-massread-producer.test.js
+++ b/test/offensive-massread-producer.test.js
@@ -1662,6 +1662,53 @@ test("v2 → MEDIUM (Codex P1): the attacker overlap is RECORD-bound — a victi
   assert.equal(result.demonstrated_severity, "medium");
 }));
 
+test("v2 → MEDIUM (Codex P1): two DIFFERENT people in SIBLING fields of ONE object ({email:victim,teammate_email:other}) is NOT single-subject", () => withTempHome(async () => {
+  // A single object whose sibling sensitive fields name TWO people — the victim's `email` and another subject's
+  // `teammate_email`. Object-node UNION (round-2) collapsed both same-shape identifiers into one subject → false
+  // HIGH; per-node MAX-over-shape counts 2 distinct emails in the node → 2 → rejected.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ id: 1, email: CANARY_EMAIL, teammate_email: "teammate@canary.example.test" }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, false, JSON.stringify(result));
+  assert.equal(result.victim_elevation, "victim_scope_multi_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 → MEDIUM (Codex P1): another subject's identifier in a NON-SCALAR sensitive field ({email:victim,secondary_email:[other]}) is counted", () => withTempHome(async () => {
+  // The victim's own scalar `email` plus a SECOND subject under a sensitively-named ARRAY field. The scalar-only
+  // gate (round-2) skipped the array entirely → counted 1 → false HIGH; serialize-extracting the container under
+  // max-per-shape sees 2 distinct emails in the node → 2 → rejected.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ id: 1, email: CANARY_EMAIL, secondary_email: ["other-subject@canary.example.test"] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, false, JSON.stringify(result));
+  assert.equal(result.victim_elevation, "victim_scope_multi_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 → MEDIUM (Codex P1/CodeRabbit): the victim only as IN-ROW METADATA (viewer_email constant) is not the row's subject", () => withTempHome(async () => {
+  // The attacker's bulk rows are about OTHER subjects (`email` varies: other1, other2). The victim's email sits
+  // only in a CONSTANT relational-metadata field (`viewer_email`) — it names who is viewing, not the row's
+  // subject. Subject-binding via cross-record variance: the victim is not a value of any VARYING field → no
+  // overlap → MEDIUM (a record-bound any-sensitive-field match would have falsely signed HIGH).
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const attacker = { status: 200, body: JSON.stringify({ data: [
+    { id: 1, email: "other1@canary.example.test", viewer_email: CANARY_EMAIL },
+    { id: 2, email: "other2@canary.example.test" },
+  ] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ attacker });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.confirmed, true, JSON.stringify(result));
+  assert.equal(result.cross_tenant_proven, false);
+  assert.equal(result.victim_elevation, "attacker_did_not_read_victim_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
 test("v2 HIGH still mints when the two sessions share only a SHORT benign cookie (no over-decline)", () => withTempHome(async () => {
   const domain = uniqueDomain();
   // Distinct long session tokens, but both jars carry the same short benign cookie (locale=en) — that must

--- a/test/offensive-massread-producer.test.js
+++ b/test/offensive-massread-producer.test.js
@@ -1578,6 +1578,20 @@ test("v2 → MEDIUM (#L): a multi-subject victim scope (org/team listing incl. t
   assert.equal(result.demonstrated_severity, "medium");
 }));
 
+test("v2 HIGH: a /me carrying MULTIPLE identifier shapes for ONE person (email+ssn) is single-subject (record-count, not key-count)", () => withTempHome(async () => {
+  // LIVE-VALIDATION regression: the single-subject gate must count RECORDS (people), not distinct identifier
+  // KEYS. A real /me returns one person with several identifier shapes (email AND ssn) — a key-count saw 2
+  // and wrongly declined "victim_scope_multi_subject"; a record-count sees ONE record → the victim's own /me.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ id: 1, email: CANARY_EMAIL, ssn: "111-22-9000", phone: "+1-202-555-0150" }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, true, JSON.stringify(result));
+  assert.equal(result.victim_elevation, "cross_principal_break_proven");
+  assert.equal(result.demonstrated_severity, "high");
+}));
+
 test("v2 HIGH still mints when the two sessions share only a SHORT benign cookie (no over-decline)", () => withTempHome(async () => {
   const domain = uniqueDomain();
   // Distinct long session tokens, but both jars carry the same short benign cookie (locale=en) — that must

--- a/test/offensive-massread-producer.test.js
+++ b/test/offensive-massread-producer.test.js
@@ -1631,6 +1631,37 @@ test("v2 HIGH (#N): a /me with a SELF-OWNED child collection (no extra subjects)
   assert.equal(result.demonstrated_severity, "high");
 }));
 
+test("v2 → MEDIUM (Codex P1): a MIXED-SHAPE multi-subject scope ({email:victim}+{ssn:other}) is NOT single-subject", () => withTempHome(async () => {
+  // Two DIFFERENT people exposing DISJOINT identifier shapes — the victim as {email} and a second subject as
+  // {ssn}. The prior max-per-shape count saw max(1 email, 1 ssn) = 1 and FALSELY passed the single-subject gate
+  // → a signed HIGH on a 2-person listing. Object-node grouping sees two separate subject nodes → 2 → rejected.
+  // (Contrast the flat email+ssn /me test above: ONE person's email+ssn are siblings of one node → 1 → HIGH.)
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const victim = { status: 200, body: JSON.stringify({ members: [{ email: CANARY_EMAIL }, { ssn: "987-65-4321" }] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ victim });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.cross_tenant_proven, false, JSON.stringify(result));
+  assert.equal(result.victim_elevation, "victim_scope_multi_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
+test("v2 → MEDIUM (Codex P1): the attacker overlap is RECORD-bound — a victim email in response METADATA does not count", () => withTempHome(async () => {
+  // The victim's known email appears ONLY in a top-level metadata field (requested_by_email), not in any bulk
+  // RECORD the attacker read; the attacker read only OTHER subjects' rows. Whole-body matching would falsely
+  // satisfy the overlap and sign attacker_read_victim_subject HIGH; record-bound matching scans only the `data`
+  // rows → no overlap → stays MEDIUM.
+  const domain = uniqueDomain();
+  setupV2Session(domain);
+  const attacker = { status: 200, body: JSON.stringify({ requested_by_email: CANARY_EMAIL, data: [{ id: 1, email: "other1@canary.example.test" }, { id: 2, email: "other2@canary.example.test" }] }), final_url: null, body_truncated: false };
+  const { driver } = makeV2Driver({ attacker });
+  const result = await runV2(domain, { driver });
+  assert.equal(result.confirmed, true, JSON.stringify(result));
+  assert.equal(result.cross_tenant_proven, false);
+  assert.equal(result.victim_elevation, "attacker_did_not_read_victim_subject");
+  assert.equal(result.demonstrated_severity, "medium");
+}));
+
 test("v2 HIGH still mints when the two sessions share only a SHORT benign cookie (no over-decline)", () => withTempHome(async () => {
   const domain = uniqueDomain();
   // Distinct long session tokens, but both jars carry the same short benign cookie (locale=en) — that must


### PR DESCRIPTION
## What

Fixes a soundness bug in the v2 mass-read victim arm (#159) that the **first live firing** surfaced — a real `/me` carrying one person's **email + SSN** was wrongly rejected as multi-subject, so the cross-tenant HIGH never fired.

## How it was found

I stood up a cookie-session validation lab (`/Users/memehalis/sec/offensive-lab/`) and drove the **real producer** (live Patchright browser, `authed_fetch`, real `Set-Cookie` sessions) against it — the first end-to-end firing, not a seeded driver. v1 MEDIUM fired clean; v2 fell back to MEDIUM with `victim_elevation: "victim_scope_multi_subject"`.

## Root cause

The #L single-subject gate used `subjectIdentifierSet(victim.body).size === 1`, which counts distinct identifier **keys**. One person's `/me` legitimately carries several identifier *shapes* (`email` **and** `ssn`) → 2 keys → falsely "multi-subject". Every real `/me` with email+SSN (KYC / financial / gov) would have failed HIGH. All 99 unit tests put only `email` in the victim body (size 1 either way), so they missed it.

## Fix

Count **records** (people), not identifier keys — a new `recordCountOf(body)` (a collection's element count, or 1 for a singleton `/me` object). One record = one subject regardless of identifier shapes. The #L intent is preserved: a multi-subject org/team listing is a multi-**record** collection → count > 1 → still declines.

## Verification

- **Re-fired live after the fix:** v1 MEDIUM **and** v2 HIGH both fire (`cross_tenant_proven:true`, `overlap:1`) and mint MAC-signed `offensive-runs` rows; the masked rail carries no raw PII against real bodies.
- Regression test added (a `/me` with email+ssn+phone for one person → HIGH). **100/100** producer tests, `test:mcp` green, `check:syntax` clean.

Follow-up to #159 / #157.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved v2 victim-elevation “single-subject” detection by traversing the full request payload, counting distinct normalized subject identifiers (including multi-shape cases), and failing closed when traversal limits are reached.
  * Updated attacker/victim overlap logic to enforce that overlap is derived from bulk data records (not response/relational metadata) and anchored to matching victim subject leaf keys with varying-path evidence.

* **Tests**
  * Added v2 “victim-arm” regression coverage for single-person multi-identifier eligibility, multi-subject rejection, and record-bound attacker overlap enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->