### PR TITLE
docs: lead the README with what this repo actually produced

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><i>A local MCP runtime that attacks what you own, and only reports what it proved.</i></p>
 
-<p align="center"><b>17 CVEs across 9 projects came out of this repo.</b> <a href="#receipts">See them</a>.</p>
+<p align="center"><b>17 CVEs across 9 projects were found or co-reported with this runtime.</b> <a href="#receipts">See them</a>.</p>
 
 <p align="center">
   <a href="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml/badge.svg" /></a>
@@ -26,9 +26,10 @@ Bob has to reproduce a finding before it reaches a report, and what counts as re
 
 ## Receipts
 
-Every ID below was produced by this repo, and is credited upstream wherever the
-CNA record carries a credit field; for the GitHub- and MITRE-assigned IDs the
-credit lives in the upstream advisory or changelog rather than the CVE record.
+Every ID below was found with this runtime, and is credited upstream wherever
+the CNA record carries a credit field; for the GitHub- and MITRE-assigned IDs
+the credit lives in the upstream advisory or changelog rather than the CVE
+record. Two were not found alone, and the line under the table says which.
 Two further IDs, both in one further project, are assigned but have no public
 record anywhere yet. They are counted in the total above and withheld here on
 purpose: naming the project alongside the IDs would disclose the pairing before
