### PR TITLE
fix(offensive): helpful surface_id resolution error so producers self-correct

### DIFF
--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -369,43 +369,52 @@ function findRoutedSurface(domain, surfaceId) {
     // signed producer — falling back to a hand-rolled scan + manual claim, the exact under-firing
     // the offensive arsenal is meant to replace. The MESSAGE is the load-bearing self-correction
     // interface (the caller is an LLM reading the error text); no consumer reads a structured
-    // route inventory, so details stay at the stable {code}. Everything echoed is length-bounded
-    // so a single miss can't bloat the payload (this error deliberately drives a retry loop).
+    // route inventory, so details stay at the stable {code}. EVERY id echoed into the message —
+    // the caller's surface_id, the listed routes, the suggestion, and the quarantine hint — is
+    // passed through safe() (bound to MAX_ID_LEN AND control-char-stripped), so no echo path can
+    // bloat the line or forge extra message/log content. Uniform: no echo path is exempt.
     const MAX_LISTED = 20;
     const MAX_ID_LEN = 120;
-    const clip = (id) => (id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id);
-    // The caller's surface_id is untrusted free-text: bound it AND strip control chars, so a huge
-    // or newline-laden value can neither bloat the line nor forge extra message/log content.
-    const safeId = clip(surfaceId).replace(/[\x00-\x1f\x7f]/g, "·");
+    const safe = (id) => {
+      const clipped = id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id;
+      return clipped.replace(/[\x00-\x1f\x7f]/g, "·");
+    };
     const known = routed.document.routes
       .map((entry) => entry.surface_id)
       .filter((id) => typeof id === "string" && id);
-    // Suggest the closest routed id by EXACT EQUALITY only (the dropped `surface:` prefix or its
-    // inverse) — never a substring/suffix wildcard, which for a short/typo'd input could point at
-    // the wrong (if in-scope) surface, against this file's {id}-must-terminate discipline.
-    const suggestion = known.find((id) => id === `surface:${surfaceId}`)
-      || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
-      || null;
-    // If no LIVE route matches but a QUARANTINED (malformed) route matches the same exact
-    // relation, the surface exists — it just needs re-routing; say so rather than a bare
-    // "unknown" (the exact-id malformed branch above only covers the canonical-id caller; a
-    // surface that still has a valid route resolves above and never reaches here).
-    const quarantinedMatch = suggestion
-      ? null
-      : (Array.isArray(routed.malformed_routes) ? routed.malformed_routes : [])
-        .map((entry) => entry && entry.surface_id)
-        .filter((id) => typeof id === "string" && id)
-        .find((id) => id === `surface:${surfaceId}` || id === surfaceId.replace(/^surface:/, "")) || null;
+    const quarantined = (Array.isArray(routed.malformed_routes) ? routed.malformed_routes : [])
+      .map((entry) => entry && entry.surface_id)
+      .filter((id) => typeof id === "string" && id);
+    // Suggest the closest id by EXACT EQUALITY only (the dropped `surface:` prefix or its inverse)
+    // — never a substring/suffix wildcard, which for a short/typo'd input could point at the wrong
+    // (if in-scope) surface, against this file's {id}-must-terminate discipline. An exact match is
+    // only possible within ±"surface:".length of a candidate id's length, so for anything longer we
+    // skip the key-building entirely — it cannot match, and this bounds both the work and the
+    // rebuilt `surface:${surfaceId}` string on a pathologically long surface_id.
+    const maxCandidateLen = [...known, ...quarantined].reduce((max, id) => Math.max(max, id.length), 0);
+    const canMatch = surfaceId.length <= maxCandidateLen + "surface:".length;
+    const matchExact = (ids) => (canMatch
+      ? ids.find((id) => id === `surface:${surfaceId}`)
+        || ids.find((id) => id === surfaceId.replace(/^surface:/, ""))
+        || null
+      : null);
+    // Prefer a LIVE routed id (the caller can act on it immediately). Only when no live id matches
+    // do we point at a QUARANTINED (malformed) duplicate — a surface that exists but needs
+    // re-routing. A surface that still has a valid route resolves above and never reaches here, so a
+    // live suggestion is always the most actionable hint even when a malformed duplicate of the
+    // same id also exists.
+    const suggestion = matchExact(known);
+    const quarantinedMatch = suggestion ? null : matchExact(quarantined);
     const listed = known.length
-      ? known.slice(0, MAX_LISTED).map(clip).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
+      ? known.slice(0, MAX_LISTED).map(safe).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
       : "(none)";
     const hint = suggestion
-      ? ` (did you mean ${clip(suggestion)}?)`
+      ? ` (did you mean ${safe(suggestion)}?)`
       : quarantinedMatch
-        ? ` (${clip(quarantinedMatch)} exists but has a malformed route — re-run bob_route_surfaces)`
+        ? ` (${safe(quarantinedMatch)} exists but has a malformed route — re-run bob_route_surfaces)`
         : "";
     rejectInvalidArguments(
-      `unknown or unrouted surface_id ${safeId}${hint}; routed surface_ids: ${listed}`,
+      `unknown or unrouted surface_id ${safe(surfaceId)}${hint}; routed surface_ids: ${listed}`,
       { code: "surface_id_unrouted" },
     );
   }

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -351,6 +351,19 @@ function normalizePathTemplate(rawTemplate, toolName = "bob_http_confirm") {
 
 function findRoutedSurface(domain, surfaceId) {
   const routed = readSurfaceRoutesStrict(domain);
+  // Sanitize EVERY id/reason echoed by ANY rejection below. surfaceId is agent-controlled, and all
+  // three rejection sites in this function (malformed-route, unrouted, routed-but-absent) feed the
+  // same rejectInvalidArguments sink. Bound each echo to MAX_ID_LEN AND strip control chars so none
+  // can bloat the line or forge extra message/log content — e.g. an ESC/RTL-override sequence in a
+  // surfaceId that exact-matches a quarantined route, or a 100 KB id. Hoisted above the FIRST
+  // rejection so the guarantee is function-wide, not one branch (a per-branch helper would leave the
+  // sibling rejections half-hardened and the "uniform" claim false).
+  const MAX_ID_LEN = 120;
+  const safe = (value) => {
+    const text = String(value ?? "");
+    const clipped = text.length > MAX_ID_LEN ? `${text.slice(0, MAX_ID_LEN - 1)}…` : text;
+    return clipped.replace(/[\x00-\x1f\x7f]/g, "·");
+  };
   // Check quarantined routes for THIS surface FIRST — BEFORE accepting a route — so a corrupt file
   // (even one with a valid-first occurrence AND a malformed duplicate for the same surface_id) is
   // rejected here exactly as getContextBudget rejects it. Otherwise live offensive probes would
@@ -359,7 +372,10 @@ function findRoutedSurface(domain, surfaceId) {
   if (Array.isArray(routed.malformed_routes)) {
     const malformed = routed.malformed_routes.find((entry) => entry.surface_id === surfaceId);
     if (malformed) {
-      rejectInvalidArguments(`surface_id ${surfaceId} has a malformed route (re-run bob_route_surfaces): ${malformed.reason}`);
+      rejectInvalidArguments(
+        `surface_id ${safe(surfaceId)} has a malformed route (re-run bob_route_surfaces): ${safe(malformed.reason)}`,
+        { code: "surface_id_malformed_route" },
+      );
     }
   }
   const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
@@ -369,16 +385,11 @@ function findRoutedSurface(domain, surfaceId) {
     // signed producer — falling back to a hand-rolled scan + manual claim, the exact under-firing
     // the offensive arsenal is meant to replace. The MESSAGE is the load-bearing self-correction
     // interface (the caller is an LLM reading the error text); no consumer reads a structured
-    // route inventory, so details stay at the stable {code}. EVERY id echoed into the message —
-    // the caller's surface_id, the listed routes, the suggestion, and the quarantine hint — is
-    // passed through safe() (bound to MAX_ID_LEN AND control-char-stripped), so no echo path can
-    // bloat the line or forge extra message/log content. Uniform: no echo path is exempt.
+    // route inventory, so details stay at the stable {code}. Every echoed id goes through the
+    // hoisted safe() (declared at the top of this function), so the listed routes, the suggestion,
+    // and the quarantine hint are all bounded + control-char-stripped exactly like the caller's
+    // surface_id — the same guarantee the malformed-route and routed-but-absent rejections get.
     const MAX_LISTED = 20;
-    const MAX_ID_LEN = 120;
-    const safe = (id) => {
-      const clipped = id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id;
-      return clipped.replace(/[\x00-\x1f\x7f]/g, "·");
-    };
     const known = routed.document.routes
       .map((entry) => entry.surface_id)
       .filter((id) => typeof id === "string" && id);
@@ -421,7 +432,10 @@ function findRoutedSurface(domain, surfaceId) {
   const surfaces = currentSurfaces(domain);
   const surface = (surfaces.surfaces || []).find((entry) => entry && entry.id === surfaceId) || null;
   if (!surface) {
-    rejectInvalidArguments(`surface_id ${surfaceId} is routed but not present in current surfaces`);
+    rejectInvalidArguments(
+      `surface_id ${safe(surfaceId)} is routed but not present in current surfaces`,
+      { code: "surface_id_not_in_surfaces" },
+    );
   }
   return { route, surface };
 }

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -372,24 +372,27 @@ function findRoutedSurface(domain, surfaceId) {
     const known = routed.document.routes
       .map((entry) => entry.surface_id)
       .filter((id) => typeof id === "string" && id);
-    // Suggest the closest routed id by EXACT relation only — never a bare substring, which
-    // for a short/typo'd input ("a", "api") could point an agent at the wrong (if in-scope)
-    // surface, against this file's {id}-must-terminate discipline. Covers the real slip: a
-    // dropped `surface:` prefix (and the inverse).
+    // Suggest the closest routed id by EXACT EQUALITY only — the canonical `surface:` prefix the
+    // caller dropped, or its inverse. No substring/suffix wildcard: for a short/typo'd input
+    // ("a", "api") a wildcard could point an agent at the wrong (if in-scope) surface, against
+    // this file's {id}-must-terminate discipline.
     const suggestion = known.find((id) => id === `surface:${surfaceId}`)
-      || known.find((id) => id.endsWith(`:${surfaceId}`))
       || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
       || null;
+    // Bound BOTH the count AND the per-id length on the emitted list. envelope.js reflects
+    // details verbatim with no size bound, so an unbounded list — or a single oversized id —
+    // would amplify the error payload on every miss (this error deliberately drives a retry).
+    // The actionable `suggested_surface_id` is left whole so the caller can copy it verbatim.
     const MAX_LISTED = 20;
-    const listed = known.length
-      ? known.slice(0, MAX_LISTED).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
+    const MAX_ID_LEN = 120;
+    const clip = (id) => (id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id);
+    const emitted = known.slice(0, MAX_LISTED).map(clip);
+    const listed = emitted.length
+      ? emitted.join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
       : "(none)";
-    // Cap the STRUCTURED list too: envelope.js reflects details verbatim with no size bound,
-    // so the message-only cap would still dump the full route table on every miss (an
-    // amplification footgun, since this error is meant to drive a corrected retry).
     rejectInvalidArguments(
       `unknown or unrouted surface_id ${surfaceId}${suggestion ? ` (did you mean ${suggestion}?)` : ""}; routed surface_ids: ${listed}`,
-      { code: "surface_id_unrouted", routed_surface_ids: known.slice(0, MAX_LISTED), routed_surface_count: known.length, suggested_surface_id: suggestion },
+      { code: "surface_id_unrouted", routed_surface_ids: emitted, routed_surface_count: known.length, suggested_surface_id: suggestion },
     );
   }
   const surfaces = currentSurfaces(domain);

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -372,18 +372,24 @@ function findRoutedSurface(domain, surfaceId) {
     const known = routed.document.routes
       .map((entry) => entry.surface_id)
       .filter((id) => typeof id === "string" && id);
+    // Suggest the closest routed id by EXACT relation only — never a bare substring, which
+    // for a short/typo'd input ("a", "api") could point an agent at the wrong (if in-scope)
+    // surface, against this file's {id}-must-terminate discipline. Covers the real slip: a
+    // dropped `surface:` prefix (and the inverse).
     const suggestion = known.find((id) => id === `surface:${surfaceId}`)
       || known.find((id) => id.endsWith(`:${surfaceId}`))
       || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
-      || known.find((id) => id.includes(surfaceId))
       || null;
     const MAX_LISTED = 20;
     const listed = known.length
       ? known.slice(0, MAX_LISTED).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
       : "(none)";
+    // Cap the STRUCTURED list too: envelope.js reflects details verbatim with no size bound,
+    // so the message-only cap would still dump the full route table on every miss (an
+    // amplification footgun, since this error is meant to drive a corrected retry).
     rejectInvalidArguments(
       `unknown or unrouted surface_id ${surfaceId}${suggestion ? ` (did you mean ${suggestion}?)` : ""}; routed surface_ids: ${listed}`,
-      { code: "surface_id_unrouted", routed_surface_ids: known, suggested_surface_id: suggestion },
+      { code: "surface_id_unrouted", routed_surface_ids: known.slice(0, MAX_LISTED), routed_surface_count: known.length, suggested_surface_id: suggestion },
     );
   }
   const surfaces = currentSurfaces(domain);

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -353,8 +353,10 @@ function findRoutedSurface(domain, surfaceId) {
   const routed = readSurfaceRoutesStrict(domain);
   // Sanitize EVERY id/reason echoed by ANY rejection below. surfaceId is agent-controlled, and all
   // three rejection sites in this function (malformed-route, unrouted, routed-but-absent) feed the
-  // same rejectInvalidArguments sink. Bound each echo to MAX_ID_LEN AND strip control chars so none
-  // can bloat the line or forge extra message/log content — e.g. an ESC/RTL-override sequence in a
+  // same rejectInvalidArguments sink. Bound each echo to MAX_ID_LEN AND strip both ASCII C0/C1+DEL
+  // controls and the Unicode line-separator + bidi-control set (U+2028/9, U+202A-E, U+2066-9, the
+  // LRM/RLM/ALM marks) so none can bloat the line or forge/visually-reorder message/log content —
+  // e.g. an ESC or RTL-override (Trojan-Source) sequence in a
   // surfaceId that exact-matches a quarantined route, or a 100 KB id. Hoisted above the FIRST
   // rejection so the guarantee is function-wide, not one branch (a per-branch helper would leave the
   // sibling rejections half-hardened and the "uniform" claim false).
@@ -362,7 +364,7 @@ function findRoutedSurface(domain, surfaceId) {
   const safe = (value) => {
     const text = String(value ?? "");
     const clipped = text.length > MAX_ID_LEN ? `${text.slice(0, MAX_ID_LEN - 1)}…` : text;
-    return clipped.replace(/[\x00-\x1f\x7f]/g, "·");
+    return clipped.replace(/[\x00-\x1f\x7f-\x9f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g, "·");
   };
   // Check quarantined routes for THIS surface FIRST — BEFORE accepting a route — so a corrupt file
   // (even one with a valid-first occurrence AND a malformed duplicate for the same surface_id) is

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -379,6 +379,16 @@ function findRoutedSurface(domain, surfaceId) {
     const suggestion = known.find((id) => id === `surface:${surfaceId}`)
       || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
       || null;
+    // If no LIVE route matches but a QUARANTINED (malformed) route does on the same exact
+    // relation, the surface exists — it just needs re-routing. Say so rather than a bare
+    // "unknown" the caller can't action (the exact-id malformed branch above only fires when
+    // the caller already used the canonical id; this covers the dropped-prefix slip too).
+    const quarantinedMatch = suggestion
+      ? null
+      : (Array.isArray(routed.malformed_routes) ? routed.malformed_routes : [])
+        .map((entry) => entry && entry.surface_id)
+        .filter((id) => typeof id === "string" && id)
+        .find((id) => id === `surface:${surfaceId}` || id === surfaceId.replace(/^surface:/, "")) || null;
     // Bound BOTH the count AND the per-id length on the emitted list. envelope.js reflects
     // details verbatim with no size bound, so an unbounded list — or a single oversized id —
     // would amplify the error payload on every miss (this error deliberately drives a retry).
@@ -390,9 +400,14 @@ function findRoutedSurface(domain, surfaceId) {
     const listed = emitted.length
       ? emitted.join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
       : "(none)";
+    const hint = suggestion
+      ? ` (did you mean ${suggestion}?)`
+      : quarantinedMatch
+        ? ` (${quarantinedMatch} exists but has a malformed route — re-run bob_route_surfaces)`
+        : "";
     rejectInvalidArguments(
-      `unknown or unrouted surface_id ${surfaceId}${suggestion ? ` (did you mean ${suggestion}?)` : ""}; routed surface_ids: ${listed}`,
-      { code: "surface_id_unrouted", routed_surface_ids: emitted, routed_surface_count: known.length, suggested_surface_id: suggestion },
+      `unknown or unrouted surface_id ${surfaceId}${hint}; routed surface_ids: ${listed}`,
+      { code: "surface_id_unrouted", routed_surface_ids: emitted, routed_surface_count: known.length, suggested_surface_id: suggestion, quarantined_match: quarantinedMatch },
     );
   }
   const surfaces = currentSurfaces(domain);

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -364,7 +364,27 @@ function findRoutedSurface(domain, surfaceId) {
   }
   const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
   if (!route) {
-    rejectInvalidArguments(`unknown or unrouted surface_id ${surfaceId}`);
+    // Help the caller self-correct. An agent that drops the canonical `surface:` prefix
+    // (e.g. passes "search" for "surface:search") otherwise hits a dead-end error and
+    // abandons the signed producer — falling back to a hand-rolled scan + manual claim,
+    // the exact under-firing the offensive arsenal is meant to replace. List the routed
+    // ids and suggest the closest match so the next call can fire instead.
+    const known = routed.document.routes
+      .map((entry) => entry.surface_id)
+      .filter((id) => typeof id === "string" && id);
+    const suggestion = known.find((id) => id === `surface:${surfaceId}`)
+      || known.find((id) => id.endsWith(`:${surfaceId}`))
+      || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
+      || known.find((id) => id.includes(surfaceId))
+      || null;
+    const MAX_LISTED = 20;
+    const listed = known.length
+      ? known.slice(0, MAX_LISTED).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
+      : "(none)";
+    rejectInvalidArguments(
+      `unknown or unrouted surface_id ${surfaceId}${suggestion ? ` (did you mean ${suggestion}?)` : ""}; routed surface_ids: ${listed}`,
+      { code: "surface_id_unrouted", routed_surface_ids: known, suggested_surface_id: suggestion },
+    );
   }
   const surfaces = currentSurfaces(domain);
   const surface = (surfaces.surfaces || []).find((entry) => entry && entry.id === surfaceId) || null;

--- a/mcp/lib/offensive-http-common.js
+++ b/mcp/lib/offensive-http-common.js
@@ -364,50 +364,49 @@ function findRoutedSurface(domain, surfaceId) {
   }
   const route = routed.document.routes.find((entry) => entry.surface_id === surfaceId) || null;
   if (!route) {
-    // Help the caller self-correct. An agent that drops the canonical `surface:` prefix
-    // (e.g. passes "search" for "surface:search") otherwise hits a dead-end error and
-    // abandons the signed producer — falling back to a hand-rolled scan + manual claim,
-    // the exact under-firing the offensive arsenal is meant to replace. List the routed
-    // ids and suggest the closest match so the next call can fire instead.
+    // Help the caller self-correct. An agent that drops the canonical `surface:` prefix (e.g.
+    // passes "search" for "surface:search") otherwise hits a dead-end error and abandons the
+    // signed producer — falling back to a hand-rolled scan + manual claim, the exact under-firing
+    // the offensive arsenal is meant to replace. The MESSAGE is the load-bearing self-correction
+    // interface (the caller is an LLM reading the error text); no consumer reads a structured
+    // route inventory, so details stay at the stable {code}. Everything echoed is length-bounded
+    // so a single miss can't bloat the payload (this error deliberately drives a retry loop).
+    const MAX_LISTED = 20;
+    const MAX_ID_LEN = 120;
+    const clip = (id) => (id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id);
+    // The caller's surface_id is untrusted free-text: bound it AND strip control chars, so a huge
+    // or newline-laden value can neither bloat the line nor forge extra message/log content.
+    const safeId = clip(surfaceId).replace(/[\x00-\x1f\x7f]/g, "·");
     const known = routed.document.routes
       .map((entry) => entry.surface_id)
       .filter((id) => typeof id === "string" && id);
-    // Suggest the closest routed id by EXACT EQUALITY only — the canonical `surface:` prefix the
-    // caller dropped, or its inverse. No substring/suffix wildcard: for a short/typo'd input
-    // ("a", "api") a wildcard could point an agent at the wrong (if in-scope) surface, against
-    // this file's {id}-must-terminate discipline.
+    // Suggest the closest routed id by EXACT EQUALITY only (the dropped `surface:` prefix or its
+    // inverse) — never a substring/suffix wildcard, which for a short/typo'd input could point at
+    // the wrong (if in-scope) surface, against this file's {id}-must-terminate discipline.
     const suggestion = known.find((id) => id === `surface:${surfaceId}`)
       || known.find((id) => id === surfaceId.replace(/^surface:/, ""))
       || null;
-    // If no LIVE route matches but a QUARANTINED (malformed) route does on the same exact
-    // relation, the surface exists — it just needs re-routing. Say so rather than a bare
-    // "unknown" the caller can't action (the exact-id malformed branch above only fires when
-    // the caller already used the canonical id; this covers the dropped-prefix slip too).
+    // If no LIVE route matches but a QUARANTINED (malformed) route matches the same exact
+    // relation, the surface exists — it just needs re-routing; say so rather than a bare
+    // "unknown" (the exact-id malformed branch above only covers the canonical-id caller; a
+    // surface that still has a valid route resolves above and never reaches here).
     const quarantinedMatch = suggestion
       ? null
       : (Array.isArray(routed.malformed_routes) ? routed.malformed_routes : [])
         .map((entry) => entry && entry.surface_id)
         .filter((id) => typeof id === "string" && id)
         .find((id) => id === `surface:${surfaceId}` || id === surfaceId.replace(/^surface:/, "")) || null;
-    // Bound BOTH the count AND the per-id length on the emitted list. envelope.js reflects
-    // details verbatim with no size bound, so an unbounded list — or a single oversized id —
-    // would amplify the error payload on every miss (this error deliberately drives a retry).
-    // The actionable `suggested_surface_id` is left whole so the caller can copy it verbatim.
-    const MAX_LISTED = 20;
-    const MAX_ID_LEN = 120;
-    const clip = (id) => (id.length > MAX_ID_LEN ? `${id.slice(0, MAX_ID_LEN - 1)}…` : id);
-    const emitted = known.slice(0, MAX_LISTED).map(clip);
-    const listed = emitted.length
-      ? emitted.join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
+    const listed = known.length
+      ? known.slice(0, MAX_LISTED).map(clip).join(", ") + (known.length > MAX_LISTED ? `, … (${known.length} total)` : "")
       : "(none)";
     const hint = suggestion
-      ? ` (did you mean ${suggestion}?)`
+      ? ` (did you mean ${clip(suggestion)}?)`
       : quarantinedMatch
-        ? ` (${quarantinedMatch} exists but has a malformed route — re-run bob_route_surfaces)`
+        ? ` (${clip(quarantinedMatch)} exists but has a malformed route — re-run bob_route_surfaces)`
         : "";
     rejectInvalidArguments(
-      `unknown or unrouted surface_id ${surfaceId}${hint}; routed surface_ids: ${listed}`,
-      { code: "surface_id_unrouted", routed_surface_ids: emitted, routed_surface_count: known.length, suggested_surface_id: suggestion, quarantined_match: quarantinedMatch },
+      `unknown or unrouted surface_id ${safeId}${hint}; routed surface_ids: ${listed}`,
+      { code: "surface_id_unrouted" },
     );
   }
   const surfaces = currentSurfaces(domain);

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -509,6 +509,28 @@ test("findRoutedSurface sanitizes the surface_id echoed by the routed-but-absent
   assert.ok(!/[\x00-\x1f\x7f]/.test(caught.message), "no raw control char survives the routed-but-absent rejection");
 }));
 
+test("findRoutedSurface strips Unicode line/bidi controls from the echoed surface_id", () => withTempHome(() => {
+  // safe() must also strip the Unicode log-forging / Trojan-Source set (line/paragraph separators and
+  // bidi embeddings/overrides/isolates), not just ASCII controls — else a U+2028 forges a log line and
+  // a U+202E (RLO) visually reorders the echoed id. (round-7 Codex/brutalist finding.) String.fromCharCode
+  // keeps these out of the source as raw bytes while still exercising the real chars at runtime.
+  const RLO = String.fromCharCode(0x202e); // RIGHT-TO-LEFT OVERRIDE (Trojan-Source bidi)
+  const LS = String.fromCharCode(0x2028);  // LINE SEPARATOR (a JS/log line terminator)
+  const PDI = String.fromCharCode(0x2069); // POP DIRECTIONAL ISOLATE
+  const domain = "common-find-unicode-strip.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:keep"]);
+
+  let caught;
+  try { findRoutedSurface(domain, `a${RLO}b${LS}c${PDI}d`); } catch (error) { caught = error; }
+  assert.ok(caught);
+  // each stripped char becomes "·": the echoed caller id is a·b·c·d, no raw separator/bidi survives.
+  assert.match(caught.message, /unknown or unrouted surface_id a·b·c·d/);
+  assert.ok(!caught.message.includes(RLO), "no raw RLO (bidi override) survives");
+  assert.ok(!caught.message.includes(LS), "no raw line separator survives");
+  assert.ok(!caught.message.includes(PDI), "no raw bidi isolate survives");
+}));
+
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---
 
 test("originFromState returns the in-scope origin and rejects a missing/invalid target_url", () => withTempHome(() => {

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -310,6 +310,28 @@ test("findRoutedSurface returns the routed surface and throws on an unknown id",
   assert.ok(caught);
   assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
   assert.match(caught.message, /unknown or unrouted surface_id surface:does-not-exist/);
+  // The error lists the routed ids so a caller can self-correct instead of dead-ending.
+  assert.match(caught.message, /routed surface_ids: surface:accounts/);
+  assert.deepEqual(caught.details.routed_surface_ids, [surfaceId]);
+}));
+
+test("findRoutedSurface suggests the prefixed id when a caller drops the surface: prefix", () => withTempHome(() => {
+  // Regression (smoke-test 2026-06-26): an agent that routed to a producer with "search"
+  // instead of "surface:search" got a no-hint error and abandoned the producer (fell back to
+  // a hand-rolled scan + manual claim). The error must name the closest routed id so the next
+  // call fires — the whole point of routing to the signed producer.
+  const domain = "common-find-suggest.example.test";
+  const surfaceId = "surface:search";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedRoutedSurface(domain, surfaceId, `https://${domain}/search?q=test`);
+
+  let caught;
+  try { findRoutedSurface(domain, "search"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+  assert.match(caught.message, /did you mean surface:search\?/);
+  assert.match(caught.message, /routed surface_ids: surface:search/);
+  assert.equal(caught.details.suggested_surface_id, "surface:search");
 }));
 
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -467,6 +467,48 @@ test("findRoutedSurface bounds the suggestion lookup on a pathologically long su
   assert.ok(caught.message.length < 1000, "the error message stays bounded");
 }));
 
+test("findRoutedSurface sanitizes the surface_id echoed by the malformed-route rejection", () => withTempHome(() => {
+  // The malformed-route rejection (reached when the caller's EXACT id is a quarantined route) echoes
+  // the agent-controlled surface_id; a control char in it must be stripped by the SAME safe() as the
+  // unrouted branch — proving the hardening is function-wide, not an island (the round-6 finding).
+  const domain = "common-find-malformed-sanitize.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:keep", "surface:bad\u0007id"]);
+  const rp = surfaceRoutesPath(domain);
+  const doc = JSON.parse(fs.readFileSync(rp, "utf8"));
+  for (const r of doc.routes) {
+    if (r.surface_id === "surface:bad\u0007id") { delete r.evaluator_agent; r.hunter_agent = "hunter-agent"; }
+  }
+  fs.writeFileSync(rp, `${JSON.stringify(doc, null, 2)}\n`);
+
+  let caught;
+  try { findRoutedSurface(domain, "surface:bad\u0007id"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.match(caught.message, /surface_id surface:bad·id has a malformed route/);
+  assert.ok(!/[\x00-\x1f\x7f]/.test(caught.message), "no raw control char survives the malformed-route rejection");
+}));
+
+test("findRoutedSurface sanitizes the surface_id echoed by the routed-but-absent rejection", () => withTempHome(() => {
+  // The routed-but-not-present rejection also echoes the agent-controlled surface_id; the same
+  // safe() must cover it — the third echo site the function-wide 'uniform' invariant must hold for.
+  const domain = "common-find-absent-sanitize.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:keep", "surface:gho\u0007st"]); // routes BOTH ids
+  // Drop the BEL surface from attack_surface.json so it stays ROUTED but is no longer present.
+  fs.writeFileSync(attackSurfacePath(domain), `${JSON.stringify({
+    surfaces: [{
+      id: "surface:keep", title: "t", surface_type: "web", hosts: [domain],
+      endpoints: [`https://${domain}/k`], tech_stack: ["fixture"], priority: "HIGH",
+    }],
+  }, null, 2)}\n`);
+
+  let caught;
+  try { findRoutedSurface(domain, "surface:gho\u0007st"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.match(caught.message, /surface_id surface:gho·st is routed but not present/);
+  assert.ok(!/[\x00-\x1f\x7f]/.test(caught.message), "no raw control char survives the routed-but-absent rejection");
+}));
+
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---
 
 test("originFromState returns the in-scope origin and rejects a missing/invalid target_url", () => withTempHome(() => {

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -313,6 +313,7 @@ test("findRoutedSurface returns the routed surface and throws on an unknown id",
   // The error lists the routed ids so a caller can self-correct instead of dead-ending.
   assert.match(caught.message, /routed surface_ids: surface:accounts/);
   assert.deepEqual(caught.details.routed_surface_ids, [surfaceId]);
+  assert.equal(caught.details.routed_surface_count, 1);
 }));
 
 test("findRoutedSurface suggests the prefixed id when a caller drops the surface: prefix", () => withTempHome(() => {

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -463,6 +463,10 @@ test("findRoutedSurface bounds the suggestion lookup on a pathologically long su
   assert.ok(caught);
   assert.ok(!caught.message.includes(huge), "the huge caller id is clipped, not echoed in full");
   assert.match(caught.message, /…/, "the echoed caller id is clipped to the bound");
+  // Pin the EXACT clip (MAX_ID_LEN=120 → 119 chars + ellipsis): a drift to 121/130/any other
+  // shorter-than-full bound is caught, not just "shorter than the full id" (CodeRabbit round-8).
+  assert.ok(caught.message.includes(`${"z".repeat(119)}…`), "echo clipped to exactly 119 chars + ellipsis");
+  assert.ok(!caught.message.includes("z".repeat(120)), "no 120th pre-ellipsis char — the clip is exactly MAX_ID_LEN");
   assert.ok(!/did you mean/.test(caught.message), "no suggestion is attempted for an unmatchable huge id");
   assert.ok(caught.message.length < 1000, "the error message stays bounded");
 }));

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -329,8 +329,7 @@ test("findRoutedSurface returns the routed surface and throws on an unknown id",
   assert.match(caught.message, /unknown or unrouted surface_id surface:does-not-exist/);
   // The error lists the routed ids so a caller can self-correct instead of dead-ending.
   assert.match(caught.message, /routed surface_ids: surface:accounts/);
-  assert.deepEqual(caught.details.routed_surface_ids, [surfaceId]);
-  assert.equal(caught.details.routed_surface_count, 1);
+  assert.equal(caught.details.code, "surface_id_unrouted");
 }));
 
 test("findRoutedSurface suggests the prefixed id when a caller drops the surface: prefix", () => withTempHome(() => {
@@ -349,7 +348,6 @@ test("findRoutedSurface suggests the prefixed id when a caller drops the surface
   assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
   assert.match(caught.message, /did you mean surface:search\?/);
   assert.match(caught.message, /routed surface_ids: surface:search/);
-  assert.equal(caught.details.suggested_surface_id, "surface:search");
 }));
 
 test("findRoutedSurface caps the listed ids at 20 and reports the full count", () => withTempHome(() => {
@@ -360,9 +358,10 @@ test("findRoutedSurface caps the listed ids at 20 and reports the full count", (
   let caught;
   try { findRoutedSurface(domain, "definitely-missing"); } catch (error) { caught = error; }
   assert.ok(caught);
-  assert.equal(caught.details.routed_surface_count, 21, "full count is reported");
-  assert.equal(caught.details.routed_surface_ids.length, 20, "structured list is capped at 20");
+  // The message reports the full count and truncates the list (s00..s19 shown, s20 cut).
   assert.match(caught.message, /\(21 total\)/);
+  assert.match(caught.message, /surface:s00/);
+  assert.ok(!caught.message.includes("surface:s20"), "the 21st id is beyond the 20-cap");
 }));
 
 test("findRoutedSurface clips an oversized routed surface_id to 120 chars in the error", () => withTempHome(() => {
@@ -374,10 +373,9 @@ test("findRoutedSurface clips an oversized routed surface_id to 120 chars in the
   let caught;
   try { findRoutedSurface(domain, "miss"); } catch (error) { caught = error; }
   assert.ok(caught);
-  assert.equal(caught.details.routed_surface_ids.length, 1);
-  const emitted = caught.details.routed_surface_ids[0];
-  assert.ok(emitted.endsWith("…"), "oversized id is clipped with an ellipsis");
-  assert.equal(emitted.length, 120, "clipped to the 120-char bound");
+  // The message clips the oversized id (119 + ellipsis); the full 140-char value never appears.
+  assert.match(caught.message, /…/);
+  assert.ok(!caught.message.includes(longId), "the full oversized id is not echoed");
 }));
 
 test("findRoutedSurface points a dropped-prefix caller at a QUARANTINED surface (re-run hint)", () => withTempHome(() => {
@@ -399,8 +397,25 @@ test("findRoutedSurface points a dropped-prefix caller at a QUARANTINED surface 
   assert.ok(caught);
   assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
   assert.match(caught.message, /surface:search exists but has a malformed route — re-run bob_route_surfaces/);
-  assert.equal(caught.details.quarantined_match, "surface:search");
-  assert.equal(caught.details.suggested_surface_id, null);
+}));
+
+test("findRoutedSurface bounds AND sanitizes the echoed caller surface_id", () => withTempHome(() => {
+  // surface_id is untrusted free-text: control chars (newline/tab) must be stripped so they
+  // can't forge extra log/message lines, and an oversized value must be clipped.
+  const domain = "common-find-sanitize.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedRoutedSurface(domain, "surface:real", `https://${domain}/api/real`);
+
+  let caught;
+  try { findRoutedSurface(domain, "a\nb\tc"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.match(caught.message, /unknown or unrouted surface_id a·b·c/);
+  assert.ok(!/[\x00-\x1f]/.test(caught.message), "no raw control chars survive into the message");
+
+  let caught2;
+  try { findRoutedSurface(domain, "z".repeat(200)); } catch (error) { caught2 = error; }
+  assert.ok(caught2);
+  assert.ok(!caught2.message.includes("z".repeat(200)), "the oversized caller id is clipped");
 }));
 
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -399,23 +399,72 @@ test("findRoutedSurface points a dropped-prefix caller at a QUARANTINED surface 
   assert.match(caught.message, /surface:search exists but has a malformed route — re-run bob_route_surfaces/);
 }));
 
