### PR TITLE
ci: bump brutalist-mcp to 1.18.3 (routed fail-fast)

### DIFF
--- a/.github/brutalist-tools/package-lock.json
+++ b/.github/brutalist-tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/claude-code": "2.1.177",
-        "@brutalist/mcp": "1.18.2",
+        "@brutalist/mcp": "1.18.3",
         "@openai/codex": "0.139.0"
       }
     },
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@brutalist/mcp": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@brutalist/mcp/-/mcp-1.18.2.tgz",
-      "integrity": "sha512-IT7xq26+6y61IVTgyd/XzkLzWNBHtGAr78Xw87OB8pIBfsukGs4C7U5nR1sME/Jkwr4B6Sfr2VKokkGXIOxt0A==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@brutalist/mcp/-/mcp-1.18.3.tgz",
+      "integrity": "sha512-1RUI5BSvGDmOOZRIFJZBYFvGnvh9vUBz1UefPIIaxSyvr9apW7JRQwKPNkYy/qP0d3m1Bsw7CumxnmM5ZsHBPg==",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/.github/brutalist-tools/package.json
+++ b/.github/brutalist-tools/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@anthropic-ai/claude-code": "2.1.177",
-    "@brutalist/mcp": "1.18.2",
+    "@brutalist/mcp": "1.18.3",
     "@openai/codex": "0.139.0"
   },
   "overrides": {

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install CLI critics
         working-directory: .github/brutalist-tools
         env:
-          EXPECTED_TOOLS_LOCK_SHA256: 3f51525eacc6d4e8f96838ebc6eb32f92dfe8057f62ffe2c3133c5400b324294
+          EXPECTED_TOOLS_LOCK_SHA256: 32506d6d425025783e47d005561698244373696505d1a3df0ad7f66b1fbd8147
         run: |
           actual="$(sha256sum package-lock.json | cut -d ' ' -f1)"
           if [ "$actual" != "$EXPECTED_TOOLS_LOCK_SHA256" ]; then


### PR DESCRIPTION
Bumps `@brutalist/mcp` to **1.18.3**: an over-quota routed critic (GLM) now **fails fast** at pre-flight (a tiny `/v1/messages` 429 probe) instead of retrying the 429 for ~3–4 min per chunk. A healthy GLM is unaffected (probe returns 200 → it runs).