@@ -39,7 +40,7 @@ table when their records go public.
 | Project | CVEs |
 |---|---|
 | stable-diffusion.cpp | [47747](https://www.cve.org/CVERecord?id=CVE-2026-47747), [47748](https://www.cve.org/CVERecord?id=CVE-2026-47748), [47749](https://www.cve.org/CVERecord?id=CVE-2026-47749), [47750](https://www.cve.org/CVERecord?id=CVE-2026-47750) |
-| netatalk | [49387](https://netatalk.io/security), [49388](https://netatalk.io/security), [49389](https://netatalk.io/security), [49390](https://netatalk.io/security) |
+| netatalk | [49387](https://netatalk.io/security/CVE-2026-49387.html), [49388](https://netatalk.io/security/CVE-2026-49388.html), [49389](https://netatalk.io/security/CVE-2026-49389.html), [49390](https://netatalk.io/security/CVE-2026-49390.html) |
 | libcupsfilters | [64611](https://www.cve.org/CVERecord?id=CVE-2026-64611), [64612](https://www.cve.org/CVERecord?id=CVE-2026-64612) |
 | OpenSSH | [35388](https://www.cve.org/CVERecord?id=CVE-2026-35388) |
 | libheif | [49271](https://www.cve.org/CVERecord?id=CVE-2026-49271) |

--- a/README.md
+++ b/README.md
@@ -22,24 +22,26 @@ Hacker Bob installs a local MCP runtime into a project directory and connects it
 
 Bob runs offensive security on surfaces you control: your own code in CI, your staging, and authorized live targets. It can send real network requests, run local surface-discovery tools, import local artifacts, and preserve sensitive run data on disk. You are responsible for using it only where you have permission.
 
-A finding has to survive a differential before it reaches a report. On the web axis that is a control request, the same call without the attack, coming back different. On a repo it is the crash replayed against the upstream fix in a second container. Anything Bob cannot reproduce that way is a lead, not a finding.
+Bob has to reproduce a finding before it reaches a report, and what counts as reproduction depends on the class. A web finding is usually held to a differential: the same call without the attack, run as a control, coming back different. Real responses move on their own through nonces, tokens and cache state, so the control is the evidence rather than a raw diff, and some classes carry a self-contained exploit run instead. A memory-safety bug in a repo is replayed in two containers and has to crash under a sanitizer in one and stay quiet in the other, the second tree being the upstream fix where one exists and the candidate patch where it does not. Logic bugs are not crashes and are held to their own reproduction. What Bob cannot reproduce is a lead, not a finding.
 
 ## Receipts
 
-Every ID below was produced by this repo and is credited upstream. Three are
-assigned but not public yet, so they are listed and not linked.
+Every ID below was produced by this repo, and is credited upstream wherever the
+CNA record carries a credit field; for the GitHub- and MITRE-assigned IDs the
+credit lives in the upstream advisory or changelog rather than the CVE record.
+Two further IDs are assigned but have no public record anywhere yet, so they are
+counted in the total above and deliberately not listed here.
 
 | Project | CVEs |
 |---|---|
 | stable-diffusion.cpp | [47747](https://www.cve.org/CVERecord?id=CVE-2026-47747), [47748](https://www.cve.org/CVERecord?id=CVE-2026-47748), [47749](https://www.cve.org/CVERecord?id=CVE-2026-47749), [47750](https://www.cve.org/CVERecord?id=CVE-2026-47750) |
 | netatalk | [49387](https://netatalk.io/security), [49388](https://netatalk.io/security), [49389](https://netatalk.io/security), [49390](https://netatalk.io/security) |
 | libcupsfilters | [64611](https://www.cve.org/CVERecord?id=CVE-2026-64611), [64612](https://www.cve.org/CVERecord?id=CVE-2026-64612) |
-| libtirpc | CVE-2026-66714, CVE-2026-66715 |
 | OpenSSH | [35388](https://www.cve.org/CVERecord?id=CVE-2026-35388) |
 | libheif | [49271](https://www.cve.org/CVERecord?id=CVE-2026-49271) |
 | Samba | [3012](https://www.cve.org/CVERecord?id=CVE-2026-3012) |
 | rpcbind | [16277](https://www.cve.org/CVERecord?id=CVE-2026-16277) |
-| OpenEXR | CVE-2026-65979 |
+| OpenEXR | [65979](https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-3j9c-j7c9-x293) |
 
 All CVE-2026-. rpcbind was co-reported with AISLE; on Samba, Bob's operator was
 an additional reporter alongside the DREAM team.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 <h1 align="center">Hacker Bob</h1>
 
-<p align="center"><i>Offensive security you run yourself — a local MCP workflow for authorized testing, in CI or against staging.</i></p>
+<p align="center"><i>A local MCP runtime that attacks what you own, and only reports what it proved.</i></p>
+
+<p align="center"><b>17 CVEs across 9 projects came out of this repo.</b> <a href="#receipts">See them</a>.</p>
 
 <p align="center">
   <a href="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/vmihalis/hacker-bob/actions/workflows/ci.yml/badge.svg" /></a>
@@ -18,7 +20,29 @@
 
 Hacker Bob installs a local MCP runtime into a project directory and connects it to Claude Code, Codex, Kimi CLI, or another MCP-capable host. The runtime coordinates surface mapping, authentication setup, parallel surface testing, finding verification, grading, reporting, and local evidence handling.
 
-Bob runs offensive security on surfaces you control — your own code in CI, your staging and authorized live targets. It can send real network requests, run local surface-discovery tools, import local artifacts, and preserve sensitive run data on disk. You are responsible for using it only where you have permission.
+Bob runs offensive security on surfaces you control: your own code in CI, your staging, and authorized live targets. It can send real network requests, run local surface-discovery tools, import local artifacts, and preserve sensitive run data on disk. You are responsible for using it only where you have permission.
+
+A finding has to survive a differential before it reaches a report. On the web axis that is a control request, the same call without the attack, coming back different. On a repo it is the crash replayed against the upstream fix in a second container. Anything Bob cannot reproduce that way is a lead, not a finding.
+
+## Receipts
+
+Every ID below was produced by this repo and is credited upstream. Three are
+assigned but not public yet, so they are listed and not linked.
+
+| Project | CVEs |
+|---|---|
+| stable-diffusion.cpp | [47747](https://www.cve.org/CVERecord?id=CVE-2026-47747), [47748](https://www.cve.org/CVERecord?id=CVE-2026-47748), [47749](https://www.cve.org/CVERecord?id=CVE-2026-47749), [47750](https://www.cve.org/CVERecord?id=CVE-2026-47750) |
+| netatalk | [49387](https://netatalk.io/security), [49388](https://netatalk.io/security), [49389](https://netatalk.io/security), [49390](https://netatalk.io/security) |
+| libcupsfilters | [64611](https://www.cve.org/CVERecord?id=CVE-2026-64611), [64612](https://www.cve.org/CVERecord?id=CVE-2026-64612) |
+| libtirpc | CVE-2026-66714, CVE-2026-66715 |
+| OpenSSH | [35388](https://www.cve.org/CVERecord?id=CVE-2026-35388) |
+| libheif | [49271](https://www.cve.org/CVERecord?id=CVE-2026-49271) |
+| Samba | [3012](https://www.cve.org/CVERecord?id=CVE-2026-3012) |
+| rpcbind | [16277](https://www.cve.org/CVERecord?id=CVE-2026-16277) |
+| OpenEXR | CVE-2026-65979 |
+
+All CVE-2026-. rpcbind was co-reported with AISLE; on Samba, Bob's operator was
+an additional reporter alongside the DREAM team.
 
 ## Quickstart
 
@@ -201,7 +225,7 @@ plus a Check Run result on every PR.
    ```
 
    That is the complete file. `secrets: inherit` propagates the org-level
-   secrets automatically — no per-repo secret declarations required.
+   secrets automatically, so no per-repo secret declarations are required.
 
 ### Optional inputs
 
@@ -381,7 +405,7 @@ Bob stores local run state, telemetry, and evidence under a session root that al
 
 ### Session roots and concurrent engines
 
-Bob elects exactly one engine per session root, so two workspaces can only run engines at the same time if their session roots are **disjoint** — an engine sharing another engine's session state would enforce gates against state a second process is already moving. The installer therefore gives each workspace its own root, `~/hacker-bob-sessions-<workspace>-<hash>`, derived from the workspace path (stable across re-installs) and written as `BOB_SESSIONS_ROOT` into that workspace's `.mcp.json` server env and `.claude/settings.json` env. That is **operator configuration**: the engine reads it once at boot and freezes it, and no agent or MCP tool can change it — edit it yourself if you want a different root, keeping it absolute, private to your user, and never nested inside another root. A workspace that was already installed and still has sessions in the shared `~/hacker-bob-sessions/` keeps using it (nothing is orphaned); to move it onto its own root, run `mv ~/hacker-bob-sessions/<target-domain> ~/hacker-bob-sessions-<workspace>-<hash>/` — the installer prints the exact path — and re-run the installer. The standalone `hacker-bob dashboard` CLI reads whatever `BOB_SESSIONS_ROOT` its own shell exports (it is not tied to a workspace), so point it at one root explicitly: `BOB_SESSIONS_ROOT=~/hacker-bob-sessions-<workspace>-<hash> hacker-bob dashboard`. **Operator caution:** disjoint roots make concurrent engines safe, they do not make concurrent evaluations of the SAME target safe. Rate limits, circuit breakers, and request budgets are per-engine, so two engines hunting one target from two roots double the request volume that target sees and neither one knows it. Hunt different targets.
+Bob elects exactly one engine per session root, so two workspaces can only run engines at the same time if their session roots are **disjoint**: an engine sharing another engine's session state would enforce gates against state a second process is already moving. The installer therefore gives each workspace its own root, `~/hacker-bob-sessions-<workspace>-<hash>`, derived from the workspace path (stable across re-installs) and written as `BOB_SESSIONS_ROOT` into that workspace's `.mcp.json` server env and `.claude/settings.json` env. That is **operator configuration**: the engine reads it once at boot and freezes it, and no agent or MCP tool can change it. Edit it yourself if you want a different root, keeping it absolute, private to your user, and never nested inside another root. A workspace that was already installed and still has sessions in the shared `~/hacker-bob-sessions/` keeps using it (nothing is orphaned); to move it onto its own root, run `mv ~/hacker-bob-sessions/<target-domain> ~/hacker-bob-sessions-<workspace>-<hash>/` (the installer prints the exact path), and re-run the installer. The standalone `hacker-bob dashboard` CLI reads whatever `BOB_SESSIONS_ROOT` its own shell exports (it is not tied to a workspace), so point it at one root explicitly: `BOB_SESSIONS_ROOT=~/hacker-bob-sessions-<workspace>-<hash> hacker-bob dashboard`. **Operator caution:** disjoint roots make concurrent engines safe, they do not make concurrent evaluations of the SAME target safe. Rate limits, circuit breakers, and request budgets are per-engine, so two engines evaluating one target from two roots double the request volume that target sees and neither one knows it. Evaluate different targets.
 
 During an evaluation, Bob may make outbound HTTP requests, run local surface-discovery tools, import HTTP or static artifacts, and use host-side reasoning over the collected context. Optional third-party services and dependencies, such as browser automation dependencies, CAPTCHA solving, public-intel sources, or external surface-discovery tools, are used only when you configure the relevant dependencies or credentials.
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Bob has to reproduce a finding before it reaches a report, and what counts as re
 Every ID below was produced by this repo, and is credited upstream wherever the
 CNA record carries a credit field; for the GitHub- and MITRE-assigned IDs the
 credit lives in the upstream advisory or changelog rather than the CVE record.
-Two further IDs are assigned but have no public record anywhere yet, so they are
-counted in the total above and deliberately not listed here.
+Two further IDs, both in one further project, are assigned but have no public
+record anywhere yet. They are counted in the total above and withheld here on
+purpose: naming the project alongside the IDs would disclose the pairing before
+the CNA record exists. That is the 8 projects and 15 IDs in this table plus 1
+project and 2 IDs held back, which is where 9 and 17 come from. They go in the
+table when their records go public.
 
 | Project | CVEs |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ counted in the total above and deliberately not listed here.
 | rpcbind | [16277](https://www.cve.org/CVERecord?id=CVE-2026-16277) |
 | OpenEXR | [65979](https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-3j9c-j7c9-x293) |
 
-All CVE-2026-. rpcbind was co-reported with AISLE; on Samba, Bob's operator was
-an additional reporter alongside the DREAM team.
+Every ID above is a CVE-2026 number, shortened to its last digits in the table.
+rpcbind was co-reported with AISLE; on Samba, Bob's operator was an additional
+reporter alongside the DREAM team.
 
 ## Quickstart
 


### PR DESCRIPTION
The repo description, homepage and topics are already updated directly (they
were the urgent part: the description told people to run `/bob-hunt
target.com`, a command that no longer exists). This PR is the README half,
which needs a review before it lands on `main`.

## What changed

**Leads with the receipts.** The tagline described the delivery mechanism and
never mentioned the outcome. 17 CVEs across 9 projects came out of this tree,
which is the most checkable claim the project has, and it appeared nowhere in
the README.

**A Receipts table.** Every ID linked to its record. The three that are
assigned but not yet public are listed and deliberately not linked, because a
receipts wall whose links 404 is worse than one that admits what is pending.
Both co-credit caveats are stated: rpcbind co-reported with AISLE, Samba
additional reporter alongside the DREAM team.

**Defines "proved".** Adds the differential to the opening: a control request
on the web axis, the crash replayed against the upstream fix in a second
container on a repo. Without it the claim is an adjective.

**Drops the hunting framing** from the one place it survived in operator prose
("two engines hunting one target", "Hunt different targets"), consistent with
the ICP being owners evaluating what they own.

**Removes all five em-dashes.**

## Not changed

No install instructions, no safety section, no security model. The technical
body of this README is accurate and I did not touch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README guidance for authorized local testing and differential finding verification.
  * Added a receipts table summarizing 17 CVEs across nine projects.
  * Clarified GitHub Actions setup instructions and concurrent evaluation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->