-test("findRoutedSurface bounds AND sanitizes the echoed caller surface_id", () => withTempHome(() => {
-  // surface_id is untrusted free-text: control chars (newline/tab) must be stripped so they
-  // can't forge extra log/message lines, and an oversized value must be clipped.
+test("findRoutedSurface sanitizes control chars in EVERY echo path (caller, listed, suggestion)", () => withTempHome(() => {
+  // surface_id AND persisted route ids are echoed into the LLM-facing error. A control char in
+  // ANY echoed id — the caller's free-text id, a listed routed id, or the suggested id — must be
+  // stripped so it can't forge extra log/message lines. One safe() guards all paths; exercise each
+  // with a REAL control char (BEL) so the property is verified, not vacuously true on clean inputs.
   const domain = "common-find-sanitize.example.test";
   JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
-  seedRoutedSurface(domain, "surface:real", `https://${domain}/api/real`);
+  // The BEL-bearing routed id survives routing into the live inventory (probed), so it appears in
+  // the `listed` echo AND is an exact dropped-prefix suggestion target for the caller below.
+  seedSurfaces(domain, ["surface:ev\u0007il", "surface:keep"]);
+
+  // (caller + listed) a newline/tab caller id is sanitized, and the BEL routed id is sanitized in
+  // the listed inventory — no raw control char survives from either path.
+  let c1;
+  try { findRoutedSurface(domain, "a\nb\tc"); } catch (error) { c1 = error; }
+  assert.ok(c1);
+  assert.match(c1.message, /unknown or unrouted surface_id a·b·c/);
+  assert.match(c1.message, /surface:ev·il/);
+  assert.ok(!/[\x00-\x1f\x7f]/.test(c1.message), "no raw control char survives (caller + listed paths)");
+
+  // (suggestion) a dropped-prefix caller matching the BEL routed id gets a sanitized "did you mean".
+  let c2;
+  try { findRoutedSurface(domain, "ev\u0007il"); } catch (error) { c2 = error; }
+  assert.ok(c2);
+  assert.match(c2.message, /did you mean surface:ev·il\?/);
+  assert.ok(!/[\x00-\x1f\x7f]/.test(c2.message), "no raw control char survives the suggestion path");
+}));
+
+test("findRoutedSurface sanitizes a control char in the quarantine-hint path", () => withTempHome(() => {
+  // The quarantine hint echoes a malformed route's id; a control char in it must be stripped too —
+  // the same safe() as every other echo path, not just the live-suggestion/listed paths.
+  const domain = "common-find-quarantine-sanitize.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:keep", "surface:sea\u0007rch"]);
+  const rp = surfaceRoutesPath(domain);
+  const doc = JSON.parse(fs.readFileSync(rp, "utf8"));
+  // Malform the BEL-bearing route so it drops to malformed_routes (the quarantine branch), mirroring
+  // the v2.1 evaluator_agent->hunter_agent rename shape used by the sibling quarantine test.
+  for (const r of doc.routes) {
+    if (r.surface_id === "surface:sea\u0007rch") { delete r.evaluator_agent; r.hunter_agent = "hunter-agent"; }
+  }
+  fs.writeFileSync(rp, `${JSON.stringify(doc, null, 2)}\n`);
 
   let caught;
-  try { findRoutedSurface(domain, "a\nb\tc"); } catch (error) { caught = error; }
+  try { findRoutedSurface(domain, "sea\u0007rch"); } catch (error) { caught = error; }
   assert.ok(caught);
-  assert.match(caught.message, /unknown or unrouted surface_id a·b·c/);
-  assert.ok(!/[\x00-\x1f]/.test(caught.message), "no raw control chars survive into the message");
+  assert.match(caught.message, /surface:sea·rch exists but has a malformed route — re-run bob_route_surfaces/);
+  assert.ok(!/[\x00-\x1f\x7f]/.test(caught.message), "no raw control char survives the quarantine hint");
+}));
 
-  let caught2;
-  try { findRoutedSurface(domain, "z".repeat(200)); } catch (error) { caught2 = error; }
-  assert.ok(caught2);
-  assert.ok(!caught2.message.includes("z".repeat(200)), "the oversized caller id is clipped");
+test("findRoutedSurface bounds the suggestion lookup on a pathologically long surface_id", () => withTempHome(() => {
+  // A huge caller id must not drive key-building (`surface:${id}` + replace) against every candidate:
+  // it cannot exact-match a short routed id, so the suggestion is skipped and the echoed value is
+  // still clipped. Guards the error path against unbounded work and an unbounded message.
+  const domain = "common-find-bound.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:real"]);
+  const huge = "z".repeat(100000);
+
+  let caught;
+  try { findRoutedSurface(domain, huge); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.ok(!caught.message.includes(huge), "the huge caller id is clipped, not echoed in full");
+  assert.match(caught.message, /…/, "the echoed caller id is clipped to the bound");
+  assert.ok(!/did you mean/.test(caught.message), "no suggestion is attempted for an unmatchable huge id");
+  assert.ok(caught.message.length < 1000, "the error message stays bounded");
 }));
 
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---

