### PR TITLE
fix(authority): thread lab_authorization through the bootstrap gate (init deadlock)

### DIFF
--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -32,6 +32,9 @@
 // cannot self-grant a private-target scan by forging the file.
 
 const net = require("net");
+// Used so the lab-bootstrap validator normalizes egress_profile IDENTICALLY to the initSession
+// handler (validation.js is a leaf utility — no import cycle back to this module).
+const { assertNonEmptyString } = require("./validation.js");
 
 // Operator attestation channel. The ack is an ENVIRONMENT variable, NOT a tool
 // argument: a model that can call bob_init_session must not be able to authorize
@@ -162,15 +165,25 @@ function labBootstrapPolicyViolation(args, labAuthorization) {
     };
   }
   // (2) A proxy-backed egress would scan the attested private target from the proxy's network, not
-  // the operator's lab network — require the default (direct) egress profile.
-  const egress = args && typeof args.egress_profile === "string" && args.egress_profile.trim()
-    ? args.egress_profile.trim()
-    : "default";
+  // the operator's lab network — require the default (direct) egress profile. Normalize EXACTLY as
+  // the initSession handler does (null/undefined → "default", else assertNonEmptyString which trims
+  // and throws on a non-string/empty/whitespace value), catching that throw as a violation — so the
+  // gate rejects precisely what the handler rejects, with no "gate allowed → handler throws" gap on a
+  // malformed egress_profile (this is what makes gate-validation ⊆ handler-validation actually hold).
+  const egressViolation = {
+    code: "lab_authorization_requires_default_egress",
+    message: "lab_authorization requires the default (direct) egress profile: a proxy-backed egress would scan the attested private target from the proxy's network, not the operator's lab network",
+  };
+  let egress;
+  try {
+    egress = args == null || args.egress_profile == null
+      ? "default"
+      : assertNonEmptyString(args.egress_profile, "egress_profile");
+  } catch {
+    return egressViolation;
+  }
   if (egress !== "default") {
-    return {
-      code: "lab_authorization_requires_default_egress",
-      message: "lab_authorization requires the default (direct) egress profile: a proxy-backed egress would scan the attested private target from the proxy's network, not the operator's lab network",
-    };
+    return egressViolation;
   }
   return null;
 }

--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -146,6 +146,35 @@ function labTargetPermitted(host, { authorization } = {}) {
   return operatorAuthorizedLabHost(host);
 }
 
+// The two POLICY constraints an operator-attested lab init must satisfy, factored into ONE place so
+// the pre-handler authority gate (session-authority.js authorizeBootstrap) and the initSession
+// handler (session-state.js) enforce IDENTICAL rules — no split-brain where the gate returns
+// "allowed" for a lab init the handler then rejects. Returns a {code, message} violation descriptor
+// or null; each caller throws it in its own form (the handler a ToolError, the gate a blockedDecision).
+function labBootstrapPolicyViolation(args, labAuthorization) {
+  if (!labAuthorization) return null;
+  // (1) An attested private target needs internal-host egress to be reachable, so it cannot be
+  // combined with an explicit block_internal_hosts:true.
+  if (args && args.block_internal_hosts === true) {
+    return {
+      code: "lab_authorization_block_internal_conflict",
+      message: "lab_authorization cannot be combined with block_internal_hosts: an attested private target requires internal-host egress to be reachable",
+    };
+  }
+  // (2) A proxy-backed egress would scan the attested private target from the proxy's network, not
+  // the operator's lab network — require the default (direct) egress profile.
+  const egress = args && typeof args.egress_profile === "string" && args.egress_profile.trim()
+    ? args.egress_profile.trim()
+    : "default";
+  if (egress !== "default") {
+    return {
+      code: "lab_authorization_requires_default_egress",
+      message: "lab_authorization requires the default (direct) egress profile: a proxy-backed egress would scan the attested private target from the proxy's network, not the operator's lab network",
+    };
+  }
+  return null;
+}
+
 // Read the persisted, audit-graded attestation for a target's session. Returns
 // the normalized authorization or null. FAIL CLOSED on any read/parse error
 // (missing file, malformed JSON, forged shape). Lazy-require paths/storage to
