### PR TITLE
fix(recon): katana -kf comma-list rejected — deep crawl yielded zero URLs every run

### DIFF
--- a/.claude/agents/deep-surface-discovery-agent.md
+++ b/.claude/agents/deep-surface-discovery-agent.md
@@ -214,7 +214,7 @@ while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/c
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA=""; for c in "$HOME/go/bin/katana" "$(command -v katana 2>/dev/null||true)"; do [ -n "$c" ] && [ -x "$c" ] && ! { [ "$(head -c2 "$c" 2>/dev/null)" = '#!' ] && head -1 "$c" 2>/dev/null | grep -qi python; } && { KATANA="$c"; break; }; done
-if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 3 -jc -kf all -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
 cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'

--- a/adapters/codex/skills/bob-evaluate/SKILL.md
+++ b/adapters/codex/skills/bob-evaluate/SKILL.md
@@ -669,7 +669,7 @@ while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/c
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA=""; for c in "$HOME/go/bin/katana" "$(command -v katana 2>/dev/null||true)"; do [ -n "$c" ] && [ -x "$c" ] && ! { [ "$(head -c2 "$c" 2>/dev/null)" = '#!' ] && head -1 "$c" 2>/dev/null | grep -qi python; } && { KATANA="$c"; break; }; done
-if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 3 -jc -kf all -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
 cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'

--- a/adapters/kimi/skills/bob-evaluate/SKILL.md
+++ b/adapters/kimi/skills/bob-evaluate/SKILL.md
@@ -652,7 +652,7 @@ while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/c
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA=""; for c in "$HOME/go/bin/katana" "$(command -v katana 2>/dev/null||true)"; do [ -n "$c" ] && [ -x "$c" ] && ! { [ "$(head -c2 "$c" 2>/dev/null)" = '#!' ] && head -1 "$c" 2>/dev/null | grep -qi python; } && { KATANA="$c"; break; }; done
-if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 3 -jc -kf all -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
 cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'

--- a/prompts/roles/deep-surface-discovery.md
+++ b/prompts/roles/deep-surface-discovery.md
@@ -207,7 +207,7 @@ while read -r root; do timeout 50 curl -ks "https://web.archive.org/cdx/search/c
 { awk '{print $1}' "$SESSION/live_hosts.txt" 2>/dev/null; awk '{print $1}' "$SESSION/family_live.txt" 2>/dev/null; } | sort -u | head -n 80 > "$SESSION/crawl_roots.txt"
 : > "$SESSION/katana_urls.txt"
 KATANA=""; for c in "$HOME/go/bin/katana" "$(command -v katana 2>/dev/null||true)"; do [ -n "$c" ] && [ -x "$c" ] && ! { [ "$(head -c2 "$c" 2>/dev/null)" = '#!' ] && head -1 "$c" 2>/dev/null | grep -qi python; } && { KATANA="$c"; break; }; done
-if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
+if [ -n "$KATANA" ] && [ -s "$SESSION/crawl_roots.txt" ]; then timeout 180 "$KATANA" -list "$SESSION/crawl_roots.txt" -silent -d 3 -jc -kf all -fs rdn -rl 20 -timeout 8 -o "$SESSION/katana_urls.txt" 2>/dev/null || true; fi
 cat "$SESSION/katana_urls.txt" >> "$SESSION/all_urls.txt" 2>/dev/null || true
 sort -u -o "$SESSION/all_urls.txt" "$SESSION/all_urls.txt"
 python3 - "$SESSION" <<'PY'


### PR DESCRIPTION
## Problem

`prompts/roles/deep-surface-discovery.md` ran katana as:
```
katana -list crawl_roots.txt -silent -d 2 -jc -kf robotstxt,sitemapxml -fs rdn -rl 20 -timeout 8 -o katana_urls.txt
```
katana **rejects the comma-separated `-kf` value outright**:
```
invalid value "robotstxt,sitemapxml" for flag -kf: allowed values are sitemapxml, all, robotstxt
```
(reproduced against the live katana v1.5.0 binary). The whole katana step exits non-zero, `|| true` swallows it, and `katana_urls.txt` is **empty on every deep run** — confirmed in the dromeas.gr session (empty `katana_urls.txt`, no katana contribution to `all_urls.txt`). The deep crawl silently loses all katana-discovered URLs.

## Fix

- `-kf robotstxt,sitemapxml` → `-kf all` (a valid enum value).
- `-d 2` → `-d 3`: katana's `-known-files` **requires a minimum depth of 3** (per its own `-h` text) to crawl robots.txt/sitemap.xml properly; at `-d 2` known-files crawling under-runs even with a valid flag.

Verified against the live binary. Source edit + regenerated agent/codex/kimi copies. `test:prompts` green (202/0).

## Safety

Recon-breadth only — no auth, no offensive producers, no scope change. Strictly more coverage than the current always-failing state. Ref: `docs/DROMEAS_RUN_FORENSICS.md` MUST-FIX #5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced URL discovery depth to capture more web pages during crawling operations.
  * Expanded URL source filtering to include additional discovery methods, improving comprehensiveness of discovered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->