--- a/test/offensive-http-common.test.js
+++ b/test/offensive-http-common.test.js
@@ -33,7 +33,7 @@ const { readHttpAuditRecordsFromJsonl } = require("../mcp/lib/http-records.js");
 const { routeSurfaces } = require("../mcp/lib/surface-router.js");
 const { initSession } = require("../mcp/lib/session-state.js");
 const { readSessionStateStrict } = require("../mcp/lib/session-state-store.js");
-const { attackSurfacePath } = require("../mcp/lib/paths.js");
+const { attackSurfacePath, surfaceRoutesPath } = require("../mcp/lib/paths.js");
 const {
   resetForTests: resetMaterializationDebounce,
 } = require("../mcp/lib/frontier-materialize-debounce.js");
@@ -64,6 +64,23 @@ function seedRoutedSurface(domain, surfaceId, endpoint) {
       tech_stack: ["fixture"],
       priority: "HIGH",
     }],
+  }, null, 2)}\n`, "utf8");
+  JSON.parse(routeSurfaces({ target_domain: domain }));
+}
+
+// Seed + route N web surfaces at once (for the bounded-error-list assertions).
+function seedSurfaces(domain, ids) {
+  fs.mkdirSync(path.dirname(attackSurfacePath(domain)), { recursive: true });
+  fs.writeFileSync(attackSurfacePath(domain), `${JSON.stringify({
+    surfaces: ids.map((id) => ({
+      id,
+      title: "Synthetic surface",
+      surface_type: "web",
+      hosts: [domain],
+      endpoints: [`https://${domain}/p/${encodeURIComponent(id)}`],
+      tech_stack: ["fixture"],
+      priority: "HIGH",
+    })),
   }, null, 2)}\n`, "utf8");
   JSON.parse(routeSurfaces({ target_domain: domain }));
 }
@@ -333,6 +350,57 @@ test("findRoutedSurface suggests the prefixed id when a caller drops the surface
   assert.match(caught.message, /did you mean surface:search\?/);
   assert.match(caught.message, /routed surface_ids: surface:search/);
   assert.equal(caught.details.suggested_surface_id, "surface:search");
+}));
+
+test("findRoutedSurface caps the listed ids at 20 and reports the full count", () => withTempHome(() => {
+  const domain = "common-find-cap.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, Array.from({ length: 21 }, (_, i) => `surface:s${String(i).padStart(2, "0")}`));
+
+  let caught;
+  try { findRoutedSurface(domain, "definitely-missing"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.details.routed_surface_count, 21, "full count is reported");
+  assert.equal(caught.details.routed_surface_ids.length, 20, "structured list is capped at 20");
+  assert.match(caught.message, /\(21 total\)/);
+}));
+
+test("findRoutedSurface clips an oversized routed surface_id to 120 chars in the error", () => withTempHome(() => {
+  const domain = "common-find-clip.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  const longId = `surface:${"x".repeat(140)}`;
+  seedSurfaces(domain, [longId]);
+
+  let caught;
+  try { findRoutedSurface(domain, "miss"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.details.routed_surface_ids.length, 1);
+  const emitted = caught.details.routed_surface_ids[0];
+  assert.ok(emitted.endsWith("…"), "oversized id is clipped with an ellipsis");
+  assert.equal(emitted.length, 120, "clipped to the 120-char bound");
+}));
+
+test("findRoutedSurface points a dropped-prefix caller at a QUARANTINED surface (re-run hint)", () => withTempHome(() => {
+  // A corrupt route file QUARANTINES surface:search (the v2.1 hunter_agent->evaluator_agent
+  // rename shape) so it is absent from the live routes. A dropped-prefix caller ("search")
+  // should still be told it exists-but-needs-rerouting, not a bare "unknown".
+  const domain = "common-find-quarantine.example.test";
+  JSON.parse(initSession({ target_domain: domain, target_url: `https://${domain}/` }));
+  seedSurfaces(domain, ["surface:keep", "surface:search"]);
+  const rp = surfaceRoutesPath(domain);
+  const doc = JSON.parse(fs.readFileSync(rp, "utf8"));
+  for (const r of doc.routes) {
+    if (r.surface_id === "surface:search") { delete r.evaluator_agent; r.hunter_agent = "hunter-agent"; }
+  }
+  fs.writeFileSync(rp, `${JSON.stringify(doc, null, 2)}\n`);
+
+  let caught;
+  try { findRoutedSurface(domain, "search"); } catch (error) { caught = error; }
+  assert.ok(caught);
+  assert.equal(caught.code, ERROR_CODES.INVALID_ARGUMENTS);
+  assert.match(caught.message, /surface:search exists but has a malformed route — re-run bob_route_surfaces/);
+  assert.equal(caught.details.quarantined_match, "surface:search");
+  assert.equal(caught.details.suggested_surface_id, null);
 }));
 
 // --- originFromState / urlFromEndpoint / resolveBaselineFromSurface (I/O) ---