@@ -199,6 +228,7 @@ module.exports = {
   labTargetEligibleHost,
   parseLabAuthorization,
   labTargetPermitted,
+  labBootstrapPolicyViolation,
   labAuthorizationForTarget,
   recordLabAuthorization,
 };

--- a/mcp/lib/lab-target-attest.js
+++ b/mcp/lib/lab-target-attest.js
@@ -32,9 +32,9 @@
 // cannot self-grant a private-target scan by forging the file.
 
 const net = require("net");
-// Used so the lab-bootstrap validator normalizes egress_profile IDENTICALLY to the initSession
-// handler (validation.js is a leaf utility — no import cycle back to this module).
-const { assertNonEmptyString } = require("./validation.js");
+// Used so the lab-bootstrap validator normalizes egress_profile / block_internal_hosts IDENTICALLY
+// to the initSession handler (validation.js is a leaf utility — no import cycle back to this module).
+const { assertNonEmptyString, assertBoolean } = require("./validation.js");
 
 // Operator attestation channel. The ack is an ENVIRONMENT variable, NOT a tool
 // argument: a model that can call bob_init_session must not be able to authorize
@@ -149,20 +149,36 @@ function labTargetPermitted(host, { authorization } = {}) {
   return operatorAuthorizedLabHost(host);
 }
 
-// The two POLICY constraints an operator-attested lab init must satisfy, factored into ONE place so
-// the pre-handler authority gate (session-authority.js authorizeBootstrap) and the initSession
-// handler (session-state.js) enforce IDENTICAL rules — no split-brain where the gate returns
-// "allowed" for a lab init the handler then rejects. Returns a {code, message} violation descriptor
-// or null; each caller throws it in its own form (the handler a ToolError, the gate a blockedDecision).
+// The two lab POLICY constraints an operator-attested lab init must satisfy — no block_internal_hosts,
+// and the default (direct) egress — factored into ONE place so the pre-handler authority gate
+// (session-authority.js authorizeBootstrap) and the initSession handler (session-state.js) decide
+// these two THE SAME WAY, normalizing the two fields they read (block_internal_hosts, egress_profile)
+// with the same assertBoolean/assertNonEmptyString the handler uses. Scope note: this is the lab
+// POLICY layer ONLY — it is NOT a full input validator. Validation of OTHER fields (allow_internal_hosts
+// type, target_url/target_domain shape beyond scope, future handler checks) stays handler-side and is
+// reached after the gate; a fast-path that trusts a gate "allowed" must still run the handler for those.
+// Returns a {code, message} violation descriptor or null; each caller throws it in its own form (the
+// handler a ToolError, the gate a blockedDecision).
 function labBootstrapPolicyViolation(args, labAuthorization) {
   if (!labAuthorization) return null;
   // (1) An attested private target needs internal-host egress to be reachable, so it cannot be
-  // combined with an explicit block_internal_hosts:true.
-  if (args && args.block_internal_hosts === true) {
-    return {
+  // combined with block_internal_hosts. Normalize the flag with the SAME assertBoolean the handler's
+  // deriveBlockInternalHostsPolicy uses (throws on a non-boolean) — caught as a violation so a
+  // truthy-but-non-boolean value (e.g. "yes") is rejected at the gate too, not silently admitted.
+  if (args && args.block_internal_hosts != null) {
+    const blockInternalConflict = {
       code: "lab_authorization_block_internal_conflict",
       message: "lab_authorization cannot be combined with block_internal_hosts: an attested private target requires internal-host egress to be reachable",
     };
+    let blockInternal;
+    try {
+      blockInternal = assertBoolean(args.block_internal_hosts, "block_internal_hosts");
+    } catch {
+      return blockInternalConflict;
+    }
+    if (blockInternal === true) {
+      return blockInternalConflict;
+    }
   }
   // (2) A proxy-backed egress would scan the attested private target from the proxy's network, not
   // the operator's lab network — require the default (direct) egress profile. Normalize EXACTLY as

--- a/mcp/lib/session-authority.js
+++ b/mcp/lib/session-authority.js
@@ -853,14 +853,16 @@ function authorizeBootstrap(rule, args) {
       match: true,
     });
   }
-  // Operator-attested lab/private-target escape: this pre-handler bootstrap gate runs FIRST, so it
-  // must enforce the SAME rules the initSession handler does — otherwise a fresh private-lab init
-  // either deadlocks (scope) or the gate decision diverges from execution (policy). It threads
+  // Operator-attested lab/private-target escape: this pre-handler bootstrap gate runs FIRST, so for
+  // the lab PATH it must agree with the initSession handler — otherwise a fresh private-lab init
+  // either deadlocks (scope) or the gate's lab decision diverges from execution (policy). It threads
   // lab_authorization through the scope checks (assertHttpScopeDomain/validateHttpScanScope) AND runs
-  // the handler's lab POLICY checks via the SHARED labBootstrapPolicyViolation, so gate-validation ⊆
-  // handler-validation holds (a gate "allowed" is never a handler reject — important the day a
-  // fast-path trusts this decision instead of always re-reaching the handler). parseLabAuthorization
-  // still requires the operator env ack, so non-lab targets are unaffected.
+  // the handler's two lab POLICY checks via the SHARED labBootstrapPolicyViolation (which normalizes
+  // block_internal_hosts/egress_profile with the same assertBoolean/assertNonEmptyString the handler
+  // uses) — so a gate "allowed" is never a handler reject on those lab POLICY + SCOPE grounds. It is
+  // NOT a full input validator: the handler still validates OTHER fields (e.g. allow_internal_hosts
+  // type) after the gate, so a future fast-path trusting this decision must still reach the handler
+  // for those. parseLabAuthorization requires the operator env ack, so non-lab targets are unaffected.
   const labAuthorization = parseLabAuthorization(args.lab_authorization);
   // Policy check BEFORE the scope normalization, mirroring the handler's order (block_internal is
   // checked before assertHttpScopeDomain there) so the gate and handler surface the same error first.

--- a/mcp/lib/session-authority.js
+++ b/mcp/lib/session-authority.js
@@ -16,6 +16,9 @@ const {
   validateHttpScanScope,
 } = require("./scope.js");
 const {
+  parseLabAuthorization,
+} = require("./lab-target-attest.js");
+const {
   normalizeSessionStateDocument,
 } = require("./session-state-contracts.js");
 
@@ -569,7 +572,7 @@ function shadowDecision(error, tool, rule) {
   };
 }
 
