### PR TITLE
ci: bump per-critic cap to 30min

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -70,8 +70,8 @@ jobs:
         # owner-controlled ejmockler/brutalist-mcp repo + release pipeline.
         uses: ejmockler/brutalist-mcp/packages/github-action@v1
         env:
-          BRUTALIST_TIMEOUT: "600000"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "900000"
+          BRUTALIST_TIMEOUT: "1800000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2700000"
           # Disable agy's in-run self-update (it self-updates from a us-central1
           # endpoint mid-run). NOTE: this does NOT pin the installed version —
           # install.sh above fetches the latest; this only stops drift WITHIN a run.


### PR DESCRIPTION
Bumps `BRUTALIST_TIMEOUT` to **30 min** (1800000) and `BRUTALIST_ORCHESTRATOR_TIMEOUT_MS` to **45 min** so a slow routed critic (GLM) gets room on large diffs instead of hitting the cap. agy unaffected (self-caps at 6 min).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the time allowed for automated review checks, helping long-running runs complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->