### PR TITLE
Fix sealed runner replay completion

### DIFF
--- a/infra/runner/entrypoint.js
+++ b/infra/runner/entrypoint.js
@@ -727,8 +727,30 @@ async function main({
     client = await clientFactory(runtimeEnvironment);
     tracker = await resumeLifecycleTracker(client, payload.runSlug);
     sequenceInitialized = true;
-    await transitionRun(client, secret, payload.runSlug, "provisioning", "setup");
-    await transitionRun(client, secret, payload.runSlug, "running", "open frontier");
+    const provisioning = await transitionRun(client, secret, payload.runSlug, "provisioning", "setup");
+    if (provisioning.status === "sealed") {
+      completionCommitted = true;
+      exitCode = 0;
+      console.log(JSON.stringify({
+        status: "done",
+        runSlug: payload.runSlug,
+        reportSlug: `${payload.runSlug}-report`,
+        resumed: true,
+      }));
+      return exitCode;
+    }
+    const running = await transitionRun(client, secret, payload.runSlug, "running", "open frontier");
+    if (running.status === "sealed") {
+      completionCommitted = true;
+      exitCode = 0;
+      console.log(JSON.stringify({
+        status: "done",
+        runSlug: payload.runSlug,
+        reportSlug: `${payload.runSlug}-report`,
+        resumed: true,
+      }));
+      return exitCode;
+    }
 
     const child = spawnFactory(
       "node",

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -522,6 +522,53 @@ test("main resumes when host replay finds the control plane already running", as
   });
 });
 
+test("host replay treats an already sealed run as completed without rerunning", async (t) => {
+  const runPayload = payload({ runSlug: "runner-host-sealed" });
+  await withRunnerEnvironment(runPayload, async () => {
+    const client = recordingClient({
+      statusResult: () => "sealed",
+    });
+    const logs = [];
+    let spawnCalls = 0;
+    t.mock.method(console, "log", (message) => logs.push(String(message)));
+    t.mock.method(console, "error", () => {});
+
+    const code = await entrypoint.main({
+      clientFactory: async () => client,
+      spawnFactory: () => {
+        spawnCalls += 1;
+        return fakeChild();
+      },
+      clock: () => Date.UTC(2026, 7, 25, 12),
+      delay: immediateDelay,
+    });
+
+    assert.equal(code, 0);
+    assert.equal(client.closed, true);
+    assert.equal(spawnCalls, 0);
+    assert.deepEqual(
+      client.calls
+        .filter((call) => call.name === "runs:setStatus")
+        .map((call) => call.args.status),
+      ["provisioning"],
+    );
+    assert.equal(
+      client.calls.some((call) => call.name === "reports:completeHostedRun"),
+      false,
+    );
+    assert.equal(
+      client.calls.some((call) => call.name === "runs:appendEvent"),
+      false,
+    );
+    assert.deepEqual(JSON.parse(logs.at(-1)), {
+      status: "done",
+      runSlug: runPayload.runSlug,
+      reportSlug: `${runPayload.runSlug}-report`,
+      resumed: true,
+    });
+  });
+});
+
 test("hosted completion conflict marks the sealing run failed and closes", async (t) => {
   const runPayload = payload({ runSlug: "runner-completion-conflict" });
   await withRunnerEnvironment(runPayload, async ({ sessionsRoot }) => {


### PR DESCRIPTION
## Summary

- treat an already sealed hosted run as successfully completed during dispatch replay
- avoid rerunning Codex or rewriting hosted completion after a sealed response
- add focused regression coverage for the replay path

## Verification

- `node --test test/runner-entrypoint.test.js` (13 passed)
- `npm run check:syntax`
- `git diff --check HEAD^ HEAD`

This preserves and lands the existing private runner-wiring commit on public main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resumed runs that were already completed, preventing duplicate processing.
  * Ensured resumed runs report success and close cleanly without starting another runner or repeating completion steps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->