### PR TITLE
chore(package): trim 921 KB social card from the npm pack (unblock size budget)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "docs/**/*.json",
     "docs/**/*.html",
     "docs/**/*.png",
+    "!docs/hacker-bob-social.png",
     "mcp/**/*",
     "!mcp/node_modules/**",
     "prompts/**/*",

--- a/scripts/lib/package-policy.js
+++ b/scripts/lib/package-policy.js
@@ -76,6 +76,11 @@ const STALE_HOOK_SCRIPT_NAMES = Object.freeze([
 const EXCLUDED_CANONICAL_PACKAGE_FILES = Object.freeze([
   ...STALE_HOOK_SCRIPT_NAMES.map((name) => `.claude/hooks/${name}`),
   "docs/hacker-bob-offline-guide.pdf",
+  // The 921 KB social-preview card is a web/marketing asset (referenced only by the
+  // non-packed site/ and GitHub's social-preview, never by the installed runtime). It
+  // dominated the tarball at ~27% of pack size; excluding it reclaims the budget headroom
+  // the comment in test/package.test.js long flagged as the obvious trim target.
+  "docs/hacker-bob-social.png",
   "scripts/authority-inventory.js",
   "scripts/replay-refusal.js",
   "scripts/bench-prompts.sh",

--- a/scripts/lib/package-policy.js
+++ b/scripts/lib/package-policy.js
@@ -5,6 +5,17 @@ const path = require("node:path");
 
 const DEFAULT_ROOT = path.join(__dirname, "..", "..");
 
+// Single source of truth for the npm pack-size tripwire. Imported by BOTH
+// test/package.test.js and scripts/release-check.js so the ceiling cannot drift
+// between them (no duplicated magic number). Ratcheted from the historical 3.4 MB
+// after the 921 KB docs/hacker-bob-social.png was excluded from the pack
+// (EXCLUDED_CANONICAL_PACKAGE_FILES): the lean pack fell to ~2.48 MB, so this snug
+// 2.7 MB ceiling keeps ~217 KB of operating headroom — enough to absorb the ~3 KB
+// pack-size non-determinism plus a couple PRs of normal source growth, while still
+// firing early on a surprising regression (a re-added asset, a vendored dep). Bump
+// it deliberately (and only here) when a real growth stream warrants it.
+const CANONICAL_PACKAGE_MAX_BYTES = 2_700_000;
+
 const WRAPPER_PACKAGE_SPECS = Object.freeze([
   Object.freeze({
     name: "hacker-bob-cc",
@@ -195,6 +206,7 @@ function expectedCanonicalFiles(root = DEFAULT_ROOT) {
 }
 
 module.exports = {
+  CANONICAL_PACKAGE_MAX_BYTES,
   DISALLOWED_PACKED_FILE_PATTERNS,
   DISALLOWED_PACKED_TEXT_PATTERNS,
   EXCLUDED_CANONICAL_PACKAGE_FILES,

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -6,6 +6,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const {
+  CANONICAL_PACKAGE_MAX_BYTES,
   DISALLOWED_PACKED_FILE_PATTERNS,
   DISALLOWED_PACKED_TEXT_PATTERNS,
   EXCLUDED_CANONICAL_PACKAGE_FILES,
@@ -207,11 +208,14 @@ function checkCanonicalPack(rootPackage) {
   // primitive→producer evaluator prose (P12) crossed 3.3 MB (lean pack ~3.30 MB).
   // The 921 KB docs/hacker-bob-social.png (a web/marketing asset) is now excluded
   // from the pack (EXCLUDED_CANONICAL_PACKAGE_FILES), dropping the lean pack to
-  // ~2.48 MB under this unchanged budget. Stays in lockstep with test/package.test.js.
-  if (canonical.size < 3400000) {
-    pass(`canonical pack size ${canonical.size} bytes is under 3.4 MB`);
+  // ~2.48 MB, and the ceiling was RATCHETED DOWN from 3.4 MB to a snug 2.7 MB so the
+  // reclaimed space is not unmonitored slack. The ceiling is a single source of truth
+  // (CANONICAL_PACKAGE_MAX_BYTES in scripts/lib/package-policy.js) shared with
+  // test/package.test.js — they cannot drift.
+  if (canonical.size < CANONICAL_PACKAGE_MAX_BYTES) {
+    pass(`canonical pack size ${canonical.size} bytes is under the ${CANONICAL_PACKAGE_MAX_BYTES}-byte ceiling`);
   } else {
-    fail(`canonical pack size ${canonical.size} bytes exceeds 3.4 MB`);
+    fail(`canonical pack size ${canonical.size} bytes exceeds the ${CANONICAL_PACKAGE_MAX_BYTES}-byte ceiling`);
   }
 
   let foundDisallowed = false;

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -205,7 +205,9 @@ function checkCanonicalPack(rootPackage) {
   // test/package.test.js ceiling (keep the two in lockstep).
   // Raised to 3.4 MB: accumulated offensive-surface growth since PR7 plus the
   // primitive→producer evaluator prose (P12) crossed 3.3 MB (lean pack ~3.30 MB).
-  // Stays in lockstep with test/package.test.js.
+  // The 921 KB docs/hacker-bob-social.png (a web/marketing asset) is now excluded
+  // from the pack (EXCLUDED_CANONICAL_PACKAGE_FILES), dropping the lean pack to
+  // ~2.48 MB under this unchanged budget. Stays in lockstep with test/package.test.js.
   if (canonical.size < 3400000) {
     pass(`canonical pack size ${canonical.size} bytes is under 3.4 MB`);
   } else {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -174,9 +174,13 @@ test("npm package contains runtime surfaces and excludes test/cache artifacts", 
     // route/client in mcp/lib/dashboard.js, #151). Headroom had fallen to ~0 KB and the
     // npm-pack tarball size is non-deterministic by ~3 KB across runs (CI measured
     // 3,300,833 B on a commit a parallel run packed under 3.3 MB — the budget was
-    // flapping), so this restores a stable margin (lean pack ~3.30 MB) without trimming
-    // assets (the 921 KB docs/hacker-bob-social.png remains the obvious trim target if a
-    // future squeeze warrants it). Mirror of the same budget in scripts/release-check.js.
+    // flapping), so this restored a stable margin (lean pack ~3.30 MB).
+    // That future squeeze then arrived: the lean pack crept back to ~3.40 MB (~0 KB
+    // headroom, CI-red), so the 921 KB docs/hacker-bob-social.png — a web/marketing asset
+    // unused by the installed runtime — is now excluded from the pack (see
+    // EXCLUDED_CANONICAL_PACKAGE_FILES in scripts/lib/package-policy.js). The lean pack
+    // dropped to ~2.48 MB, restoring ~0.9 MB of headroom under this unchanged 3.4 MB
+    // budget. Mirror of the same budget in scripts/release-check.js.
     assert.ok(pack.size < 3400000, `npm pack size ${pack.size} exceeds 3.4 MB threshold`);
 
     for (const file of files) {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const {
+  CANONICAL_PACKAGE_MAX_BYTES,
   DISALLOWED_PACKED_FILE_PATTERNS,
   DISALLOWED_PACKED_TEXT_PATTERNS,
   EXCLUDED_CANONICAL_PACKAGE_FILES,
@@ -178,10 +179,16 @@ test("npm package contains runtime surfaces and excludes test/cache artifacts", 
     // That future squeeze then arrived: the lean pack crept back to ~3.40 MB (~0 KB
     // headroom, CI-red), so the 921 KB docs/hacker-bob-social.png — a web/marketing asset
     // unused by the installed runtime — is now excluded from the pack (see
-    // EXCLUDED_CANONICAL_PACKAGE_FILES in scripts/lib/package-policy.js). The lean pack
-    // dropped to ~2.48 MB, restoring ~0.9 MB of headroom under this unchanged 3.4 MB
-    // budget. Mirror of the same budget in scripts/release-check.js.
-    assert.ok(pack.size < 3400000, `npm pack size ${pack.size} exceeds 3.4 MB threshold`);
+    // EXCLUDED_CANONICAL_PACKAGE_FILES in scripts/lib/package-policy.js), dropping the lean
+    // pack to ~2.48 MB. The ceiling was then RATCHETED DOWN from 3.4 MB to a snug 2.7 MB so
+    // the reclaimed ~0.9 MB is not unmonitored slack — the tripwire keeps ~217 KB of working
+    // headroom and again fires early on growth. The ceiling is a single source of truth
+    // (CANONICAL_PACKAGE_MAX_BYTES in scripts/lib/package-policy.js), shared with
+    // scripts/release-check.js so the two cannot drift.
+    assert.ok(
+      pack.size < CANONICAL_PACKAGE_MAX_BYTES,
+      `npm pack size ${pack.size} exceeds ${CANONICAL_PACKAGE_MAX_BYTES}-byte ceiling`,
+    );
 
     for (const file of files) {
       assert.ok(!file.startsWith("node_modules/"), `${file} should not vendor runtime dependencies`);


### PR DESCRIPTION
## Why

The npm pack-size gate (`test/package.test.js` test 6 + the `scripts/release-check.js` mirror, both `< 3.4 MB`) is **CI-red on `main`**: the lean tarball had crept back to ~3.40 MB with ~0 KB headroom, so the next few-KB change tips it over. This is the hard blocker on **#169** (surface_id error ergonomics) and a contributor to the parked **#168**.

The budget comment in `test/package.test.js` has long flagged the fix: *"the 921 KB `docs/hacker-bob-social.png` remains the obvious trim target if a future squeeze warrants it."* The squeeze arrived.

## What

`docs/hacker-bob-social.png` (921 KB — **~27% of the entire tarball**) is a web/marketing social-preview card. It is referenced **only** by the non-packed `site/` and GitHub's social-preview — **never by the installed runtime**, and not even by `README.md` (which uses `docs/hacker-bob.png`). So it is pure dead weight in the npm package.

Exclude it from the pack across the three surfaces that must agree:

- **`package.json`** — `!docs/hacker-bob-social.png` in `files` (npm no longer packs it).
- **`scripts/lib/package-policy.js`** — add it to `EXCLUDED_CANONICAL_PACKAGE_FILES` (idiomatic — sits beside the already-excluded `docs/hacker-bob-offline-guide.pdf`). This keeps `expectedCanonicalFiles()` and the actual pack consistent, and **guards the exclusion against regression** (the policy is shared by both the test and `release-check.js`).
- **`test/package.test.js`** + **`scripts/release-check.js`** — refresh the budget comments to record the trim (the `< 3.4 MB` budget itself is **unchanged** — no band-aid bump).

## Result

- Lean pack: **~3.40 MB → 2.48 MB** (`2,483,242 B`), restoring ~0.9 MB of headroom under the unchanged 3.4 MB budget. Permanently relieves #169, #168, and future PRs.
- No asset is lost — the social card still lives in the repo for GitHub's social-preview and the marketing site.

## Verification

- Clean tree (untracked analysis docs stashed so the tree == CI): `node --test test/package.test.js` → **20/20 pass**, clean pack `2,483,242 B`.
- Policy logic: `isExcludedCanonicalPackageFile("docs/hacker-bob-social.png") === true`; `expectedCanonicalFiles()` no longer lists it; pack no longer contains it.
- `node --check scripts/release-check.js` OK; `package.json` valid JSON; `npm run check:syntax` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced the published package contents by excluding an unnecessary image asset from release builds.
  * Centralized the npm package size ceiling used by release verification and package tests into a shared policy value.
  * Updated release-checking and test messaging to reflect the adjusted, smaller package footprint and the tightened size enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->