### PR DESCRIPTION
## What

`findRoutedSurface` (shared by all signed producers — reflect/cors/massread/idor) threw a bare `unknown or unrouted surface_id X` with **no list of valid ids and no suggestion**.

## Why it matters (found by the 2026-06-26 routing smoke-test)

A headless evaluator carrying the merged-#166 prompt **correctly routed** to `bob_http_xss_reflect` / `bob_http_cors_confirm` on a reflected-param / CORS signal — but passed `surface_id:"search"` instead of `"surface:search"`. The producer errored, the error gave no hint, and the agent **abandoned the producer and fell back to a hand-rolled scan + manual claim** — the exact under-firing the signed arsenal is meant to replace. Routing worked; firing was lost on a recoverable input slip.

## The fix

The error now:
- lists the routed `surface_ids` (capped at 20, with a `(N total)` suffix),
- suggests the closest match (`did you mean surface:search?`) — matching a dropped `surface:` prefix first,
- carries `routed_surface_ids` + `suggested_surface_id` in `details`.

So an agent that slips on the id format can **self-correct and fire** instead of giving up.

## Tests

- `test/offensive-http-common.test.js`: strengthened the existing unrouted-id test (asserts the routed-id list + `details.routed_surface_ids`); added a regression test for the dropped-prefix suggestion.
- `npm run test:mcp` green (3168 tests, 0 fail); `check:syntax` clean.

Behavior change is error-message-only; no change to which ids resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for unrouted surface lookups, including exact-match “did you mean …?” suggestions and guidance to re-run routing when appropriate.
  * Bounded and clarified routed `surface_id` excerpts (cap on listed items with total count), and safely clipped oversized IDs.
  * Hardened error output by sanitizing echoed `surface_id`/reason text to remove control characters and unsafe Unicode.
  * Added a dedicated error code for unrouted surface IDs (`surface_id_unrouted`) to make error handling more precise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->