-function normalizeArgumentTarget(rule, args) {
+function normalizeArgumentTarget(rule, args, opts = {}) {
   if (rule.target_domain !== "required") {
     return null;
   }
@@ -592,7 +595,7 @@ function normalizeArgumentTarget(rule, args) {
     return trimmed;
   }
   try {
-    const normalized = assertHttpScopeDomain(args.target_domain);
+    const normalized = assertHttpScopeDomain(args.target_domain, opts);
     args.target_domain = normalized;
     return normalized;
   } catch (error) {
@@ -849,7 +852,14 @@ function authorizeBootstrap(rule, args) {
       match: true,
     });
   }
-  const authorityTargetDomain = normalizeArgumentTarget(rule, args);
+  // Operator-attested lab/private-target escape: the handler (session-state.js)
+  // threads lab_authorization into assertHttpScopeDomain, but this pre-handler
+  // bootstrap gate runs FIRST and must thread it too — otherwise a fresh private
+  // lab init deadlocks (the persisted lab-authorization.json the fallback reads
+  // is only written by the handler this gate would block). parseLabAuthorization
+  // still requires the operator env ack, so non-lab targets are unaffected.
+  const labAuthorization = parseLabAuthorization(args.lab_authorization);
+  const authorityTargetDomain = normalizeArgumentTarget(rule, args, { labAuthorization });
   if (!hasUrl) {
     throw blockedDecision(rule, args, {
       errorCode: "normalization_failed",
@@ -861,7 +871,7 @@ function authorizeBootstrap(rule, args) {
     });
   }
   try {
-    validateHttpScanScope(args.target_url, authorityTargetDomain);
+    validateHttpScanScope(args.target_url, authorityTargetDomain, { labAuthorization });
   } catch (error) {
     throw blockedDecision(rule, args, {
       errorCode: "target_url_drift",

--- a/mcp/lib/session-authority.js
+++ b/mcp/lib/session-authority.js
@@ -17,6 +17,7 @@ const {
 } = require("./scope.js");
 const {
   parseLabAuthorization,
+  labBootstrapPolicyViolation,
 } = require("./lab-target-attest.js");
 const {
   normalizeSessionStateDocument,
@@ -852,13 +853,28 @@ function authorizeBootstrap(rule, args) {
       match: true,
     });
   }
-  // Operator-attested lab/private-target escape: the handler (session-state.js)
-  // threads lab_authorization into assertHttpScopeDomain, but this pre-handler
-  // bootstrap gate runs FIRST and must thread it too — otherwise a fresh private
-  // lab init deadlocks (the persisted lab-authorization.json the fallback reads
-  // is only written by the handler this gate would block). parseLabAuthorization
+  // Operator-attested lab/private-target escape: this pre-handler bootstrap gate runs FIRST, so it
+  // must enforce the SAME rules the initSession handler does — otherwise a fresh private-lab init
+  // either deadlocks (scope) or the gate decision diverges from execution (policy). It threads
+  // lab_authorization through the scope checks (assertHttpScopeDomain/validateHttpScanScope) AND runs
+  // the handler's lab POLICY checks via the SHARED labBootstrapPolicyViolation, so gate-validation ⊆
+  // handler-validation holds (a gate "allowed" is never a handler reject — important the day a
+  // fast-path trusts this decision instead of always re-reaching the handler). parseLabAuthorization
   // still requires the operator env ack, so non-lab targets are unaffected.
   const labAuthorization = parseLabAuthorization(args.lab_authorization);
+  // Policy check BEFORE the scope normalization, mirroring the handler's order (block_internal is
+  // checked before assertHttpScopeDomain there) so the gate and handler surface the same error first.
+  const labPolicyViolation = labBootstrapPolicyViolation(args, labAuthorization);
+  if (labPolicyViolation) {
+    throw blockedDecision(rule, args, {
+      errorCode: labPolicyViolation.code,
+      envelopeCode: ERROR_CODES.INVALID_ARGUMENTS,
+      message: labPolicyViolation.message,
+      authorityTargetDomain: null,
+      sessionPresent: false,
+      match: false,
+    });
+  }
   const authorityTargetDomain = normalizeArgumentTarget(rule, args, { labAuthorization });
   if (!hasUrl) {
     throw blockedDecision(rule, args, {

--- a/mcp/lib/session-state.js
+++ b/mcp/lib/session-state.js
@@ -71,6 +71,7 @@ const {
 } = require("./scope.js");
 const {
   parseLabAuthorization,
+  labBootstrapPolicyViolation,
   recordLabAuthorization,
 } = require("./lab-target-attest.js");
 const {
@@ -202,11 +203,12 @@ function initSession(args) {
   // fail-closed). When present, a loopback/RFC1918 target_domain that the
   // public-DNS gate would reject is permitted for this session only.
   const labAuthorization = parseLabAuthorization(args.lab_authorization);
-  if (labAuthorization && args.block_internal_hosts === true) {
-    throw new ToolError(
-      ERROR_CODES.INVALID_ARGUMENTS,
-      "lab_authorization cannot be combined with block_internal_hosts: an attested private target requires internal-host egress to be reachable",
-    );
+  // Both lab POLICY constraints (no block_internal_hosts, default egress only) are enforced through
+  // the shared validator so this handler and the pre-handler authority gate (session-authority.js)
+  // stay in lockstep — a gate "allowed" must never become a handler reject.
+  const labPolicyViolation = labBootstrapPolicyViolation(args, labAuthorization);
+  if (labPolicyViolation) {
+    throw new ToolError(ERROR_CODES.INVALID_ARGUMENTS, labPolicyViolation.message);
   }
   let domain;
   try {
@@ -238,17 +240,9 @@ function initSession(args) {
   const requestedEgressProfile = args.egress_profile == null
     ? "default"
     : assertNonEmptyString(args.egress_profile, "egress_profile");
-  // A lab attestation certifies the operator owns the private target on their
-  // OWN network. A non-default (proxy-backed) egress profile would route the
-  // scan through the proxy's network instead — turning an attested private
-  // target into a private-address scan from someone else's vantage. Require
-  // direct egress so the scan originates from the attested lab network.
-  if (labAuthorization && requestedEgressProfile !== "default") {
-    throw new ToolError(
-      ERROR_CODES.INVALID_ARGUMENTS,
-      "lab_authorization requires the default (direct) egress profile: a proxy-backed egress would scan the attested private target from the proxy's network, not the operator's lab network",
-    );
-  }
+  // (The lab_authorization + non-default-egress rejection — why a proxy-backed egress would scan the
+  // attested private target from the proxy's network rather than the operator's lab — is enforced at
+  // the top via labBootstrapPolicyViolation, the same validator the authority gate uses.)
 
   return withSessionLock(domain, () => {
     const dir = sessionDir(domain);

--- a/test/repo-target-binding.test.js
+++ b/test/repo-target-binding.test.js
@@ -269,6 +269,20 @@ test("session-authority bootstrap threads lab_authorization for an operator-atte
       process.env.BOB_LAB_TARGET = "127.0.0.1";
       assert.throws(() => authorizeToolCall(initSessionTool, labArgs()));
 
+      // (d) SSRF-pivot guard — THE case this fix first activates: WITH the full attestation for
+      // 127.0.0.1, a target_url whose HOST differs from the attested target_domain must STILL be
+      // blocked. Opening the private dispatch path must not become a pivot to a neighbouring RFC1918
+      // host or the cloud-metadata endpoint (validateHttpScanScope's url-drift check is independent
+      // of the lab eligibility relaxation).
+      process.env.BOB_LAB_TARGET_ACK = ACK;
+      process.env.BOB_LAB_TARGET = "127.0.0.1";
+      assert.throws(() => authorizeToolCall(initSessionTool, {
+        target_domain: "127.0.0.1", target_url: "http://169.254.169.254:8899/", lab_authorization: { private_targets: true },
+      }));
+      assert.throws(() => authorizeToolCall(initSessionTool, {
+        target_domain: "127.0.0.1", target_url: "http://10.9.9.9:8899/", lab_authorization: { private_targets: true },
+      }));
+
       // A public target is unaffected by any of this (labAuthorization is null for it).
       process.env.BOB_LAB_TARGET_ACK = ACK;
       process.env.BOB_LAB_TARGET = "127.0.0.1";

--- a/test/repo-target-binding.test.js
+++ b/test/repo-target-binding.test.js
@@ -283,6 +283,14 @@ test("session-authority bootstrap threads lab_authorization for an operator-atte
         target_domain: "127.0.0.1", target_url: "http://10.9.9.9:8899/", lab_authorization: { private_targets: true },
       }));
 
+      // (e) gate ⊆ handler: the gate now mirrors the handler's lab POLICY checks via the shared
+      // validator (no split-brain), so an attested lab init the handler would reject — lab auth +
+      // block_internal_hosts, or lab auth + a non-default egress profile — is also rejected AT THE GATE.
+      process.env.BOB_LAB_TARGET_ACK = ACK;
+      process.env.BOB_LAB_TARGET = "127.0.0.1";
+      assert.throws(() => authorizeToolCall(initSessionTool, { ...labArgs(), block_internal_hosts: true }));
+      assert.throws(() => authorizeToolCall(initSessionTool, { ...labArgs(), egress_profile: "proxy-eu" }));
+
       // A public target is unaffected by any of this (labAuthorization is null for it).
       process.env.BOB_LAB_TARGET_ACK = ACK;
       process.env.BOB_LAB_TARGET = "127.0.0.1";

--- a/test/repo-target-binding.test.js
+++ b/test/repo-target-binding.test.js
@@ -290,6 +290,15 @@ test("session-authority bootstrap threads lab_authorization for an operator-atte
       process.env.BOB_LAB_TARGET = "127.0.0.1";
       assert.throws(() => authorizeToolCall(initSessionTool, { ...labArgs(), block_internal_hosts: true }));
       assert.throws(() => authorizeToolCall(initSessionTool, { ...labArgs(), egress_profile: "proxy-eu" }));
+      // ...including the MALFORMED egress variants the handler's assertNonEmptyString rejects (empty,
+      // whitespace, number, object, array): the gate must reject them too, not coerce to "default"
+      // and allow — the validator normalizes egress identically to the handler (gate ⊆ handler).
+      for (const badEgress of ["", "   ", 42, { name: "x" }, ["proxy"]]) {
+        assert.throws(
+          () => authorizeToolCall(initSessionTool, { ...labArgs(), egress_profile: badEgress }),
+          `lab + malformed egress_profile ${JSON.stringify(badEgress)} must be blocked at the gate`,
+        );
+      }
 
       // A public target is unaffected by any of this (labAuthorization is null for it).
       process.env.BOB_LAB_TARGET_ACK = ACK;

--- a/test/repo-target-binding.test.js
+++ b/test/repo-target-binding.test.js
@@ -232,6 +232,58 @@ test("session-authority bootstrap still accepts url-only arguments (regression)"
   });
 });
 
+test("session-authority bootstrap threads lab_authorization for an operator-attested private target (regression)", () => {
+  // REGRESSION (found by the first full orchestrated lab run): the pre-handler bootstrap gate runs
+  // BEFORE the handler and must thread lab_authorization through assertHttpScopeDomain/
+  // validateHttpScanScope exactly as the handler does. Before the fix it ran first WITHOUT it and
+  // hard-deadlocked a fresh private-lab init (the persisted lab-authorization.json the fallback reads
+  // is only written by the very handler this gate was blocking). Direct initSession() harnesses never
+  // caught it because they bypass this gate; only a real MCP dispatch exercises it.
+  withTempHome(() => {
+    const ACK = "i-own-and-am-authorized-to-test-these-private-targets";
+    const prevAck = process.env.BOB_LAB_TARGET_ACK;
+    const prevHost = process.env.BOB_LAB_TARGET;
+    const labArgs = () => ({
+      target_domain: "127.0.0.1",
+      target_url: "http://127.0.0.1:8899/",
+      lab_authorization: { private_targets: true },
+    });
+    try {
+      // Full operator attestation: env ack + THIS exact host bound + in-call intent → ALLOWED.
+      process.env.BOB_LAB_TARGET_ACK = ACK;
+      process.env.BOB_LAB_TARGET = "127.0.0.1";
+      const ok = authorizeToolCall(initSessionTool, labArgs());
+      assert.equal(ok.authority_result, "allowed");
+      assert.equal(ok.authority_target_domain, "127.0.0.1");
+
+      // Fail-closed, all three ways — the relaxation is ONLY for the attested host:
+      // (a) no in-call intent (lab_authorization) → blocked even with the env ack.
+      assert.throws(() => authorizeToolCall(initSessionTool, {
+        target_domain: "127.0.0.1", target_url: "http://127.0.0.1:8899/",
+      }));
+      // (b) env ack names a DIFFERENT host → this host is not authorized.
+      process.env.BOB_LAB_TARGET = "10.9.9.9";
+      assert.throws(() => authorizeToolCall(initSessionTool, labArgs()));
+      // (c) no env ack at all → blocked regardless of the in-call intent.
+      delete process.env.BOB_LAB_TARGET_ACK;
+      process.env.BOB_LAB_TARGET = "127.0.0.1";
+      assert.throws(() => authorizeToolCall(initSessionTool, labArgs()));
+
+      // A public target is unaffected by any of this (labAuthorization is null for it).
+      process.env.BOB_LAB_TARGET_ACK = ACK;
+      process.env.BOB_LAB_TARGET = "127.0.0.1";
+      const pub = authorizeToolCall(initSessionTool, {
+        target_domain: "example.com", target_url: "https://example.com/",
+      });
+      assert.equal(pub.authority_result, "allowed");
+      assert.equal(pub.authority_target_domain, "example.com");
+    } finally {
+      if (prevAck === undefined) delete process.env.BOB_LAB_TARGET_ACK; else process.env.BOB_LAB_TARGET_ACK = prevAck;
+      if (prevHost === undefined) delete process.env.BOB_LAB_TARGET; else process.env.BOB_LAB_TARGET = prevHost;
+    }
+  });
+});
+
 test("bob_init_session refuses target_repo with a redirect pointer", () => {
   withTempHome(() => {
     const repoPath = makeTempRepoDir();

--- a/test/repo-target-binding.test.js
+++ b/test/repo-target-binding.test.js
@@ -299,6 +299,20 @@ test("session-authority bootstrap threads lab_authorization for an operator-atte
           `lab + malformed egress_profile ${JSON.stringify(badEgress)} must be blocked at the gate`,
         );
       }
+      // ...and the NON-BOOLEAN block_internal_hosts variants the handler's assertBoolean rejects: a
+      // truthy-but-non-boolean value must be blocked at the gate too (strict === true alone would
+      // admit it). false is fine (no conflict).
+      for (const badBlock of ["yes", 1, {}, "true"]) {
+        assert.throws(
+          () => authorizeToolCall(initSessionTool, { ...labArgs(), block_internal_hosts: badBlock }),
+          `lab + non-boolean block_internal_hosts ${JSON.stringify(badBlock)} must be blocked at the gate`,
+        );
+      }
+      assert.equal(
+        authorizeToolCall(initSessionTool, { ...labArgs(), block_internal_hosts: false }).authority_result,
+        "allowed",
+        "lab + block_internal_hosts:false is allowed (no conflict)",
+      );
 
       // A public target is unaffected by any of this (labAuthorization is null for it).
       process.env.BOB_LAB_TARGET_ACK = ACK;


### PR DESCRIPTION
## Why

The **first full orchestrated lab run** (`/bob-evaluate` against a local `127.0.0.1:8899` lab) exposed a real init bug that none of the direct-function smoke-tests could: `bob_init_session` for an operator-attested private lab **hard-deadlocked**.

Root cause: `authorizeBootstrap` — the pre-handler MCP authority gate — runs **before** the session handler and called `assertHttpScopeDomain` / `validateHttpScanScope` **without** `lab_authorization`. The handler threads it; the gate didn't. So a fresh private-lab init was rejected at the gate, and the persisted `lab-authorization.json` that the fallback path reads is only ever written by the very handler the gate was blocking — a chicken-and-egg deadlock. The smoke harnesses call `initSession()` directly and bypass this gate, so only a real MCP dispatch reaches it.

## What

Thread the **same fail-closed** `parseLabAuthorization(args.lab_authorization)` the handler already uses through the bootstrap gate (`normalizeArgumentTarget` → `assertHttpScopeDomain`, and `validateHttpScanScope`).

`parseLabAuthorization` reads the operator env ack (`BOB_LAB_TARGET_ACK`) **first**, before touching any arg, and returns `null` unless ack + `private_targets:true` + host-match (`BOB_LAB_TARGET`) all hold. So:
- **non-lab / public target** → `labAuthorization = null` → the gate behaves **exactly as before** (unchanged).
- **lab target** → allowed only under the full **env-ack + host-bind + in-call-intent** triad — the security model is fully intact.

## Verification

- New regression test (`test/repo-target-binding.test.js`) pins the exact hole: the bootstrap gate **ALLOWS** a `127.0.0.1` lab init with the full attestation, and still **BLOCKS** (a) without the in-call intent, (b) with a different bound host, (c) without the env ack; a public target is unaffected.
- Full `npm run test:mcp` → **3178 tests, 0 fail**.
- The fix was already **live-validated** in the run session (5/5 focused harness + 32/32 lifecycle) before being captured here for proper review.

Security-sensitive (init authority gate) — please review the fail-closed threading carefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made bootstrap session authorization lab/private-target aware by parsing operator-provided lab authorization and using it during target normalization and HTTP scope validation.
  * Centralized attested-lab bootstrap policy checks to fail closed on missing/mismatched attestation and reject conflicting settings (e.g., internal-host blocking and non-default egress).
* **Tests**
  * Added regression coverage ensuring the bootstrap gate correctly requires/passes `lab_authorization` and rejects `target_domain`/`target_url` host drift, including additional invalid policy combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->