### PR TITLE
fix(install): copy mcp/browser-driver.js (root cause of mass-read authed_fetch non-fire)

### DIFF
--- a/dev-sync.sh
+++ b/dev-sync.sh
@@ -93,6 +93,10 @@ sync_shared_runtime() {
   cp "$SCRIPT_DIR/mcp/server.js" "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/auto-signup.js" "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/redaction.js" "$TARGET_ABS/mcp/"
+  # browser-driver.js (top-level mcp/, NOT lib/) is the Patchright subprocess server.js spawns —
+  # backs every bob_browser_* tool + the trusted authed_fetch transport. Mirror install.js so a
+  # dev-sync refreshes it too (else the driver stays frozen on whatever first landed).
+  cp "$SCRIPT_DIR/mcp/browser-driver.js" "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/lib/"*.js "$TARGET_ABS/mcp/lib/"
   rm -rf "$TARGET_ABS/mcp/lib/tools"
   mkdir -p "$TARGET_ABS/mcp/lib/tools"

--- a/dev-sync.sh
+++ b/dev-sync.sh
@@ -90,10 +90,12 @@ sync_shared_runtime() {
   cp "$SCRIPT_DIR/.hacker-bob/bypass-tables/"*.txt "$BOB_DIR/bypass-tables/"
 
   mkdir -p "$TARGET_ABS/mcp/lib"
-  # Glob every top-level mcp/ runtime .js (server, auto-signup, redaction, browser-driver) — a glob,
-  # NOT a hardcoded list, so a new top-level runtime file (as browser-driver.js once was — the
-  # Patchright driver server.js spawns) ships automatically instead of silently freezing the
-  # operational copy. Mirrors install.js.
+  # Copy every top-level mcp/ runtime .js (server, auto-signup, redaction, browser-driver — the
+  # Patchright driver server.js spawns; its earlier omission is what this fix addresses). dev-sync is
+  # the LOCAL test-workspace dev path, so a glob is fine here; the shipped installer
+  # (scripts/install.js) uses an explicit, test-enforced manifest instead. dev-sync intentionally does
+  # NOT fully mirror install.js — it omits e.g. lib/body-resolvers/ and the offensive-image lock,
+  # which are out of scope for a dev test workspace.
   cp "$SCRIPT_DIR/mcp/"*.js "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/lib/"*.js "$TARGET_ABS/mcp/lib/"
   rm -rf "$TARGET_ABS/mcp/lib/tools"

--- a/dev-sync.sh
+++ b/dev-sync.sh
@@ -90,13 +90,11 @@ sync_shared_runtime() {
   cp "$SCRIPT_DIR/.hacker-bob/bypass-tables/"*.txt "$BOB_DIR/bypass-tables/"
 
   mkdir -p "$TARGET_ABS/mcp/lib"
-  cp "$SCRIPT_DIR/mcp/server.js" "$TARGET_ABS/mcp/"
-  cp "$SCRIPT_DIR/mcp/auto-signup.js" "$TARGET_ABS/mcp/"
-  cp "$SCRIPT_DIR/mcp/redaction.js" "$TARGET_ABS/mcp/"
-  # browser-driver.js (top-level mcp/, NOT lib/) is the Patchright subprocess server.js spawns —
-  # backs every bob_browser_* tool + the trusted authed_fetch transport. Mirror install.js so a
-  # dev-sync refreshes it too (else the driver stays frozen on whatever first landed).
-  cp "$SCRIPT_DIR/mcp/browser-driver.js" "$TARGET_ABS/mcp/"
+  # Glob every top-level mcp/ runtime .js (server, auto-signup, redaction, browser-driver) — a glob,
+  # NOT a hardcoded list, so a new top-level runtime file (as browser-driver.js once was — the
+  # Patchright driver server.js spawns) ships automatically instead of silently freezing the
+  # operational copy. Mirrors install.js.
+  cp "$SCRIPT_DIR/mcp/"*.js "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/lib/"*.js "$TARGET_ABS/mcp/lib/"
   rm -rf "$TARGET_ABS/mcp/lib/tools"
   mkdir -p "$TARGET_ABS/mcp/lib/tools"

--- a/dev-sync.sh
+++ b/dev-sync.sh
@@ -90,15 +90,14 @@ sync_shared_runtime() {
   cp "$SCRIPT_DIR/.hacker-bob/bypass-tables/"*.txt "$BOB_DIR/bypass-tables/"
 
   mkdir -p "$TARGET_ABS/mcp/lib"
-  # Copy the top-level mcp/ runtime files from the SAME manifest the shipped installer uses
-  # (scripts/install.js MCP_TOP_LEVEL_RUNTIME_FILES) so dev and ship never skew on which files are
-  # runtime. browser-driver.js — the Patchright driver server.js spawns — is in that manifest; its
-  # earlier omission is the gap this fix closes. (dev-sync still copies only the targeted runtime set,
-  # not the full install: lib/body-resolvers/ + the offensive-image lock are out of scope here.)
-  mcp_runtime_files=$(node -e "process.stdout.write(require('$SCRIPT_DIR/scripts/install.js').MCP_TOP_LEVEL_RUNTIME_FILES.join(' '))")
-  for mcp_runtime_file in $mcp_runtime_files; do
-    cp "$SCRIPT_DIR/mcp/$mcp_runtime_file" "$TARGET_ABS/mcp/"
-  done
+  # Top-level mcp/ runtime files. scripts/install.js MCP_TOP_LEVEL_RUNTIME_FILES is the canonical,
+  # test-enforced list (install-smoke.test.js pins it == the real top-level mcp/*.js); keep these in
+  # step with it. browser-driver.js — the Patchright driver server.js spawns — is the file the installer
+  # historically missed; dev-sync must copy it too so a dev workspace gets the current driver.
+  cp "$SCRIPT_DIR/mcp/server.js" "$TARGET_ABS/mcp/"
+  cp "$SCRIPT_DIR/mcp/auto-signup.js" "$TARGET_ABS/mcp/"
+  cp "$SCRIPT_DIR/mcp/redaction.js" "$TARGET_ABS/mcp/"
+  cp "$SCRIPT_DIR/mcp/browser-driver.js" "$TARGET_ABS/mcp/"
   cp "$SCRIPT_DIR/mcp/lib/"*.js "$TARGET_ABS/mcp/lib/"
   rm -rf "$TARGET_ABS/mcp/lib/tools"
   mkdir -p "$TARGET_ABS/mcp/lib/tools"

--- a/dev-sync.sh
+++ b/dev-sync.sh
@@ -90,13 +90,15 @@ sync_shared_runtime() {
   cp "$SCRIPT_DIR/.hacker-bob/bypass-tables/"*.txt "$BOB_DIR/bypass-tables/"
 
   mkdir -p "$TARGET_ABS/mcp/lib"
-  # Copy every top-level mcp/ runtime .js (server, auto-signup, redaction, browser-driver — the
-  # Patchright driver server.js spawns; its earlier omission is what this fix addresses). dev-sync is
-  # the LOCAL test-workspace dev path, so a glob is fine here; the shipped installer
-  # (scripts/install.js) uses an explicit, test-enforced manifest instead. dev-sync intentionally does
-  # NOT fully mirror install.js — it omits e.g. lib/body-resolvers/ and the offensive-image lock,
-  # which are out of scope for a dev test workspace.
-  cp "$SCRIPT_DIR/mcp/"*.js "$TARGET_ABS/mcp/"
+  # Copy the top-level mcp/ runtime files from the SAME manifest the shipped installer uses
+  # (scripts/install.js MCP_TOP_LEVEL_RUNTIME_FILES) so dev and ship never skew on which files are
+  # runtime. browser-driver.js — the Patchright driver server.js spawns — is in that manifest; its
+  # earlier omission is the gap this fix closes. (dev-sync still copies only the targeted runtime set,
+  # not the full install: lib/body-resolvers/ + the offensive-image lock are out of scope here.)
+  mcp_runtime_files=$(node -e "process.stdout.write(require('$SCRIPT_DIR/scripts/install.js').MCP_TOP_LEVEL_RUNTIME_FILES.join(' '))")
+  for mcp_runtime_file in $mcp_runtime_files; do
+    cp "$SCRIPT_DIR/mcp/$mcp_runtime_file" "$TARGET_ABS/mcp/"
+  done
   cp "$SCRIPT_DIR/mcp/lib/"*.js "$TARGET_ABS/mcp/lib/"
   rm -rf "$TARGET_ABS/mcp/lib/tools"
   mkdir -p "$TARGET_ABS/mcp/lib/tools"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -16,6 +16,20 @@ const { commandExists } = require("./lib/command-exists.js");
 
 const BOB_RESOURCE_DIR = ".hacker-bob";
 const NEUTRAL_INSTALL_SCHEMA_VERSION = 2;
+
+// The top-level mcp/ runtime files the installer ships (server.js loads/spawns each). An EXPLICIT
+// manifest, NOT a glob: deny-by-default so a stray top-level mcp/*.js (a scratch/test file) never
+// ships to every install. Completeness is enforced mechanically by test/install-smoke.test.js, which
+// asserts this set EQUALS the real top-level mcp/*.js on disk — so a NEW runtime file (as
+// browser-driver.js, the Patchright DRIVER_SCRIPT_PATH server.js spawns, once was) that is added to
+// mcp/ but forgotten here FAILS the test instead of silently freezing the operational copy (the drift
+// that broke the offensive mass-read producer's authed_fetch transport while older commands worked).
+const MCP_TOP_LEVEL_RUNTIME_FILES = Object.freeze([
+  "server.js",
+  "auto-signup.js",
+  "redaction.js",
+  "browser-driver.js",
+]);
 const RESOURCE_SETS = Object.freeze([
   {
     name: "bypassTables",
@@ -362,16 +376,13 @@ function installProject(projectDir, options = {}) {
 
   const mcpDir = path.join(targetAbs, "mcp");
   fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
-  // Copy EVERY top-level mcp/ runtime file via a glob, NOT a hardcoded list. The original list
-  // ["server.js", "auto-signup.js", "redaction.js"] silently omitted browser-driver.js — the
-  // Patchright subprocess server.js spawns as DRIVER_SCRIPT_PATH (mcp/browser-driver.js; top-level,
-  // so the lib/*.js copy below also misses it). That froze the operational driver: the older
-  // bob_browser_* commands kept working but the newer set_auth_cookies/authed_fetch (#155) the
-  // offensive mass-read producer drives threw browser_transport_error. A glob makes any NEW top-level
-  // runtime file ship automatically instead of silently — the drift that hid this bug. (Top-level
-  // mcp/ holds only these runtime .js files; lib/ + node_modules/ are directories, which
-  // copyDirFiles skips by design, and are copied explicitly below.)
-  copyDirFiles(path.join(sourceRoot, "mcp"), mcpDir, (name) => name.endsWith(".js"));
+  // Copy the top-level mcp/ runtime files from the explicit MCP_TOP_LEVEL_RUNTIME_FILES manifest
+  // (deny-by-default — a stray top-level mcp/*.js never ships; the manifest's completeness vs the
+  // real dir is test-enforced, so a forgotten new runtime file fails CI rather than silently freezing
+  // the operational copy). lib/ + its subdirs are copied separately below.
+  for (const file of MCP_TOP_LEVEL_RUNTIME_FILES) {
+    copyFile(path.join(sourceRoot, "mcp", file), path.join(mcpDir, file));
+  }
   fs.chmodSync(path.join(mcpDir, "server.js"), 0o755);
   copyDirFiles(path.join(sourceRoot, "mcp", "lib"), path.join(mcpDir, "lib"), (name) => name.endsWith(".js"));
   // The offensive arsenal image digest lockfile is operator-minted JSON data (scripts/build-offensive-image.sh).
@@ -619,6 +630,7 @@ function printInstallSummary(summary) {
 
 module.exports = {
   BOB_RESOURCE_DIR,
+  MCP_TOP_LEVEL_RUNTIME_FILES,
   NEUTRAL_INSTALL_SCHEMA_VERSION,
   RESOURCE_SETS,
   commandExists,

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -362,15 +362,16 @@ function installProject(projectDir, options = {}) {
 
   const mcpDir = path.join(targetAbs, "mcp");
   fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
-  // browser-driver.js is the Patchright subprocess server.js spawns as DRIVER_SCRIPT_PATH
-  // (mcp/browser-driver.js — top-level, NOT under lib/, so the lib/*.js copy below misses it).
-  // It backs EVERY bob_browser_* tool plus the trusted authed_fetch transport (#155) the
-  // offensive mass-read producer drives; omitting it leaves an install/refresh frozen on
-  // whatever driver first landed, so newer driver commands (set_auth_cookies / authed_fetch)
-  // throw browser_transport_error while the older commands keep working.
-  for (const file of ["server.js", "auto-signup.js", "redaction.js", "browser-driver.js"]) {
-    copyFile(path.join(sourceRoot, "mcp", file), path.join(mcpDir, file));
-  }
+  // Copy EVERY top-level mcp/ runtime file via a glob, NOT a hardcoded list. The original list
+  // ["server.js", "auto-signup.js", "redaction.js"] silently omitted browser-driver.js — the
+  // Patchright subprocess server.js spawns as DRIVER_SCRIPT_PATH (mcp/browser-driver.js; top-level,
+  // so the lib/*.js copy below also misses it). That froze the operational driver: the older
+  // bob_browser_* commands kept working but the newer set_auth_cookies/authed_fetch (#155) the
+  // offensive mass-read producer drives threw browser_transport_error. A glob makes any NEW top-level
+  // runtime file ship automatically instead of silently — the drift that hid this bug. (Top-level
+  // mcp/ holds only these runtime .js files; lib/ + node_modules/ are directories, which
+  // copyDirFiles skips by design, and are copied explicitly below.)
+  copyDirFiles(path.join(sourceRoot, "mcp"), mcpDir, (name) => name.endsWith(".js"));
   fs.chmodSync(path.join(mcpDir, "server.js"), 0o755);
   copyDirFiles(path.join(sourceRoot, "mcp", "lib"), path.join(mcpDir, "lib"), (name) => name.endsWith(".js"));
   // The offensive arsenal image digest lockfile is operator-minted JSON data (scripts/build-offensive-image.sh).

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -376,20 +376,14 @@ function installProject(projectDir, options = {}) {
 
   const mcpDir = path.join(targetAbs, "mcp");
   fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
-  // On a REINSTALL the target mcp/ may carry a top-level runtime .js from an older version the current
-  // manifest no longer lists (a renamed/dropped file). Remove those stale top-level .js FIRST so a
-  // reinstall CONVERGES to exactly the manifest — the same stale-lingering hazard this fix closes, one
-  // level up (Codex). Scoped to top-level *.js files only; lib/ + node_modules/ are directories managed
-  // by their own copies below.
-  for (const name of fs.readdirSync(mcpDir)) {
-    if (!name.endsWith(".js") || MCP_TOP_LEVEL_RUNTIME_FILES.includes(name)) continue;
-    const candidate = path.join(mcpDir, name);
-    if (fs.statSync(candidate).isFile()) fs.rmSync(candidate, { force: true });
-  }
-  // Copy the top-level mcp/ runtime files from the explicit MCP_TOP_LEVEL_RUNTIME_FILES manifest
-  // (deny-by-default — a stray top-level mcp/*.js never ships; the manifest's completeness vs the
-  // real dir is test-enforced, so a forgotten new runtime file fails CI rather than silently freezing
-  // the operational copy). lib/ + its subdirs are copied separately below.
+  // Copy Bob's top-level mcp/ runtime files from the explicit MCP_TOP_LEVEL_RUNTIME_FILES manifest.
+  // copyFile OVERWRITES, so a reinstall refreshes a stale prior version — that is what fixes the frozen
+  // browser-driver.js this PR is about. We deliberately do NOT delete other top-level mcp/*.js: the
+  // install target is the user's project and may hold files Bob never placed, so deleting by negation
+  // would destroy them (Codex/glm round-4). A Bob runtime file later renamed/removed lingers harmlessly
+  // (server.js never require()s it). The manifest is the single source of truth; install-smoke.test.js
+  // pins it EQUAL to the real top-level mcp/*.js, so a NEW runtime file can't be silently forgotten —
+  // the drift that hid browser-driver.js. lib/ + its subdirs are copied separately below.
   for (const file of MCP_TOP_LEVEL_RUNTIME_FILES) {
     copyFile(path.join(sourceRoot, "mcp", file), path.join(mcpDir, file));
   }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -376,6 +376,16 @@ function installProject(projectDir, options = {}) {
 
   const mcpDir = path.join(targetAbs, "mcp");
   fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
+  // On a REINSTALL the target mcp/ may carry a top-level runtime .js from an older version the current
+  // manifest no longer lists (a renamed/dropped file). Remove those stale top-level .js FIRST so a
+  // reinstall CONVERGES to exactly the manifest — the same stale-lingering hazard this fix closes, one
+  // level up (Codex). Scoped to top-level *.js files only; lib/ + node_modules/ are directories managed
+  // by their own copies below.
+  for (const name of fs.readdirSync(mcpDir)) {
+    if (!name.endsWith(".js") || MCP_TOP_LEVEL_RUNTIME_FILES.includes(name)) continue;
+    const candidate = path.join(mcpDir, name);
+    if (fs.statSync(candidate).isFile()) fs.rmSync(candidate, { force: true });
+  }
   // Copy the top-level mcp/ runtime files from the explicit MCP_TOP_LEVEL_RUNTIME_FILES manifest
   // (deny-by-default — a stray top-level mcp/*.js never ships; the manifest's completeness vs the
   // real dir is test-enforced, so a forgotten new runtime file fails CI rather than silently freezing
@@ -573,7 +583,7 @@ function printInstallSummary(summary) {
   }
   console.log(`  ${summary.bypassTables} neutral bypass tables`);
   console.log(`  ${summary.knowledge} neutral evaluator knowledge files`);
-  console.log(`  MCP runtime (mcp/server.js, auto-signup.js, redaction.js, browser-driver.js, lib/*.js, lib/tools/*.js, dependency files ${summary.runtimeDependencyFiles})`);
+  console.log(`  MCP runtime (mcp/{${MCP_TOP_LEVEL_RUNTIME_FILES.join(", ")}}, lib/*.js, lib/tools/*.js, dependency files ${summary.runtimeDependencyFiles})`);
   console.log("  .hacker-bob/ resources");
   console.log("  .hacker-bob/VERSION and install.json");
   console.log("  ~/hacker-bob-sessions/  (legacy ~/bounty-agent-sessions/ remains readable until v2.1.0)");

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -362,7 +362,13 @@ function installProject(projectDir, options = {}) {
 
   const mcpDir = path.join(targetAbs, "mcp");
   fs.mkdirSync(path.join(mcpDir, "lib", "tools"), { recursive: true });
-  for (const file of ["server.js", "auto-signup.js", "redaction.js"]) {
+  // browser-driver.js is the Patchright subprocess server.js spawns as DRIVER_SCRIPT_PATH
+  // (mcp/browser-driver.js — top-level, NOT under lib/, so the lib/*.js copy below misses it).
+  // It backs EVERY bob_browser_* tool plus the trusted authed_fetch transport (#155) the
+  // offensive mass-read producer drives; omitting it leaves an install/refresh frozen on
+  // whatever driver first landed, so newer driver commands (set_auth_cookies / authed_fetch)
+  // throw browser_transport_error while the older commands keep working.
+  for (const file of ["server.js", "auto-signup.js", "redaction.js", "browser-driver.js"]) {
     copyFile(path.join(sourceRoot, "mcp", file), path.join(mcpDir, file));
   }
   fs.chmodSync(path.join(mcpDir, "server.js"), 0o755);
@@ -555,7 +561,7 @@ function printInstallSummary(summary) {
   }
   console.log(`  ${summary.bypassTables} neutral bypass tables`);
   console.log(`  ${summary.knowledge} neutral evaluator knowledge files`);
-  console.log(`  MCP runtime (mcp/server.js, auto-signup.js, redaction.js, lib/*.js, lib/tools/*.js, dependency files ${summary.runtimeDependencyFiles})`);
+  console.log(`  MCP runtime (mcp/server.js, auto-signup.js, redaction.js, browser-driver.js, lib/*.js, lib/tools/*.js, dependency files ${summary.runtimeDependencyFiles})`);
   console.log("  .hacker-bob/ resources");
   console.log("  .hacker-bob/VERSION and install.json");
   console.log("  ~/hacker-bob-sessions/  (legacy ~/bounty-agent-sessions/ remains readable until v2.1.0)");

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -555,11 +555,14 @@ test("install doctor uninstall dry-run uninstall and reinstall workflow works", 
   }
 });
 
-test("reinstall preserves a user-owned top-level mcp/ file Bob did not place", () => {
-  // Codex/glm round-4: the installer must NEVER delete a top-level mcp/*.js it did not place — the
-  // target is the user's project. (An earlier "converge to the manifest" cleanup deleted by negation,
-  // which would destroy user files; reverted.) A Bob runtime file later renamed/removed lingers
-  // harmlessly; a user's own file is preserved across reinstalls.
+test("reinstall REFRESHES a stale Bob runtime file but preserves user-owned mcp/ files", () => {
+  // Two contracts at once:
+  //  - REFRESH (CodeRabbit/glm round-5): the actual bug was a FROZEN browser-driver.js. copyFile
+  //    overwrites, so a reinstall must replace a stale driver with the current source — assert the
+  //    seeded-stale content is gone, not just that the file exists.
+  //  - PRESERVE (Codex/glm round-4): the installer must NEVER delete a top-level mcp/*.js it did not
+  //    place — the target is the user's project. (An earlier "converge to the manifest" cleanup deleted
+  //    by negation, which would destroy user files; reverted.)
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-userfile-"));
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-home-"));
   const workspace = path.join(tempRoot, "workspace");
@@ -573,12 +576,31 @@ test("reinstall preserves a user-owned top-level mcp/ file Bob did not place", (
     install();
     const userFile = path.join(workspace, "mcp", "my-own-mcp-thing.js");
     fs.writeFileSync(userFile, "// a file the user placed in their own mcp/ dir\n");
+    const driver = path.join(workspace, "mcp", "browser-driver.js");
+    const staleMarker = "// STALE driver from an older install — must be overwritten on reinstall\n";
+    fs.writeFileSync(driver, staleMarker);
     install(); // reinstall over the existing workspace
     assert.ok(fs.existsSync(userFile), "reinstall must NOT delete a top-level mcp/ file Bob did not place");
-    assert.ok(fs.existsSync(path.join(workspace, "mcp", "browser-driver.js")), "reinstall still refreshes Bob's runtime");
+    const refreshed = fs.readFileSync(driver, "utf8");
+    assert.notEqual(refreshed, staleMarker, "reinstall must overwrite a stale browser-driver.js (the frozen-driver bug)");
+    assert.equal(refreshed, fs.readFileSync(path.join(ROOT, "mcp", "browser-driver.js"), "utf8"),
+      "reinstall must refresh browser-driver.js to the current source version");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("dev-sync.sh copies every top-level mcp/ runtime file in the manifest", () => {
+  // agy round-5: dev-sync.sh's explicit cp list can drift from MCP_TOP_LEVEL_RUNTIME_FILES. Rather than
+  // couple dev-sync to the install.js require-graph at runtime (reverted in round 4 — fragile + a
+  // single-quote-path hazard), pin the two with a TEST: every manifest runtime file must appear as a
+  // dev-sync cp target, so adding a runtime file to the manifest without updating dev-sync fails CI.
+  const { MCP_TOP_LEVEL_RUNTIME_FILES } = require("../scripts/install.js");
+  const devSync = fs.readFileSync(path.join(ROOT, "dev-sync.sh"), "utf8");
+  for (const name of MCP_TOP_LEVEL_RUNTIME_FILES) {
+    assert.ok(devSync.includes(`mcp/${name}`),
+      `dev-sync.sh must copy top-level mcp/${name} (keep its cp list in step with MCP_TOP_LEVEL_RUNTIME_FILES)`);
   }
 });
 

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -44,6 +44,11 @@ test("installer copies a require-able complete MCP runtime", () => {
     const installedServer = path.join(workspace, "mcp", "server.js");
     assert.ok(fs.existsSync(installedServer));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "redaction.js")));
+    // browser-driver.js is the Patchright subprocess server.js spawns (DRIVER_SCRIPT_PATH).
+    // It is top-level mcp/, NOT lib/, so the lib/*.js copy misses it — a "complete MCP runtime"
+    // that omits it leaves every bob_browser_* tool + the authed_fetch transport (#155) broken on
+    // a fresh install/refresh. Asserting it here is the regression guard for that installer gap.
+    assert.ok(fs.existsSync(path.join(workspace, "mcp", "browser-driver.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "dispatch.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "tools", "index.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "egress-profiles.js")));

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -548,6 +548,36 @@ test("install doctor uninstall dry-run uninstall and reinstall workflow works", 
   }
 });
 
+test("reinstall removes a stale top-level mcp/ runtime file no longer in the manifest", () => {
+  // Codex: the manifest copy alone leaves a top-level runtime .js an OLDER version shipped (later
+  // renamed/dropped) lingering on a reinstall — the same stale-file hazard this PR fixes one level up.
+  // The installer removes stale top-level *.js before copying, so a reinstall converges to the manifest.
+  const { MCP_TOP_LEVEL_RUNTIME_FILES } = require("../scripts/install.js");
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-stale-"));
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-home-"));
+  const workspace = path.join(tempRoot, "workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  const install = () => execFileSync(process.execPath, [CLI, "install", workspace], {
+    cwd: ROOT,
+    env: { ...process.env, HOME: tempHome },
+    stdio: "pipe",
+  });
+  try {
+    install();
+    const stale = path.join(workspace, "mcp", "legacy-driver.js");
+    fs.writeFileSync(stale, "// stale top-level runtime file from an older install\n");
+    assert.ok(fs.existsSync(stale));
+    install(); // reinstall over the existing workspace
+    assert.ok(!fs.existsSync(stale), "reinstall must remove a stale top-level mcp/ runtime .js not in the manifest");
+    for (const name of MCP_TOP_LEVEL_RUNTIME_FILES) {
+      assert.ok(fs.existsSync(path.join(workspace, "mcp", name)), `reinstall must keep manifest file mcp/${name}`);
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
 test("codex adapter installs direct skills and doctor checks MCP wiring", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bob-codex-adapter-"));
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-home-"));

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -44,11 +44,18 @@ test("installer copies a require-able complete MCP runtime", () => {
     const installedServer = path.join(workspace, "mcp", "server.js");
     assert.ok(fs.existsSync(installedServer));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "redaction.js")));
-    // browser-driver.js is the Patchright subprocess server.js spawns (DRIVER_SCRIPT_PATH).
-    // It is top-level mcp/, NOT lib/, so the lib/*.js copy misses it — a "complete MCP runtime"
-    // that omits it leaves every bob_browser_* tool + the authed_fetch transport (#155) broken on
-    // a fresh install/refresh. Asserting it here is the regression guard for that installer gap.
-    assert.ok(fs.existsSync(path.join(workspace, "mcp", "browser-driver.js")));
+    // The installer copies EVERY top-level mcp/ runtime .js via a glob. Assert the INSTALLED set
+    // covers the SOURCE set so a new top-level runtime file can never be silently dropped again:
+    // the omission of browser-driver.js (the Patchright DRIVER_SCRIPT_PATH server.js spawns) is
+    // exactly what froze the operational driver and broke the authed_fetch transport (#155) while
+    // the older bob_browser_* commands kept working.
+    const sourceMcpDir = path.join(__dirname, "..", "mcp");
+    const sourceTopLevelJs = fs.readdirSync(sourceMcpDir)
+      .filter((name) => name.endsWith(".js") && fs.statSync(path.join(sourceMcpDir, name)).isFile());
+    assert.ok(sourceTopLevelJs.includes("browser-driver.js"), "source mcp/ must contain the Patchright driver this guard protects");
+    for (const name of sourceTopLevelJs) {
+      assert.ok(fs.existsSync(path.join(workspace, "mcp", name)), `installer must copy top-level mcp/${name}`);
+    }
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "dispatch.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "tools", "index.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "egress-profiles.js")));

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -44,18 +44,21 @@ test("installer copies a require-able complete MCP runtime", () => {
     const installedServer = path.join(workspace, "mcp", "server.js");
     assert.ok(fs.existsSync(installedServer));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "redaction.js")));
-    // The installer copies EVERY top-level mcp/ runtime .js via a glob. Assert the INSTALLED set
-    // covers the SOURCE set so a new top-level runtime file can never be silently dropped again:
-    // the omission of browser-driver.js (the Patchright DRIVER_SCRIPT_PATH server.js spawns) is
-    // exactly what froze the operational driver and broke the authed_fetch transport (#155) while
-    // the older bob_browser_* commands kept working.
-    const sourceMcpDir = path.join(__dirname, "..", "mcp");
-    const sourceTopLevelJs = fs.readdirSync(sourceMcpDir)
-      .filter((name) => name.endsWith(".js") && fs.statSync(path.join(sourceMcpDir, name)).isFile());
-    assert.ok(sourceTopLevelJs.includes("browser-driver.js"), "source mcp/ must contain the Patchright driver this guard protects");
-    for (const name of sourceTopLevelJs) {
-      assert.ok(fs.existsSync(path.join(workspace, "mcp", name)), `installer must copy top-level mcp/${name}`);
-    }
+    // The installer ships an EXPLICIT manifest of top-level mcp/ runtime files (deny-by-default).
+    // Guard BOTH regressions the manifest-vs-glob review raised:
+    //  (1) the manifest EQUALS the real source top-level mcp/*.js — a NEW runtime file (as
+    //      browser-driver.js, the DRIVER_SCRIPT_PATH server.js spawns, once was) or a DELETION makes
+    //      manifest != source and fails here, closing the silent-drift gap that broke authed_fetch (#155);
+    //  (2) the INSTALLED top-level mcp/*.js EQUALS the manifest — a dropped OR a stray file fails too.
+    const { MCP_TOP_LEVEL_RUNTIME_FILES } = require("../scripts/install.js");
+    const topLevelJs = (dir) => fs.readdirSync(dir)
+      .filter((name) => name.endsWith(".js") && fs.statSync(path.join(dir, name)).isFile())
+      .sort();
+    const manifest = [...MCP_TOP_LEVEL_RUNTIME_FILES].sort();
+    assert.deepEqual(topLevelJs(path.join(ROOT, "mcp")), manifest,
+      "MCP_TOP_LEVEL_RUNTIME_FILES must equal the real top-level mcp/*.js — update the manifest when a runtime file is added/removed");
+    assert.deepEqual(topLevelJs(path.join(workspace, "mcp")), manifest,
+      "installer must copy EXACTLY the manifest top-level mcp/*.js — no dropped runtime file, no stray");
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "dispatch.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "tools", "index.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "egress-profiles.js")));

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -55,10 +55,17 @@ test("installer copies a require-able complete MCP runtime", () => {
       .filter((name) => name.endsWith(".js") && fs.statSync(path.join(dir, name)).isFile())
       .sort();
     const manifest = [...MCP_TOP_LEVEL_RUNTIME_FILES].sort();
+    // Drift guard: the manifest must list exactly the real top-level mcp/*.js, so a NEW runtime file
+    // (as browser-driver.js once was) or a deletion forces a manifest update instead of silently
+    // shipping the wrong set — the drift that froze the operational driver.
     assert.deepEqual(topLevelJs(path.join(ROOT, "mcp")), manifest,
       "MCP_TOP_LEVEL_RUNTIME_FILES must equal the real top-level mcp/*.js — update the manifest when a runtime file is added/removed");
-    assert.deepEqual(topLevelJs(path.join(workspace, "mcp")), manifest,
-      "installer must copy EXACTLY the manifest top-level mcp/*.js — no dropped runtime file, no stray");
+    // Ship guard: every manifest runtime file is installed. A SUPERSET check, not equality — the
+    // installer never deletes target files it did not place, so it must not assert the target holds
+    // ONLY these (a user's own top-level mcp/*.js is legitimately preserved).
+    for (const name of manifest) {
+      assert.ok(fs.existsSync(path.join(workspace, "mcp", name)), `installer must copy top-level mcp/${name}`);
+    }
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "dispatch.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "tools", "index.js")));
     assert.ok(fs.existsSync(path.join(workspace, "mcp", "lib", "egress-profiles.js")));
@@ -548,12 +555,12 @@ test("install doctor uninstall dry-run uninstall and reinstall workflow works", 
   }
 });
 
-test("reinstall removes a stale top-level mcp/ runtime file no longer in the manifest", () => {
-  // Codex: the manifest copy alone leaves a top-level runtime .js an OLDER version shipped (later
-  // renamed/dropped) lingering on a reinstall — the same stale-file hazard this PR fixes one level up.
-  // The installer removes stale top-level *.js before copying, so a reinstall converges to the manifest.
-  const { MCP_TOP_LEVEL_RUNTIME_FILES } = require("../scripts/install.js");
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-stale-"));
+test("reinstall preserves a user-owned top-level mcp/ file Bob did not place", () => {
+  // Codex/glm round-4: the installer must NEVER delete a top-level mcp/*.js it did not place — the
+  // target is the user's project. (An earlier "converge to the manifest" cleanup deleted by negation,
+  // which would destroy user files; reverted.) A Bob runtime file later renamed/removed lingers
+  // harmlessly; a user's own file is preserved across reinstalls.
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-userfile-"));
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "hacker-bob-home-"));
   const workspace = path.join(tempRoot, "workspace");
   fs.mkdirSync(workspace, { recursive: true });
@@ -564,14 +571,11 @@ test("reinstall removes a stale top-level mcp/ runtime file no longer in the man
   });
   try {
     install();
-    const stale = path.join(workspace, "mcp", "legacy-driver.js");
-    fs.writeFileSync(stale, "// stale top-level runtime file from an older install\n");
-    assert.ok(fs.existsSync(stale));
+    const userFile = path.join(workspace, "mcp", "my-own-mcp-thing.js");
+    fs.writeFileSync(userFile, "// a file the user placed in their own mcp/ dir\n");
     install(); // reinstall over the existing workspace
-    assert.ok(!fs.existsSync(stale), "reinstall must remove a stale top-level mcp/ runtime .js not in the manifest");
-    for (const name of MCP_TOP_LEVEL_RUNTIME_FILES) {
-      assert.ok(fs.existsSync(path.join(workspace, "mcp", name)), `reinstall must keep manifest file mcp/${name}`);
-    }
+    assert.ok(fs.existsSync(userFile), "reinstall must NOT delete a top-level mcp/ file Bob did not place");
+    assert.ok(fs.existsSync(path.join(workspace, "mcp", "browser-driver.js")), "reinstall still refreshes Bob's runtime");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(tempHome, { recursive: true, force: true });


### PR DESCRIPTION
## Root cause of the offensive mass-read producer's live non-fire

In the local lab run, `bob_http_massread_confirm` returned `blocked_by_infra` / `browser_transport_error` on **both** arms, while the general `bob_browser_*` stack worked (`bob_browser_session_start` succeeded, reached the target → 401). The lab handoff isolated it to "the producer's internal real-Chrome `authed_fetch` path."

**Why:** `scripts/install.js` copied only `["server.js", "auto-signup.js", "redaction.js"]` from top-level `mcp/`, plus `lib/*.js`. But `browser-driver.js` lives at **`mcp/browser-driver.js`** (top-level, **not** under `lib/` — it was added there in `26833e3` and never lived in `lib/`), so it was **never copied by install OR `dev-sync.sh`**.

`server.js` spawns this file at runtime as `DRIVER_SCRIPT_PATH` (`mcp/browser-driver.js`). So the operational driver was frozen on whatever first landed:
- the **older** `bob_browser_*` commands (navigate/snapshot/…) were present → general stack worked;
- the **newer** `set_auth_cookies` / `authed_fetch` commands (#155) the mass-read producer drives were **absent** → unknown-command → `browser_transport_error`.

Verified directly: `/Users/memehalis/sec/mcp/browser-driver.js` (operational) had **0** `authed_fetch`/`set_auth_cookies` occurrences; the dev driver has full handlers (cases at 479/483, impls at 669/726) and passing transport tests (`test/browser-authed-fetch.test.js` 26/0).

## Fix

- `scripts/install.js`: add `browser-driver.js` to the top-level `mcp/` copy list (+ summary line).
- `dev-sync.sh`: mirror the copy so dev workspaces refresh it too.
- `test/install-smoke.test.js`: assert `browser-driver.js` is installed — the regression guard that would have caught this (the test claimed a "complete MCP runtime" yet never checked the driver).

## Impact

This is a long-standing installer gap (since `26833e3`), not a recent regression — every install/refresh has shipped a driver that only updates when something else happens to overwrite it. After this lands, `./install.sh <target>` refreshes the driver to the current transport, and the mass-read producer's `authed_fetch` arm works.

## Tests
- `npm run test:install` 16/16, `install-smoke` 11/11, `check:syntax` clean, `bash -n dev-sync.sh` clean.

Resolves the mass-read attacker-arm `browser_transport_error` (the operational driver was stale because the installer never shipped it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fresh installs now include the browser automation runtime component as part of the complete top-level MCP runtime.
  - Reinstalls and development sync now refresh the full top-level MCP runtime set from the installer’s manifest, including `browser-driver.js`, removing stale top-level runtime files no longer included.

- **Tests**
  - Updated smoke tests to assert the installed top-level `mcp/*.js` files exactly match the installer manifest.
  - Added a reinstall regression test ensuring user-owned top-level files are preserved while expected manifest files remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->